### PR TITLE
Fix HF router auth failure on CLI (issue #36)

### DIFF
--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -263,7 +263,10 @@ class ContextManager:
         return False
 
     async def compact(
-        self, model_name: str, tool_specs: list[dict] | None = None
+        self,
+        model_name: str,
+        tool_specs: list[dict] | None = None,
+        hf_token: str | None = None,
     ) -> None:
         """Remove old messages to keep history under target size"""
         if (self.context_length <= self.max_context) or not self.items:
@@ -303,7 +306,11 @@ class ContextManager:
             )
         )
 
-        hf_key = os.environ.get("INFERENCE_TOKEN")
+        hf_key = (
+            os.environ.get("INFERENCE_TOKEN")
+            or hf_token
+            or os.environ.get("HF_TOKEN")
+        )
         response = await acompletion(
             model=model_name,
             messages=messages_to_summarize,

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -20,11 +20,11 @@ from agent.tools.jobs_tool import CPU_FLAVORS
 logger = logging.getLogger(__name__)
 
 ToolCall = ChatCompletionMessageToolCall
-# Explicit inference token for LLM API calls (separate from user OAuth tokens).
-_INFERENCE_API_KEY = os.environ.get("INFERENCE_TOKEN")
 
 
-def _resolve_hf_router_params(model_name: str) -> dict:
+def _resolve_hf_router_params(
+    model_name: str, session_hf_token: str | None = None
+) -> dict:
     """
     Build LiteLLM kwargs for HuggingFace Router models.
 
@@ -35,6 +35,13 @@ def _resolve_hf_router_params(model_name: str) -> dict:
 
     Input format:  huggingface/<router_provider>/<org>/<model>
     Example:       huggingface/novita/moonshotai/kimi-k2.5
+
+    Token resolution (first non-empty wins):
+      1. INFERENCE_TOKEN env — shared key on the hosted Space so inference
+         is free for users and billed to the Space owner.
+      2. session.hf_token — the user's own token (CLI or self-hosted),
+         resolved from env / huggingface-cli login / cached token file.
+      3. HF_TOKEN env — belt-and-suspenders fallback for CLI users.
     """
     if not model_name.startswith("huggingface/"):
         return {"model": model_name}
@@ -47,7 +54,11 @@ def _resolve_hf_router_params(model_name: str) -> dict:
 
     router_provider = parts[1]
     actual_model = parts[2]
-    api_key = _INFERENCE_API_KEY
+    api_key = (
+        os.environ.get("INFERENCE_TOKEN")
+        or session_hf_token
+        or os.environ.get("HF_TOKEN")
+    )
 
     return {
         "model": f"openai/{actual_model}",
@@ -205,6 +216,7 @@ async def _compact_and_notify(session: Session) -> None:
     await session.context_manager.compact(
         model_name=session.config.model_name,
         tool_specs=tool_specs,
+        hf_token=session.hf_token,
     )
     new_length = session.context_manager.context_length
     if new_length != old_length:
@@ -506,7 +518,9 @@ class Handlers:
             tools = session.tool_router.get_tool_specs_for_llm()
             try:
                 # ── Call the LLM (streaming or non-streaming) ──
-                llm_params = _resolve_hf_router_params(session.config.model_name)
+                llm_params = _resolve_hf_router_params(
+                    session.config.model_name, session.hf_token
+                )
                 if session.stream:
                     llm_result = await _call_llm_streaming(session, messages, tools, llm_params)
                 else:

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -213,7 +213,9 @@ RESEARCH_TOOL_SPEC = {
 }
 
 
-def _resolve_llm_params(model_name: str) -> dict:
+def _resolve_llm_params(
+    model_name: str, session_hf_token: str | None = None
+) -> dict:
     """Build LiteLLM kwargs, reusing the HF router logic from agent_loop."""
     if not model_name.startswith("huggingface/"):
         return {"model": model_name}
@@ -224,10 +226,16 @@ def _resolve_llm_params(model_name: str) -> dict:
 
     provider = parts[1]
     model_id = parts[2]
+    api_key = (
+        os.environ.get("INFERENCE_TOKEN")
+        or session_hf_token
+        or os.environ.get("HF_TOKEN")
+        or ""
+    )
     return {
         "model": f"openai/{model_id}",
         "api_base": f"https://router.huggingface.co/{provider}/v3/openai",
-        "api_key": os.environ.get("INFERENCE_TOKEN", ""),
+        "api_key": api_key,
     }
 
 
@@ -264,7 +272,7 @@ async def research_handler(
     # Use a cheaper/faster model for research
     main_model = session.config.model_name
     research_model = _get_research_model(main_model)
-    llm_params = _resolve_llm_params(research_model)
+    llm_params = _resolve_llm_params(research_model, getattr(session, "hf_token", None))
 
     # Get read-only tool specs from the session's tool router
     tool_specs = [


### PR DESCRIPTION
## Summary
- `_resolve_hf_router_params` only read `INFERENCE_TOKEN`, which is the shared server-side key set on the hosted Space so inference is free for users. On the CLI / self-hosted path that env var is absent, so router requests went out with no bearer token and HF returned 401 — surfaced as "Authentication failed" even when the user had a valid `HF_TOKEN` (#36).
- Now resolve the router `api_key` in this order: `INFERENCE_TOKEN` → `session.hf_token` → `HF_TOKEN`. Space behavior is unchanged (shared token still wins); CLI / self-hosted now works with `HF_TOKEN`, `huggingface-cli login`, or the cached token file (all three already resolved by `_get_hf_token()` in `agent/main.py`).
- Same fallback applied to `research_tool._resolve_llm_params` and `ContextManager.compact`.

## Test plan
- [ ] On the Space (with `INFERENCE_TOKEN` set): verify inference is still billed to the shared account and unchanged for all users.
- [ ] Locally without `INFERENCE_TOKEN`: `export HF_TOKEN=hf_...` → `ml-intern` → `/model huggingface/novita/zai-org/glm-5` → send a prompt, confirm no 401.
- [ ] Locally without `INFERENCE_TOKEN` and without `HF_TOKEN`, but with `huggingface-cli login` done: same flow works (session token resolves from cache).
- [ ] Confirm context compaction on a long conversation still works on CLI with only `HF_TOKEN` set.
- [ ] Confirm the research tool (sub-agent) works on CLI with only `HF_TOKEN` set.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)