### PR TITLE
Fix duplicate status display for parallel research agents

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -326,7 +326,9 @@ async def event_listener(
                 tool = event.data.get("tool", "") if event.data else ""
                 log = event.data.get("log", "") if event.data else ""
                 if log:
-                    print_tool_log(tool, log)
+                    agent_id = event.data.get("agent_id", "") if event.data else ""
+                    label = event.data.get("label", "") if event.data else ""
+                    print_tool_log(tool, log, agent_id=agent_id, label=label)
             elif event.event_type == "tool_state_change":
                 pass  # visual noise — approval flow handles this
             elif event.event_type == "error":

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -281,11 +281,21 @@ async def research_handler(
         if spec["function"]["name"] in RESEARCH_TOOL_NAMES
     ]
 
+    # Unique ID + short label so parallel agents show separate status lines
+    import hashlib
+    _agent_id = hashlib.md5(task.encode()).hexdigest()[:8]
+    _agent_label = "research: " + (task[:50] + "…" if len(task) > 50 else task)
+
     async def _log(text: str) -> None:
         """Send a progress event to the UI so it doesn't look frozen."""
         try:
             await session.send_event(
-                Event(event_type="tool_log", data={"tool": "research", "log": text})
+                Event(event_type="tool_log", data={
+                    "tool": "research",
+                    "log": text,
+                    "agent_id": _agent_id,
+                    "label": _agent_label,
+                })
             )
         except Exception:
             pass

--- a/agent/utils/terminal_display.py
+++ b/agent/utils/terminal_display.py
@@ -117,74 +117,83 @@ def print_tool_output(output: str, success: bool, truncate: bool = True) -> None
     _console.print(f"[{style}]{indented}[/{style}]")
 
 
-class SubAgentDisplay:
-    """Live-updating display: header with stats (ticks every second) + rolling 2-line tool calls."""
+class SubAgentDisplayManager:
+    """Manages multiple concurrent sub-agent displays.
 
-    _MAX_VISIBLE = 2
+    Each agent gets its own stats and rolling tool-call log.
+    All agents are rendered together so terminal escape-code
+    erase/redraw stays consistent.
+    """
+
+    _MAX_VISIBLE = 2  # tool-call lines shown per agent
 
     def __init__(self):
-        self._calls: list[str] = []
-        self._tool_count = 0
-        self._token_count = 0
-        self._start_time: float | None = None
+        self._agents: dict[str, dict] = {}  # agent_id -> state dict
         self._lines_on_screen = 0
         self._ticker_task = None
 
-    def start(self) -> None:
-        """Begin the display with a 1-second ticker."""
+    def start(self, agent_id: str, label: str = "research") -> None:
         import asyncio
         import time
-        self._calls = []
-        self._tool_count = 0
-        self._token_count = 0
-        self._start_time = time.monotonic()
-        self._redraw()
-        self._ticker_task = asyncio.ensure_future(self._tick())
-
-    def set_tokens(self, tokens: int) -> None:
-        self._token_count = tokens
-        # no redraw — ticker handles it
-
-    def set_tool_count(self, count: int) -> None:
-        self._tool_count = count
-        # no redraw — ticker handles it
-
-    def add_call(self, tool_desc: str) -> None:
-        self._calls.append(tool_desc)
+        self._agents[agent_id] = {
+            "label": label,
+            "calls": [],
+            "tool_count": 0,
+            "token_count": 0,
+            "start_time": time.monotonic(),
+        }
+        if not self._ticker_task:
+            self._ticker_task = asyncio.ensure_future(self._tick())
         self._redraw()
 
-    def clear(self) -> None:
-        if self._ticker_task:
-            self._ticker_task.cancel()
-            self._ticker_task = None
-        self._erase()
-        self._lines_on_screen = 0
-        self._calls = []
-        self._start_time = None
+    def set_tokens(self, agent_id: str, tokens: int) -> None:
+        if agent_id in self._agents:
+            self._agents[agent_id]["token_count"] = tokens
+
+    def set_tool_count(self, agent_id: str, count: int) -> None:
+        if agent_id in self._agents:
+            self._agents[agent_id]["tool_count"] = count
+
+    def add_call(self, agent_id: str, tool_desc: str) -> None:
+        if agent_id in self._agents:
+            self._agents[agent_id]["calls"].append(tool_desc)
+            self._redraw()
+
+    def clear(self, agent_id: str) -> None:
+        self._agents.pop(agent_id, None)
+        if not self._agents:
+            if self._ticker_task:
+                self._ticker_task.cancel()
+                self._ticker_task = None
+            self._erase()
+            self._lines_on_screen = 0
+        else:
+            self._redraw()
 
     async def _tick(self) -> None:
         import asyncio
         try:
             while True:
                 await asyncio.sleep(1.0)
-                self._redraw()
+                if self._agents:
+                    self._redraw()
         except asyncio.CancelledError:
             pass
 
-    def _format_stats(self) -> str:
+    @staticmethod
+    def _format_stats(agent: dict) -> str:
         import time
-        if self._start_time is None:
+        start = agent["start_time"]
+        if start is None:
             return ""
-        elapsed = time.monotonic() - self._start_time
+        elapsed = time.monotonic() - start
         if elapsed < 60:
             time_str = f"{elapsed:.0f}s"
         else:
             time_str = f"{elapsed / 60:.0f}m {elapsed % 60:.0f}s"
-        if self._token_count >= 1000:
-            tok_str = f"{self._token_count / 1000:.1f}k"
-        else:
-            tok_str = str(self._token_count)
-        return f"{self._tool_count} tool uses · {tok_str} tokens · {time_str}"
+        tok = agent["token_count"]
+        tok_str = f"{tok / 1000:.1f}k" if tok >= 1000 else str(tok)
+        return f"{agent['tool_count']} tool uses · {tok_str} tokens · {time_str}"
 
     def _erase(self) -> None:
         if self._lines_on_screen > 0:
@@ -196,39 +205,40 @@ class SubAgentDisplay:
     def _redraw(self) -> None:
         f = _console.file
         self._erase()
-        lines = []
-        # Header: ▸ research (stats)
-        stats = self._format_stats()
-        header = f"{_I}\033[38;2;255;200;80m▸ research\033[0m"
-        if stats:
-            header += f"  \033[2m({stats})\033[0m"
-        lines.append(header)
-        # Last 2 tool calls, gray
-        visible = self._calls[-self._MAX_VISIBLE:]
-        for desc in visible:
-            lines.append(f"{_I}  \033[2m{desc}\033[0m")
+        lines: list[str] = []
+        for agent in self._agents.values():
+            stats = self._format_stats(agent)
+            label = agent["label"]
+            header = f"{_I}\033[38;2;255;200;80m▸ {label}\033[0m"
+            if stats:
+                header += f"  \033[2m({stats})\033[0m"
+            lines.append(header)
+            visible = agent["calls"][-self._MAX_VISIBLE:]
+            for desc in visible:
+                lines.append(f"{_I}  \033[2m{desc}\033[0m")
         for line in lines:
             f.write(line + "\n")
         f.flush()
         self._lines_on_screen = len(lines)
 
 
-_subagent_display = SubAgentDisplay()
+_subagent_display = SubAgentDisplayManager()
 
 
-def print_tool_log(tool: str, log: str) -> None:
+def print_tool_log(tool: str, log: str, agent_id: str = "", label: str = "") -> None:
     """Handle tool log events — sub-agent calls get the rolling display."""
     if tool == "research":
+        aid = agent_id or "research"
         if log == "Starting research sub-agent...":
-            _subagent_display.start()
+            _subagent_display.start(aid, label or "research")
         elif log == "Research complete.":
-            _subagent_display.clear()
+            _subagent_display.clear(aid)
         elif log.startswith("tokens:"):
-            _subagent_display.set_tokens(int(log[7:]))
+            _subagent_display.set_tokens(aid, int(log[7:]))
         elif log.startswith("tools:"):
-            _subagent_display.set_tool_count(int(log[6:]))
+            _subagent_display.set_tool_count(aid, int(log[6:]))
         else:
-            _subagent_display.add_call(log)
+            _subagent_display.add_call(aid, log)
     else:
         _console.print(f"{_I}[dim]{tool}: {log}[/dim]")
 

--- a/frontend/src/components/Chat/ToolCallGroup.tsx
+++ b/frontend/src/components/Chat/ToolCallGroup.tsx
@@ -172,51 +172,70 @@ function formatResearchStep(raw: string): { label: string } {
   return { label: step.replace(/^▸\s*/, '') };
 }
 
-/** Rolling 2-line display of research sub-tool calls — hidden when complete. */
-function ResearchSteps({ steps, isRunning }: { steps: string[]; isRunning: boolean }) {
-  if (!isRunning) return null;
-  const visible = steps.slice(-RESEARCH_MAX_STEPS);
-  if (visible.length === 0) return null;
+/** Rolling display of research sub-tool calls per agent — hidden when complete. */
+function ResearchSteps({ agents }: { agents: Record<string, { label: string; steps: string[]; stats: { startedAt: number | null } }> }) {
+  const running = Object.entries(agents).filter(([, a]) => a.stats.startedAt !== null);
+  if (running.length === 0) return null;
 
   return (
     <Box sx={{ pl: 4.5, pr: 1.5, pb: 1, pt: 0.25 }}>
-      {visible.map((step, i) => {
-        const { label } = formatResearchStep(step);
-        const isLast = i === visible.length - 1;
+      {running.map(([agentId, agent]) => {
+        const visible = agent.steps.slice(-RESEARCH_MAX_STEPS);
         return (
-          <Stack
-            key={i}
-            direction="row"
-            alignItems="center"
-            spacing={0.75}
-            sx={{ py: 0.2 }}
-          >
-            {isLast ? (
-              <CircularProgress size={10} thickness={5} sx={{ color: 'var(--accent-yellow)', flexShrink: 0 }} />
-            ) : (
-              <CheckCircleOutlineIcon sx={{ fontSize: 12, color: 'var(--muted-text)', flexShrink: 0 }} />
+          <Box key={agentId} sx={{ mb: running.length > 1 ? 0.75 : 0 }}>
+            {running.length > 1 && (
+              <Typography
+                sx={{
+                  fontFamily: '"JetBrains Mono", ui-monospace, SFMono-Regular, monospace',
+                  fontSize: '0.62rem',
+                  color: 'var(--accent-yellow)',
+                  opacity: 0.7,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  mb: 0.25,
+                }}
+              >
+                {agent.label}
+              </Typography>
             )}
-            <Typography
-              sx={{
-                fontFamily: '"JetBrains Mono", ui-monospace, SFMono-Regular, monospace',
-                fontSize: '0.68rem',
-                color: isLast ? 'var(--text)' : 'var(--muted-text)',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {label}
-            </Typography>
-          </Stack>
+            {visible.map((step, i) => {
+              const { label } = formatResearchStep(step);
+              const isLast = i === visible.length - 1;
+              return (
+                <Stack
+                  key={i}
+                  direction="row"
+                  alignItems="center"
+                  spacing={0.75}
+                  sx={{ py: 0.2 }}
+                >
+                  {isLast ? (
+                    <CircularProgress size={10} thickness={5} sx={{ color: 'var(--accent-yellow)', flexShrink: 0 }} />
+                  ) : (
+                    <CheckCircleOutlineIcon sx={{ fontSize: 12, color: 'var(--muted-text)', flexShrink: 0 }} />
+                  )}
+                  <Typography
+                    sx={{
+                      fontFamily: '"JetBrains Mono", ui-monospace, SFMono-Regular, monospace',
+                      fontSize: '0.68rem',
+                      color: isLast ? 'var(--text)' : 'var(--muted-text)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {label}
+                  </Typography>
+                </Stack>
+              );
+            })}
+          </Box>
         );
       })}
     </Box>
   );
 }
-
-// Stable reference to avoid infinite re-renders from Zustand selectors
-const EMPTY_STEPS: string[] = [];
 
 // ---------------------------------------------------------------------------
 // Hardware pricing ($/hr) — from HF Spaces & Jobs pricing
@@ -514,14 +533,25 @@ function InlineApproval({
 
 export default function ToolCallGroup({ tools, approveTools }: ToolCallGroupProps) {
   const { setPanel, lockPanel, getJobUrl, getEditedScript, setJobStatus, getJobStatus, setToolError, getToolError, setToolRejected, getToolRejected } = useAgentStore();
-  const researchSteps = useAgentStore(s => {
+  const researchAgents = useAgentStore(s => {
     const activeId = s.activeSessionId;
-    return activeId ? (s.sessionStates[activeId]?.researchSteps) : undefined;
-  }) ?? EMPTY_STEPS;
-  const researchStats = useAgentStore(s => {
-    const activeId = s.activeSessionId;
-    return activeId ? s.sessionStates[activeId]?.researchStats : undefined;
-  }) ?? { toolCount: 0, tokenCount: 0, startedAt: null, finalElapsed: null };
+    return activeId ? (s.sessionStates[activeId]?.researchAgents) : undefined;
+  }) ?? {};
+  // Aggregate stats across all agents for the chip label
+  const aggregateStats = useMemo(() => {
+    const agents = Object.values(researchAgents);
+    if (agents.length === 0) return { toolCount: 0, tokenCount: 0, startedAt: null, finalElapsed: null };
+    const running = agents.filter(a => a.stats.startedAt !== null);
+    return {
+      toolCount: agents.reduce((sum, a) => sum + a.stats.toolCount, 0),
+      tokenCount: agents.reduce((sum, a) => sum + a.stats.tokenCount, 0),
+      startedAt: running.length > 0 ? Math.min(...running.map(a => a.stats.startedAt!)) : null,
+      finalElapsed: running.length === 0 && agents.length > 0
+        ? Math.max(...agents.map(a => a.stats.finalElapsed ?? 0))
+        : null,
+    };
+  }, [researchAgents]);
+  const researchStats = aggregateStats;
   const liveElapsed = useElapsed(researchStats.startedAt);
   const isProcessing = useAgentStore(s => s.isProcessing);
   const { setRightPanelOpen, setLeftSidebarOpen } = useLayoutStore();
@@ -1049,10 +1079,7 @@ export default function ToolCallGroup({ tools, approveTools }: ToolCallGroupProp
 
               {/* Research sub-agent rolling steps (visible only while running) */}
               {tool.toolName === 'research' && !cancelled && state !== 'output-available' && state !== 'output-error' && state !== 'output-denied' && (
-                <ResearchSteps
-                  steps={researchSteps}
-                  isRunning={researchStats.startedAt !== null}
-                />
+                <ResearchSteps agents={researchAgents} />
               )}
 
               {/* Per-tool approval: undecided */}

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -86,46 +86,63 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
           useLayoutStore.getState().setRightPanelOpen(true);
         }
       },
-      onToolLog: (tool: string, log: string) => {
-        // Research sub-agent: parse stats vs step logs
+      onToolLog: (tool: string, log: string, agentId?: string, label?: string) => {
+        // Research sub-agent: parse stats vs step logs (per-agent)
         if (tool === 'research') {
+          const aid = agentId || 'research';
           const sessState = useAgentStore.getState().getSessionState(sessionId);
-          const stats = { ...sessState.researchStats };
+          const agents = { ...sessState.researchAgents };
+          const agent = agents[aid] || { label: label || 'research', steps: [], stats: { toolCount: 0, tokenCount: 0, startedAt: null, finalElapsed: null } };
 
           if (log === 'Starting research sub-agent...') {
-            const newStats = { toolCount: 0, tokenCount: 0, startedAt: Date.now(), finalElapsed: null };
+            agents[aid] = {
+              label: label || 'research',
+              steps: [],
+              stats: { toolCount: 0, tokenCount: 0, startedAt: Date.now(), finalElapsed: null },
+            };
+            // Also update legacy flat fields (aggregate of all agents)
+            const allSteps = Object.values(agents).flatMap(a => a.steps);
+            const anyRunning = Object.values(agents).some(a => a.stats.startedAt !== null);
             updateSession(sessionId, {
-              researchSteps: [],
-              researchStats: newStats,
-              activityStatus: { type: 'tool', toolName: 'research', description: log },
+              researchAgents: agents,
+              researchSteps: allSteps.slice(-RESEARCH_MAX_STEPS),
+              researchStats: anyRunning ? agents[aid].stats : sessState.researchStats,
+              activityStatus: { type: 'tool', toolName: 'research', description: label || log },
             });
-            saveResearch(sessionId, [], newStats);
+            saveResearch(sessionId, allSteps.slice(-RESEARCH_MAX_STEPS), agents[aid].stats);
           } else if (log.startsWith('tokens:')) {
-            stats.tokenCount = parseInt(log.slice(7), 10);
-            updateSession(sessionId, { researchStats: stats });
-            saveResearch(sessionId, sessState.researchSteps, stats);
+            agent.stats = { ...agent.stats, tokenCount: parseInt(log.slice(7), 10) };
+            agents[aid] = agent;
+            updateSession(sessionId, { researchAgents: agents });
           } else if (log.startsWith('tools:')) {
-            stats.toolCount = parseInt(log.slice(6), 10);
-            updateSession(sessionId, { researchStats: stats });
-            saveResearch(sessionId, sessState.researchSteps, stats);
+            agent.stats = { ...agent.stats, toolCount: parseInt(log.slice(6), 10) };
+            agents[aid] = agent;
+            updateSession(sessionId, { researchAgents: agents });
           } else if (log === 'Research complete.') {
-            const elapsed = stats.startedAt
-              ? Math.round((Date.now() - stats.startedAt) / 1000)
+            const elapsed = agent.stats.startedAt
+              ? Math.round((Date.now() - agent.stats.startedAt) / 1000)
               : null;
-            const doneStats = { ...stats, startedAt: null, finalElapsed: elapsed };
+            agent.stats = { ...agent.stats, startedAt: null, finalElapsed: elapsed };
+            agents[aid] = agent;
+            const anyRunning = Object.values(agents).some(a => a.stats.startedAt !== null);
             updateSession(sessionId, {
-              researchStats: doneStats,
+              researchAgents: agents,
+              researchStats: anyRunning ? sessState.researchStats : agent.stats,
               activityStatus: { type: 'tool', toolName: 'research', description: log },
             });
-            clearResearch(sessionId);
+            // Clear persistence only when ALL agents are done
+            if (!anyRunning) clearResearch(sessionId);
           } else {
-            // Regular tool call step — append (trim to max)
-            const steps = [...sessState.researchSteps, log].slice(-RESEARCH_MAX_STEPS);
+            // Regular tool call step — append to this agent
+            agent.steps = [...agent.steps, log].slice(-RESEARCH_MAX_STEPS);
+            agents[aid] = agent;
+            const allSteps = Object.values(agents).flatMap(a => a.steps);
             updateSession(sessionId, {
-              researchSteps: steps,
+              researchAgents: agents,
+              researchSteps: allSteps.slice(-RESEARCH_MAX_STEPS),
               activityStatus: { type: 'tool', toolName: 'research', description: log },
             });
-            saveResearch(sessionId, steps, stats);
+            saveResearch(sessionId, allSteps.slice(-RESEARCH_MAX_STEPS), agent.stats);
           }
           return;
         }

--- a/frontend/src/lib/sse-chat-transport.ts
+++ b/frontend/src/lib/sse-chat-transport.ts
@@ -23,7 +23,7 @@ export interface SideChannelCallbacks {
   onUndoComplete: () => void;
   onCompacted: (oldTokens: number, newTokens: number) => void;
   onPlanUpdate: (plan: Array<{ id: string; content: string; status: string }>) => void;
-  onToolLog: (tool: string, log: string) => void;
+  onToolLog: (tool: string, log: string, agentId?: string, label?: string) => void;
   onConnectionChange: (connected: boolean) => void;
   onSessionDead: (sessionId: string) => void;
   onApprovalRequired: (tools: Array<{ tool: string; arguments: Record<string, unknown>; tool_call_id: string }>) => void;
@@ -131,6 +131,8 @@ function createEventToChunkStream(sideChannel: SideChannelCallbacks): TransformS
           sideChannel.onToolLog(
             (event.data?.tool as string) || '',
             (event.data?.log as string) || '',
+            (event.data?.agent_id as string) || '',
+            (event.data?.label as string) || '',
           );
           break;
 

--- a/frontend/src/store/agentStore.ts
+++ b/frontend/src/store/agentStore.ts
@@ -53,6 +53,19 @@ export type ActivityStatus =
   | { type: 'streaming' }
   | { type: 'cancelled' };
 
+export interface ResearchAgentStats {
+  toolCount: number;
+  tokenCount: number;
+  startedAt: number | null;
+  finalElapsed: number | null;
+}
+
+export interface ResearchAgentState {
+  label: string;
+  steps: string[];
+  stats: ResearchAgentStats;
+}
+
 /** State that is tracked per-session (each session has its own copy). */
 export interface PerSessionState {
   isProcessing: boolean;
@@ -61,11 +74,15 @@ export interface PerSessionState {
   panelView: PanelView;
   panelEditable: boolean;
   plan: PlanItem[];
-  /** Steps completed by the research sub-agent (tool_log events). */
+  /** Per-agent research state, keyed by agent_id. */
+  researchAgents: Record<string, ResearchAgentState>;
+  /** @deprecated kept for backward compat selectors — use researchAgents instead */
   researchSteps: string[];
-  /** Live stats from the research sub-agent. */
-  researchStats: { toolCount: number; tokenCount: number; startedAt: number | null; finalElapsed: number | null };
+  /** @deprecated kept for backward compat selectors — use researchAgents instead */
+  researchStats: ResearchAgentStats;
 }
+
+const defaultResearchStats: ResearchAgentStats = { toolCount: 0, tokenCount: 0, startedAt: null, finalElapsed: null };
 
 const defaultSessionState: PerSessionState = {
   isProcessing: false,
@@ -74,8 +91,9 @@ const defaultSessionState: PerSessionState = {
   panelView: 'script',
   panelEditable: false,
   plan: [],
+  researchAgents: {},
   researchSteps: [],
-  researchStats: { toolCount: 0, tokenCount: 0, startedAt: null, finalElapsed: null },
+  researchStats: { ...defaultResearchStats },
 };
 
 interface AgentStore {
@@ -299,8 +317,9 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
         panelView: state.panelView,
         panelEditable: state.panelEditable,
         plan: state.plan,
+        researchAgents: state.sessionStates[state.activeSessionId]?.researchAgents ?? {},
         researchSteps: state.sessionStates[state.activeSessionId]?.researchSteps ?? [],
-        researchStats: state.sessionStates[state.activeSessionId]?.researchStats ?? defaultSessionState.researchStats,
+        researchStats: state.sessionStates[state.activeSessionId]?.researchStats ?? { ...defaultResearchStats },
       };
     }
 


### PR DESCRIPTION
## Summary
- When multiple research sub-agents run in parallel, they showed identical status in both CLI and web UI because they shared a single global display instance
- Replaced the singleton `SubAgentDisplay` with a `SubAgentDisplayManager` that tracks each agent independently by unique `agent_id` (derived from task hash)
- Each research agent now shows its own labeled status line with distinct tool calls, token counts, and timing

## Changes
- **Backend (CLI)**: `SubAgentDisplayManager` renders all active agents together with per-agent headers, stats, and rolling tool call logs
- **Backend (research_tool)**: Each invocation generates a unique `agent_id` + descriptive `label` passed through `tool_log` events
- **Frontend**: Store tracks `researchAgents` map (keyed by `agent_id`) instead of flat `researchSteps`/`researchStats`, so the UI renders per-agent steps with labels

## Test plan
- [ ] Run 3+ parallel research tasks and verify each shows distinct status in CLI
- [ ] Verify web UI shows separate labeled steps for each concurrent research agent
- [ ] Verify single research agent still works correctly (backward compat)
- [ ] Verify research completion clears display correctly for each agent independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)