### PR TITLE
feat: upgrade CLI with local tools, slash commands, interrupt support

### DIFF
--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -133,13 +133,38 @@ class ContextManager:
     def get_messages(self) -> list[Message]:
         """Get all messages for sending to LLM.
 
-        Automatically patches any dangling tool_calls (assistant messages
-        with tool_calls that have no matching tool-result message).  This
-        can happen after errors or cancellations and would cause the LLM
-        API to reject the request.
+        Defensive gateway — fixes context corruption before every LLM call:
+        1. Sanitizes malformed tool_call arguments (truncated JSON)
+        2. Adds stub results for dangling tool_calls (missing tool results)
         """
+        self._sanitize_tool_calls()
         self._patch_dangling_tool_calls()
         return self.items
+
+    def _sanitize_tool_calls(self) -> None:
+        """Fix malformed tool_call arguments across all assistant messages.
+
+        When output is truncated (finish_reason=length), tool call arguments
+        can be incomplete JSON.  LLM APIs reject messages with invalid JSON
+        in function.arguments, breaking all subsequent calls.
+        """
+        import json
+
+        for msg in self.items:
+            if getattr(msg, "role", None) != "assistant":
+                continue
+            tool_calls = getattr(msg, "tool_calls", None)
+            if not tool_calls:
+                continue
+            for tc in tool_calls:
+                try:
+                    json.loads(tc.function.arguments)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    logger.warning(
+                        "Sanitizing malformed arguments for tool_call %s (%s)",
+                        tc.id, tc.function.name,
+                    )
+                    tc.function.arguments = "{}"
 
     def _patch_dangling_tool_calls(self) -> None:
         """Add stub tool results for any tool_calls that lack a matching result.

--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -141,6 +141,41 @@ class ContextManager:
         self._patch_dangling_tool_calls()
         return self.items
 
+    @staticmethod
+    def _tc_id(tc) -> str:
+        """Get tool_call id from either a ToolCall object or a dict."""
+        if isinstance(tc, dict):
+            return tc.get("id", "")
+        return tc.id
+
+    @staticmethod
+    def _tc_func_name(tc) -> str:
+        """Get function name from either a ToolCall object or a dict."""
+        if isinstance(tc, dict):
+            fn = tc.get("function", {})
+            return fn.get("name", "") if isinstance(fn, dict) else getattr(fn, "name", "")
+        return tc.function.name
+
+    @staticmethod
+    def _tc_func_args(tc) -> str:
+        """Get function arguments string from either a ToolCall object or a dict."""
+        if isinstance(tc, dict):
+            fn = tc.get("function", {})
+            return fn.get("arguments", "{}") if isinstance(fn, dict) else getattr(fn, "arguments", "{}")
+        return tc.function.arguments
+
+    @staticmethod
+    def _tc_set_func_args(tc, value: str) -> None:
+        """Set function arguments on either a ToolCall object or a dict."""
+        if isinstance(tc, dict):
+            fn = tc.get("function")
+            if isinstance(fn, dict):
+                fn["arguments"] = value
+            else:
+                fn.arguments = value
+        else:
+            tc.function.arguments = value
+
     def _sanitize_tool_calls(self) -> None:
         """Fix malformed tool_call arguments across all assistant messages.
 
@@ -158,13 +193,13 @@ class ContextManager:
                 continue
             for tc in tool_calls:
                 try:
-                    json.loads(tc.function.arguments)
+                    json.loads(self._tc_func_args(tc))
                 except (json.JSONDecodeError, TypeError, ValueError):
                     logger.warning(
                         "Sanitizing malformed arguments for tool_call %s (%s)",
-                        tc.id, tc.function.name,
+                        self._tc_id(tc), self._tc_func_name(tc),
                     )
