### PR TITLE
Rebrand package from hf-agent to ml-intern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "hf-agent"
+name = "ml-intern"
 version = "0.1.0"
-description = "Add your description here"
+description = "ML Intern — an AI agent for machine learning engineering on Hugging Face"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
@@ -44,7 +44,7 @@ dev = [
 
 # All dependencies (eval + dev)
 all = [
-    "hf-agent[eval,dev]",
+    "ml-intern[eval,dev]",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -993,76 +993,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hf-agent"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "fastmcp" },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "litellm" },
-    { name = "nbconvert" },
-    { name = "nbformat" },
-    { name = "prompt-toolkit" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "thefuzz" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "websockets" },
-    { name = "whoosh" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "datasets" },
-    { name = "inspect-ai" },
-    { name = "pandas" },
-    { name = "pytest" },
-    { name = "tenacity" },
-]
-dev = [
-    { name = "pytest" },
-]
-eval = [
-    { name = "datasets" },
-    { name = "inspect-ai" },
-    { name = "pandas" },
-    { name = "tenacity" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "datasets", specifier = ">=4.4.1" },
-    { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.3.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "fastmcp", specifier = ">=3.2.0" },
-    { name = "hf-agent", extras = ["eval", "dev"], marker = "extra == 'all'" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "huggingface-hub", specifier = ">=1.0.1" },
-    { name = "inspect-ai", marker = "extra == 'eval'", specifier = ">=0.3.149" },
-    { name = "litellm", specifier = ">=1.83.0" },
-    { name = "nbconvert", specifier = ">=7.16.6" },
-    { name = "nbformat", specifier = ">=5.10.4" },
-    { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.3.3" },
-    { name = "prompt-toolkit", specifier = ">=3.0.0" },
-    { name = "pydantic", specifier = ">=2.12.3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "requests", specifier = ">=2.33.0" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "tenacity", marker = "extra == 'eval'", specifier = ">=8.0.0" },
-    { name = "thefuzz", specifier = ">=0.22.1" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
-    { name = "websockets", specifier = ">=13.0" },
-    { name = "whoosh", specifier = ">=2.7.4" },
-]
-provides-extras = ["eval", "dev", "all"]
-
-[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1824,6 +1754,76 @@ sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
 ]
+
+[[package]]
+name = "ml-intern"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "datasets" },
+    { name = "fastapi" },
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "litellm" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "prompt-toolkit" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "thefuzz" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
+    { name = "whoosh" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "datasets" },
+    { name = "inspect-ai" },
+    { name = "pandas" },
+    { name = "pytest" },
+    { name = "tenacity" },
+]
+dev = [
+    { name = "pytest" },
+]
+eval = [
+    { name = "datasets" },
+    { name = "inspect-ai" },
+    { name = "pandas" },
+    { name = "tenacity" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets", specifier = ">=4.4.1" },
+    { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.3.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "huggingface-hub", specifier = ">=1.0.1" },
+    { name = "inspect-ai", marker = "extra == 'eval'", specifier = ">=0.3.149" },
+    { name = "litellm", specifier = ">=1.83.0" },
+    { name = "ml-intern", extras = ["eval", "dev"], marker = "extra == 'all'" },
+    { name = "nbconvert", specifier = ">=7.16.6" },
+    { name = "nbformat", specifier = ">=5.10.4" },
+    { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.3.3" },
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
+    { name = "pydantic", specifier = ">=2.12.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "requests", specifier = ">=2.33.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "tenacity", marker = "extra == 'eval'", specifier = ">=8.0.0" },
+    { name = "thefuzz", specifier = ">=0.22.1" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+    { name = "websockets", specifier = ">=13.0" },
+    { name = "whoosh", specifier = ">=2.7.4" },
+]
+provides-extras = ["eval", "dev", "all"]
 
 [[package]]
 name = "mmh3"


### PR DESCRIPTION
## Summary
- Rename the distribution name in `pyproject.toml` from `hf-agent` to `ml-intern` (and update the placeholder description and the `[all]` self-reference).
- Regenerate `uv.lock` so the package key matches.
- `uv sync` now shows `Built ml-intern@...` instead of `Built hf-agent@...`.

## Not changed
- `agent/config.py` still references the HF dataset `akseljoonas/hf-agent-sessions`. That's a remote dataset path — renaming here needs the dataset itself renamed on HF, so I left it alone. Let me know if you want that migrated too.

## Test plan
- [ ] `rm -rf .venv && uv sync` — build line reads `ml-intern`, not `hf-agent`.
- [ ] `uv run ml-intern` still launches the CLI.