### PR TITLE
Issue #23 Fix: Use logged in hf token using `huggingface_hub.get_token()` instead of requiring env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Create a `.env` file in the project root (or export these in your shell):
 
 ```bash
 ANTHROPIC_API_KEY=<your-anthropic-api-key> # if using anthropic models
-HF_TOKEN=<your-hugging-face-token>
+HF_TOKEN=<your-hugging-face-token> # optional if you've run huggingface-cli login
 GITHUB_TOKEN=<github-personal-access-token> 
 ```
-If no `HF_TOKEN` is set, the CLI will prompt you to paste one on first launch. To get a GITHUB_TOKEN follow the tutorial [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
+If no `HF_TOKEN` is set, the CLI will use the token saved by `huggingface-cli login`, or prompt you to paste one on first launch. To get a GITHUB_TOKEN follow the tutorial [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
 
 ### Usage
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -23,6 +23,7 @@ from agent.config import load_config
 from agent.core.agent_loop import submission_loop
 from agent.core.session import OpType
 from agent.core.tools import ToolRouter
+from agent.utils.hf_auth import get_hf_token
 from agent.utils.reliability_checks import check_training_script_save_pattern
 from agent.utils.terminal_display import (
     get_console,
@@ -65,25 +66,8 @@ def _safe_get_args(arguments: dict) -> dict:
 
 
 def _get_hf_token() -> str | None:
-    """Get HF token from environment, huggingface_hub API, or cached token file."""
-    token = os.environ.get("HF_TOKEN")
-    if token:
-        return token
-    try:
-        from huggingface_hub import HfApi
-        api = HfApi()
-        token = api.token
-        if token:
-            return token
-    except Exception:
-        pass
-    # Fallback: read the cached token file directly
-    token_path = Path.home() / ".cache" / "huggingface" / "token"
-    if token_path.exists():
-        token = token_path.read_text().strip()
-        if token:
-            return token
-    return None
+    """Get HF token from HF_TOKEN, then huggingface_hub login cache."""
+    return get_hf_token()
 
 
 async def _prompt_and_save_hf_token(prompt_session: PromptSession) -> str:

--- a/agent/utils/hf_auth.py
+++ b/agent/utils/hf_auth.py
@@ -1,0 +1,19 @@
+"""Hugging Face authentication helpers."""
+
+import os
+
+
+def get_hf_token() -> str | None:
+    """Return the local HF token, preferring HF_TOKEN over login cache."""
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        return token
+
+    try:
+        from huggingface_hub import get_token
+
+        token = get_token()
+    except Exception:
+        return None
+
+    return token or None

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -7,7 +7,6 @@ dependency. In dev mode (no OAUTH_CLIENT_ID), auth is bypassed automatically.
 import asyncio
 import json
 import logging
-import os
 from typing import Any
 
 from dependencies import get_current_user
@@ -31,6 +30,7 @@ from models import (
 from session_manager import MAX_SESSIONS, SessionCapacityError, session_manager
 
 from agent.core.agent_loop import _resolve_hf_router_params
+from agent.utils.hf_auth import get_hf_token
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +207,7 @@ async def create_session(
 
     Returns 503 if the server or user has reached the session limit.
     """
-    # Extract the user's HF token (Bearer header, HttpOnly cookie, or env var)
+    # Extract request token first, then fall back to local HF auth.
     hf_token = None
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
@@ -215,7 +215,7 @@ async def create_session(
     if not hf_token:
         hf_token = request.cookies.get("hf_access_token")
     if not hf_token:
-        hf_token = os.environ.get("HF_TOKEN")
+        hf_token = get_hf_token()
 
     try:
         session_id = await session_manager.create_session(


### PR DESCRIPTION
## Summary
- Add a shared Hugging Face token helper that keeps `HF_TOKEN` as the first local token source and falls back to `huggingface_hub.get_token()`
- Reuse the helper in CLI and backend session creation so users logged in with `huggingface-cli login` do not need to set `HF_TOKEN`
- Update the README quick start notes to document the login-cache fallback while keeping the existing environment variable flow

## Test plan
- [x] Run `python -m py_compile agent\utils\hf_auth.py agent\main.py backend\routes\agent.py`
- [x] Verify `HF_TOKEN` takes precedence over `huggingface_hub.get_token()`
- [x] Confirm README changes are limited to the HF token setup note

Fixes #23