-                    tc.function.arguments = "{}"
+                    self._tc_set_func_args(tc, "{}")
 
     def _patch_dangling_tool_calls(self) -> None:
         """Add stub tool results for any tool_calls that lack a matching result.
@@ -196,13 +231,14 @@ class ContextManager:
             if getattr(m, "role", None) == "tool"
         }
         for tc in assistant_msg.tool_calls:
-            if tc.id not in answered_ids:
+            tc_id = self._tc_id(tc)
+            if tc_id not in answered_ids:
                 self.items.append(
                     Message(
                         role="tool",
                         content="Tool was not executed (interrupted or error).",
-                        tool_call_id=tc.id,
-                        name=tc.function.name,
+                        tool_call_id=tc_id,
+                        name=self._tc_func_name(tc),
                     )
                 )
 

--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -142,39 +142,25 @@ class ContextManager:
         return self.items
 
     @staticmethod
-    def _tc_id(tc) -> str:
-        """Get tool_call id from either a ToolCall object or a dict."""
-        if isinstance(tc, dict):
-            return tc.get("id", "")
-        return tc.id
+    def _normalize_tool_calls(msg: Message) -> None:
+        """Ensure msg.tool_calls contains proper ToolCall objects, not dicts.
 
-    @staticmethod
-    def _tc_func_name(tc) -> str:
-        """Get function name from either a ToolCall object or a dict."""
-        if isinstance(tc, dict):
-            fn = tc.get("function", {})
-            return fn.get("name", "") if isinstance(fn, dict) else getattr(fn, "name", "")
-        return tc.function.name
+        litellm's Message has validate_assignment=False (Pydantic v2 default),
+        so direct attribute assignment (e.g. inside litellm's streaming handler)
+        can leave raw dicts.  Re-assigning via the constructor fixes this.
+        """
+        from litellm import ChatCompletionMessageToolCall as ToolCall
 
-    @staticmethod
-    def _tc_func_args(tc) -> str:
-        """Get function arguments string from either a ToolCall object or a dict."""
-        if isinstance(tc, dict):
-            fn = tc.get("function", {})
-            return fn.get("arguments", "{}") if isinstance(fn, dict) else getattr(fn, "arguments", "{}")
-        return tc.function.arguments
-
-    @staticmethod
-    def _tc_set_func_args(tc, value: str) -> None:
-        """Set function arguments on either a ToolCall object or a dict."""
-        if isinstance(tc, dict):
-            fn = tc.get("function")
-            if isinstance(fn, dict):
-                fn["arguments"] = value
-            else:
-                fn.arguments = value
-        else:
-            tc.function.arguments = value
+        tool_calls = getattr(msg, "tool_calls", None)
+        if not tool_calls:
+            return
+        needs_fix = any(isinstance(tc, dict) for tc in tool_calls)
+        if not needs_fix:
+            return
+        msg.tool_calls = [
+            tc if not isinstance(tc, dict) else ToolCall(**tc)
+            for tc in tool_calls
+        ]
 
     def _sanitize_tool_calls(self) -> None:
         """Fix malformed tool_call arguments across all assistant messages.
@@ -191,15 +177,17 @@ class ContextManager:
             tool_calls = getattr(msg, "tool_calls", None)
             if not tool_calls:
                 continue
-            for tc in tool_calls:
+            # Ensure proper ToolCall objects (litellm streaming can leave dicts)
+            self._normalize_tool_calls(msg)
+            for tc in msg.tool_calls:
                 try:
-                    json.loads(self._tc_func_args(tc))
+                    json.loads(tc.function.arguments)
                 except (json.JSONDecodeError, TypeError, ValueError):
                     logger.warning(
                         "Sanitizing malformed arguments for tool_call %s (%s)",
-                        self._tc_id(tc), self._tc_func_name(tc),
+                        tc.id, tc.function.name,
                     )
-                    self._tc_set_func_args(tc, "{}")
+                    tc.function.arguments = "{}"
 
     def _patch_dangling_tool_calls(self) -> None:
         """Add stub tool results for any tool_calls that lack a matching result.
@@ -225,20 +213,20 @@ class ContextManager:
         if not assistant_msg:
             return
 
+        self._normalize_tool_calls(assistant_msg)
         answered_ids = {
             getattr(m, "tool_call_id", None)
             for m in self.items
             if getattr(m, "role", None) == "tool"
         }
         for tc in assistant_msg.tool_calls:
-            tc_id = self._tc_id(tc)
-            if tc_id not in answered_ids:
+            if tc.id not in answered_ids:
                 self.items.append(
                     Message(
                         role="tool",
                         content="Tool was not executed (interrupted or error).",
-                        tool_call_id=tc_id,
-                        name=self._tc_func_name(tc),
+                        tool_call_id=tc.id,
+                        name=tc.function.name,
                     )
                 )
 

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -9,7 +9,6 @@ import os
 
 from litellm import ChatCompletionMessageToolCall, Message, acompletion
 from litellm.exceptions import ContextWindowExceededError
-from lmnr import observe
 
 from agent.config import Config
 from agent.core.session import Event, OpType, Session
@@ -205,7 +204,6 @@ class Handlers:
         logger.info("Abandoned %d pending approval tool(s)", len(tool_calls))
 
     @staticmethod
-    @observe(name="run_agent")
     async def run_agent(
         session: Session, text: str, max_iterations: int = 300
     ) -> str | None:
@@ -213,12 +211,6 @@ class Handlers:
         Handle user input (like user_input_or_turn in codex.rs:1291)
         Returns the final assistant response content, if any.
         """
-        # Set session ID for this trace
-        if hasattr(session, "session_id"):
-            from lmnr import Laminar
-
-            Laminar.set_trace_session_id(session_id=session.session_id)
-
         # Clear any stale cancellation flag from a previous run
         session.reset_cancel()
 
@@ -824,12 +816,13 @@ async def process_submission(session: Session, submission) -> bool:
     return True
 
 
-@observe(name="submission_loop")
 async def submission_loop(
     submission_queue: asyncio.Queue,
     event_queue: asyncio.Queue,
     config: Config | None = None,
     tool_router: ToolRouter | None = None,
+    session_holder: list | None = None,
+    hf_token: str | None = None,
 ) -> None:
     """
     Main agent loop - processes submissions and dispatches to handlers.
@@ -837,7 +830,9 @@ async def submission_loop(
     """
 
     # Create session with tool router
-    session = Session(event_queue, config=config, tool_router=tool_router)
+    session = Session(event_queue, config=config, tool_router=tool_router, hf_token=hf_token)
+    if session_holder is not None:
+        session_holder[0] = session
     logger.info("Agent loop started")
 
     # Retry any failed uploads from previous sessions (fire-and-forget)

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -261,12 +261,14 @@ class Handlers:
                     tool_choice="auto",
                     stream=True,
                     stream_options={"include_usage": True},
+                    max_completion_tokens=16384,
                     **llm_params,
                 )
 
                 full_content = ""
                 tool_calls_acc: dict[int, dict] = {}
                 token_count = 0
+                finish_reason = None
 
                 async for chunk in response:
                     choice = chunk.choices[0] if chunk.choices else None
@@ -277,6 +279,8 @@ class Handlers:
                         continue
 
                     delta = choice.delta
+                    if choice.finish_reason:
+                        finish_reason = choice.finish_reason
 
                     # Stream text deltas to the frontend
                     if delta.content:
@@ -316,6 +320,28 @@ class Handlers:
 
                 # ── Stream finished — reconstruct full message ───────
                 content = full_content or None
+
+                # Detect output truncation — tool call args will be
+                # incomplete JSON, which would poison the context.
+                if finish_reason == "length" and tool_calls_acc:
+                    logger.warning(
+                        "Output truncated (finish_reason=length) with pending "
+                        "tool calls — dropping truncated tool calls"
+                    )
+                    truncation_notice = (
+                        "\n\n[Output was truncated due to length. "
+                        "Tool calls were dropped. Break large writes "
+                        "into smaller pieces or write to sandbox in parts.]"
+                    )
+                    full_content += truncation_notice
+                    content = full_content
+                    await session.send_event(
+                        Event(
+                            event_type="assistant_chunk",
+                            data={"content": truncation_notice},
+                        )
+                    )
+                    tool_calls_acc.clear()
 
                 # Build tool_calls list from accumulated deltas
                 tool_calls: list[ToolCall] = []

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -135,6 +135,11 @@ class Session:
     def is_cancelled(self) -> bool:
         return self._cancelled.is_set()
 
+    def update_model(self, model_name: str) -> None:
+        """Switch the active model and update the context window limit."""
+        self.config.model_name = model_name
+        self.context_manager.max_context = _get_max_tokens_safe(model_name)
+
     def increment_turn(self) -> None:
         """Increment turn counter (called after each user interaction)"""
         self.turn_count += 1

--- a/agent/core/tools.py
+++ b/agent/core/tools.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
-from lmnr import observe
 from mcp.types import EmbeddedResource, ImageContent, TextContent
 
 from agent.config import MCPServerConfig
@@ -129,11 +128,11 @@ class ToolRouter:
     Based on codex-rs/core/src/tools/router.rs
     """
 
-    def __init__(self, mcp_servers: dict[str, MCPServerConfig], hf_token: str | None = None):
+    def __init__(self, mcp_servers: dict[str, MCPServerConfig], hf_token: str | None = None, local_mode: bool = False):
         self.tools: dict[str, ToolSpec] = {}
         self.mcp_servers: dict[str, dict[str, Any]] = {}
 
-        for tool in create_builtin_tools():
+        for tool in create_builtin_tools(local_mode=local_mode):
             self.register_tool(tool)
 
         self.mcp_client: Client | None = None
@@ -226,7 +225,6 @@ class ToolRouter:
             await self.mcp_client.__aexit__(exc_type, exc, tb)
             self._mcp_initialized = False
 
-    @observe(name="call_tool")
     async def call_tool(
         self,
         tool_name: str,
@@ -275,7 +273,7 @@ class ToolRouter:
 # ============================================================================
 
 
-def create_builtin_tools() -> list[ToolSpec]:
+def create_builtin_tools(local_mode: bool = False) -> list[ToolSpec]:
     """Create built-in tool specifications"""
     # in order of importance
     tools = [
@@ -352,8 +350,12 @@ def create_builtin_tools() -> list[ToolSpec]:
         ),
     ]
 
-    # Sandbox tools (highest priority)
-    tools = get_sandbox_tools() + tools
+    # Sandbox or local tools (highest priority)
+    if local_mode:
+        from agent.tools.local_tools import get_local_tools
+        tools = get_local_tools() + tools
+    else:
+        tools = get_sandbox_tools() + tools
 
     tool_names = ", ".join([t.name for t in tools])
     logger.info(f"Loaded {len(tools)} built-in tools: {tool_names}")

--- a/agent/main.py
+++ b/agent/main.py
@@ -5,12 +5,12 @@ Interactive CLI chat with the agent
 import asyncio
 import json
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
 import litellm
-from lmnr import Laminar, LaminarLiteLLMCallback
 from prompt_toolkit import PromptSession
 
 from agent.config import load_config
@@ -31,6 +31,15 @@ from agent.utils.terminal_display import (
 
 litellm.drop_params = True
 
+# ── Available models (mirrors backend/routes/agent.py) ──────────────────
+AVAILABLE_MODELS = [
+    {"id": "anthropic/claude-opus-4-6", "label": "Claude Opus 4.6"},
+    {"id": "huggingface/fireworks-ai/MiniMaxAI/MiniMax-M2.5", "label": "MiniMax M2.5"},
+    {"id": "huggingface/novita/moonshotai/kimi-k2.5", "label": "Kimi K2.5"},
+    {"id": "huggingface/novita/zai-org/glm-5", "label": "GLM 5"},
+]
+VALID_MODEL_IDS = {m["id"] for m in AVAILABLE_MODELS}
+
 
 def _safe_get_args(arguments: dict) -> dict:
     """Safely extract args dict from arguments, handling cases where LLM passes string."""
@@ -41,14 +50,20 @@ def _safe_get_args(arguments: dict) -> dict:
     return args if isinstance(args, dict) else {}
 
 
-lmnr_api_key = os.environ.get("LMNR_API_KEY")
-if lmnr_api_key:
+def _get_hf_token() -> str | None:
+    """Get HF token from environment or huggingface_hub login."""
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        return token
     try:
-        Laminar.initialize(project_api_key=lmnr_api_key)
-        litellm.callbacks = [LaminarLiteLLMCallback()]
-        print("Laminar initialized")
-    except Exception as e:
-        print(f"Failed to initialize Laminar: {e}")
+        from huggingface_hub import HfApi
+        api = HfApi()
+        token = api.token
+        if token:
+            return token
+    except Exception:
+        pass
+    return None
 
 
 @dataclass
@@ -112,6 +127,22 @@ async def event_listener(
                 if plan_display:
                     print(plan_display)
                 turn_complete_event.set()
+            elif event.event_type == "interrupted":
+                print("\n(interrupted)")
+                turn_complete_event.set()
+            elif event.event_type == "undo_complete":
+                print("Undo complete.")
+                turn_complete_event.set()
+            elif event.event_type == "tool_log":
+                tool = event.data.get("tool", "") if event.data else ""
+                log = event.data.get("log", "") if event.data else ""
+                if log:
+                    print(f"  [{tool}] {log}")
+            elif event.event_type == "tool_state_change":
+                tool = event.data.get("tool", "") if event.data else ""
+                state = event.data.get("state", "") if event.data else ""
+                if state in ("approved", "rejected", "running"):
+                    print(f"  {tool}: {state}")
             elif event.event_type == "error":
                 error = (
                     event.data.get("error", "Unknown error")
@@ -127,7 +158,7 @@ async def event_listener(
             elif event.event_type == "compacted":
                 old_tokens = event.data.get("old_tokens", 0) if event.data else 0
                 new_tokens = event.data.get("new_tokens", 0) if event.data else 0
-                print(f"Compacted context: {old_tokens} → {new_tokens} tokens")
+                print(f"Compacted context: {old_tokens} -> {new_tokens} tokens")
             elif event.event_type == "approval_required":
                 # Handle batch approval format
                 tools_data = event.data.get("tools", []) if event.data else []
@@ -143,7 +174,7 @@ async def event_listener(
                         }
                         for t in tools_data
                     ]
-                    print(f"\n⚡ YOLO MODE: Auto-approving {count} item(s)")
+                    print(f"\n YOLO MODE: Auto-approving {count} item(s)")
                     submission_id[0] += 1
                     approval_submission = Submission(
                         id=f"approval_{submission_id[0]}",
@@ -387,7 +418,7 @@ async def event_listener(
                     if response == "yolo":
                         config.yolo_mode = True
                         print(
-                            "⚡ YOLO MODE ACTIVATED - Auto-approving all future tool calls"
+                            "YOLO MODE ACTIVATED - Auto-approving all future tool calls"
                         )
                         # Auto-approve this item and all remaining
                         approvals.append(
@@ -444,6 +475,93 @@ async def get_user_input(prompt_session: PromptSession) -> str:
     return await prompt_session.prompt_async(HTML("\n<b><cyan>></cyan></b> "))
 
 
+# ── Slash command helpers ────────────────────────────────────────────────
+
+HELP_TEXT = """\
+Commands:
+  /help            Show this help
+  /undo            Undo last turn
+  /compact         Compact context window
+  /model [id]      Show available models or switch model
+  /yolo            Toggle auto-approve mode
+  /status          Show current model, turn count
+  /quit, /exit     Exit the CLI
+"""
+
+
+def _handle_slash_command(
+    cmd: str,
+    config,
+    session_holder: list,
+    submission_queue: asyncio.Queue,
+    submission_id: list[int],
+) -> Submission | None:
+    """
+    Handle a slash command. Returns a Submission to enqueue, or None if
+    the command was handled locally (caller should set turn_complete_event).
+    """
+    parts = cmd.strip().split(None, 1)
+    command = parts[0].lower()
+    arg = parts[1].strip() if len(parts) > 1 else ""
+
+    if command == "/help":
+        print(HELP_TEXT)
+        return None
+
+    if command == "/undo":
+        submission_id[0] += 1
+        return Submission(
+            id=f"sub_{submission_id[0]}",
+            operation=Operation(op_type=OpType.UNDO),
+        )
+
+    if command == "/compact":
+        submission_id[0] += 1
+        return Submission(
+            id=f"sub_{submission_id[0]}",
+            operation=Operation(op_type=OpType.COMPACT),
+        )
+
+    if command == "/model":
+        if not arg:
+            print("Available models:")
+            session = session_holder[0] if session_holder else None
+            current = config.model_name if config else ""
+            for m in AVAILABLE_MODELS:
+                marker = " <-- current" if m["id"] == current else ""
+                print(f"  {m['id']}  ({m['label']}){marker}")
+            return None
+        if arg not in VALID_MODEL_IDS:
+            print(f"Unknown model: {arg}")
+            print(f"Valid: {', '.join(VALID_MODEL_IDS)}")
+            return None
+        session = session_holder[0] if session_holder else None
+        if session:
+            session.update_model(arg)
+            print(f"Model switched to {arg}")
+        else:
+            config.model_name = arg
+            print(f"Model set to {arg} (session not started yet)")
+        return None
+
+    if command == "/yolo":
+        config.yolo_mode = not config.yolo_mode
+        state = "ON" if config.yolo_mode else "OFF"
+        print(f"YOLO mode: {state}")
+        return None
+
+    if command == "/status":
+        session = session_holder[0] if session_holder else None
+        print(f"Model: {config.model_name}")
+        if session:
+            print(f"Turns: {session.turn_count}")
+            print(f"Context items: {len(session.context_manager.items)}")
+        return None
+
+    print(f"Unknown command: {command}. Type /help for available commands.")
+    return None
+
+
 async def main():
     """Interactive chat with the agent"""
     from agent.utils.terminal_display import Colors
@@ -452,20 +570,27 @@ async def main():
     os.system("clear" if os.name != "nt" else "cls")
 
     banner = r"""
-  _   _                   _               _____                   _                    _   
- | | | |_   _  __ _  __ _(_)_ __   __ _  |  ___|_ _  ___ ___     / \   __ _  ___ _ __ | |_ 
+  _   _                   _               _____                   _                    _
+ | | | |_   _  __ _  __ _(_)_ __   __ _  |  ___|_ _  ___ ___     / \   __ _  ___ _ __ | |_
  | |_| | | | |/ _` |/ _` | | '_ \ / _` | | |_ / _` |/ __/ _ \   / _ \ / _` |/ _ \ '_ \| __|
- |  _  | |_| | (_| | (_| | | | | | (_| | |  _| (_| | (_|  __/  / ___ \ (_| |  __/ | | | |_ 
+ |  _  | |_| | (_| | (_| | | | | | (_| | |  _| (_| | (_|  __/  / ___ \ (_| |  __/ | | | |_
  |_| |_|\__,_|\__, |\__, |_|_| |_|\__, | |_|  \__,_|\___\___| /_/   \_\__, |\___|_| |_|\__|
               |___/ |___/         |___/                               |___/
     """
 
     print(format_separator())
     print(f"{Colors.YELLOW} {banner}{Colors.RESET}")
-    print("Type your messages below. Type 'exit', 'quit', or '/quit' to end.\n")
+    print("Type your messages below. Type /help for commands, /quit to exit.\n")
     print(format_separator())
     # Wait for agent to initialize
     print("Initializing agent...")
+
+    # HF token
+    hf_token = _get_hf_token()
+    if hf_token:
+        print("HF token loaded")
+    else:
+        print("Warning: No HF token found. Set HF_TOKEN or run `huggingface-cli login`.")
 
     # Create queues for communication
     submission_queue = asyncio.Queue()
@@ -480,12 +605,15 @@ async def main():
     config_path = Path(__file__).parent.parent / "configs" / "main_agent_config.json"
     config = load_config(config_path)
 
-    # Create tool router
+    # Create tool router with local mode
     print(f"Loading MCP servers: {', '.join(config.mcpServers.keys())}")
-    tool_router = ToolRouter(config.mcpServers)
+    tool_router = ToolRouter(config.mcpServers, hf_token=hf_token, local_mode=True)
 
     # Create prompt session for input
     prompt_session = PromptSession()
+
+    # Session holder for interrupt/model/status access
+    session_holder = [None]
 
     agent_task = asyncio.create_task(
         submission_loop(
@@ -493,6 +621,8 @@ async def main():
             event_queue,
             config=config,
             tool_router=tool_router,
+            session_holder=session_holder,
+            hf_token=hf_token,
         )
     )
 
@@ -510,12 +640,16 @@ async def main():
 
     await ready_event.wait()
 
-    submission_id = 0
+    submission_id = [0]
+    last_interrupt_time = 0.0
 
     try:
         while True:
-            # Wait for previous turn to complete
-            await turn_complete_event.wait()
+            # Wait for previous turn to complete, with interrupt support
+            try:
+                await turn_complete_event.wait()
+            except asyncio.CancelledError:
+                break
             turn_complete_event.clear()
 
             # Get user input
@@ -523,6 +657,21 @@ async def main():
                 user_input = await get_user_input(prompt_session)
             except EOFError:
                 break
+            except KeyboardInterrupt:
+                now = time.monotonic()
+                if now - last_interrupt_time < 3.0:
+                    print("\nDouble Ctrl+C, exiting...")
+                    break
+                last_interrupt_time = now
+                # If agent is busy, cancel it
+                session = session_holder[0]
+                if session and not turn_complete_event.is_set():
+                    session.cancel()
+                    print("\nInterrupting agent...")
+                else:
+                    print("\n(Ctrl+C again within 3s to exit)")
+                    turn_complete_event.set()
+                continue
 
             # Check for exit commands
             if user_input.strip().lower() in ["exit", "quit", "/quit", "/exit"]:
@@ -533,35 +682,50 @@ async def main():
                 turn_complete_event.set()
                 continue
 
+            # Handle slash commands
+            if user_input.strip().startswith("/"):
+                sub = _handle_slash_command(
+                    user_input.strip(), config, session_holder, submission_queue, submission_id
+                )
+                if sub is None:
+                    # Command handled locally, loop back for input
+                    turn_complete_event.set()
+                    continue
+                else:
+                    await submission_queue.put(sub)
+                    continue
+
             # Submit to agent
-            submission_id += 1
+            submission_id[0] += 1
             submission = Submission(
-                id=f"sub_{submission_id}",
+                id=f"sub_{submission_id[0]}",
                 operation=Operation(
                     op_type=OpType.USER_INPUT, data={"text": user_input}
                 ),
             )
-            # print(f"Main submitting: {submission.operation.op_type}")
             await submission_queue.put(submission)
 
     except KeyboardInterrupt:
         print("\n\nInterrupted by user")
 
     # Shutdown
-    print("\n🛑 Shutting down agent...")
+    print("\nShutting down agent...")
     shutdown_submission = Submission(
         id="sub_shutdown", operation=Operation(op_type=OpType.SHUTDOWN)
     )
     await submission_queue.put(shutdown_submission)
 
-    await asyncio.wait_for(agent_task, timeout=5.0)
+    try:
+        await asyncio.wait_for(agent_task, timeout=5.0)
+    except asyncio.TimeoutError:
+        agent_task.cancel()
     listener_task.cancel()
 
-    print("✨ Goodbye!\n")
+    print("Goodbye!\n")
 
 
 if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("\n\n✨ Goodbye!")
+        print("\n\nGoodbye!")

--- a/agent/tools/local_tools.py
+++ b/agent/tools/local_tools.py
@@ -1,0 +1,159 @@
+"""
+Local tool implementations — bash/read/write/edit running on the user's machine.
+
+Drop-in replacement for sandbox tools when running in CLI (local) mode.
+Same tool specs (names, parameters) but handlers execute locally via
+subprocess/pathlib instead of going through a remote sandbox.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from agent.tools.sandbox_client import Sandbox
+
+MAX_OUTPUT_CHARS = 30_000
+MAX_LINE_LENGTH = 2000
+DEFAULT_READ_LINES = 2000
+DEFAULT_TIMEOUT = 120
+MAX_TIMEOUT = 600
+
+
+# ── Handlers ────────────────────────────────────────────────────────────
+
+async def _bash_handler(args: dict[str, Any], **_kw) -> tuple[str, bool]:
+    command = args.get("command", "")
+    if not command:
+        return "No command provided.", False
+    work_dir = args.get("work_dir", ".")
+    timeout = min(args.get("timeout") or DEFAULT_TIMEOUT, MAX_TIMEOUT)
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            cwd=work_dir,
+            timeout=timeout,
+        )
+        output = result.stdout + result.stderr
+        if len(output) > MAX_OUTPUT_CHARS:
+            output = output[:MAX_OUTPUT_CHARS] + "\n... (output truncated)"
+        if not output.strip():
+            output = "(no output)"
+        return output, result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return f"Command timed out after {timeout}s.", False
+    except Exception as e:
+        return f"bash error: {e}", False
+
+
+async def _read_handler(args: dict[str, Any], **_kw) -> tuple[str, bool]:
+    file_path = args.get("path", "")
+    if not file_path:
+        return "No path provided.", False
+    p = Path(file_path)
+    if not p.exists():
+        return f"File not found: {file_path}", False
+    if p.is_dir():
+        return "Cannot read a directory. Use bash with 'ls' instead.", False
+    try:
+        lines = p.read_text().splitlines()
+    except Exception as e:
+        return f"read error: {e}", False
+
+    offset = max((args.get("offset") or 1), 1)
+    limit = args.get("limit") or DEFAULT_READ_LINES
+
+    selected = lines[offset - 1 : offset - 1 + limit]
+    numbered = []
+    for i, line in enumerate(selected, start=offset):
+        if len(line) > MAX_LINE_LENGTH:
+            line = line[:MAX_LINE_LENGTH] + "..."
+        numbered.append(f"{i:>6}\t{line}")
+    return "\n".join(numbered), True
+
+
+async def _write_handler(args: dict[str, Any], **_kw) -> tuple[str, bool]:
+    file_path = args.get("path", "")
+    content = args.get("content", "")
+    if not file_path:
+        return "No path provided.", False
+    p = Path(file_path)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        return f"Wrote {len(content)} bytes to {file_path}", True
+    except Exception as e:
+        return f"write error: {e}", False
+
+
+async def _edit_handler(args: dict[str, Any], **_kw) -> tuple[str, bool]:
+    file_path = args.get("path", "")
+    old_str = args.get("old_str", "")
+    new_str = args.get("new_str", "")
+    replace_all = args.get("replace_all", False)
+
+    if not file_path:
+        return "No path provided.", False
+    if old_str == new_str:
+        return "old_str and new_str must differ.", False
+
+    p = Path(file_path)
+    if not p.exists():
+        return f"File not found: {file_path}", False
+
+    try:
+        text = p.read_text()
+    except Exception as e:
+        return f"edit read error: {e}", False
+
+    count = text.count(old_str)
+    if count == 0:
+        return "old_str not found in file.", False
+    if count > 1 and not replace_all:
+        return (
+            f"old_str appears {count} times. Use replace_all=true to replace all, "
+            "or provide a more specific old_str."
+        ), False
+
+    new_text = text.replace(old_str, new_str) if replace_all else text.replace(old_str, new_str, 1)
+    try:
+        p.write_text(new_text)
+    except Exception as e:
+        return f"edit write error: {e}", False
+
+    replacements = count if replace_all else 1
+    return f"Edited {file_path} ({replacements} replacement{'s' if replacements > 1 else ''})", True
+
+
+# ── Public API ──────────────────────────────────────────────────────────
+
+_HANDLERS = {
+    "bash": _bash_handler,
+    "read": _read_handler,
+    "write": _write_handler,
+    "edit": _edit_handler,
+}
+
+
+def get_local_tools():
+    """Return local ToolSpecs for bash/read/write/edit (no sandbox_create)."""
+    from agent.core.tools import ToolSpec
+
+    tools = []
+    for name, spec in Sandbox.TOOLS.items():
+        handler = _HANDLERS.get(name)
+        if handler is None:
+            continue
+        tools.append(
+            ToolSpec(
+                name=name,
+                description=spec["description"],
+                parameters=spec["parameters"],
+                handler=handler,
+            )
+        )
+    return tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ agent = [
     "litellm>=1.0.0",
     "huggingface-hub>=1.0.1",
     "fastmcp>=2.4.0",
-    "lmnr>=0.7.23",  # Note: Using base package to avoid torch/transformers from [all] extra
     "prompt-toolkit>=3.0.0",
     "thefuzz>=0.22.1",
     "nbconvert>=7.16.6",


### PR DESCRIPTION
## Summary
- **Local tools**: Replace sandbox tools with local bash/read/write/edit that execute directly on the user machine via subprocess/pathlib
- **Slash commands**: /help, /undo, /compact, /model, /yolo, /status
- **Interrupt support**: Single Ctrl+C cancels the current agent turn, double Ctrl+C within 3s exits
- **HF token**: Auto-loads from HF_TOKEN env var or huggingface-cli login
- **Event handlers**: Added handlers for interrupted, undo_complete, tool_log, tool_state_change
- **Bug fix**: Context manager _sanitize_tool_calls and _patch_dangling_tool_calls now handle tool_calls as both dicts and ToolCall objects (fixes dict object has no attribute function crash)
- **Remove lmnr**: Removed lmnr dependency and all observe/Laminar references from agent code