### PR TITLE
Title generation: pin to Llama-3.1-8B-Instruct via Cerebras, plain-text output

### DIFF
--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -166,9 +166,9 @@ async def generate_title(
 ) -> dict:
     """Generate a short title for a chat session based on the first user message.
 
-    Always uses gpt-oss-20b via Groq on the HF router. The tab headline
-    renders as plain text, so the model is told to avoid markdown and any
-    stray formatting characters are stripped before returning.
+    Always uses Llama-3.1-8B-Instruct via Cerebras on the HF router. The tab
+    headline renders as plain text, so the model is told to avoid markdown
+    and any stray formatting characters are stripped before returning.
     """
     api_key = (
         os.environ.get("INFERENCE_TOKEN")
@@ -178,8 +178,8 @@ async def generate_title(
     try:
         response = await acompletion(
             # Double openai/ prefix: LiteLLM strips the first as its provider
-            # prefix, leaving openai/gpt-oss-20b:groq as the HF router model id.
-            model="openai/openai/gpt-oss-20b:groq",
+            # prefix, leaving the HF model id on the wire for the router.
+            model="openai/meta-llama/Llama-3.1-8B-Instruct:cerebras",
             api_base="https://router.huggingface.co/v1",
             api_key=api_key,
             messages=[
@@ -195,10 +195,7 @@ async def generate_title(
                 },
                 {"role": "user", "content": request.text[:500]},
             ],
-            # gpt-oss-20b is a reasoning model — without this it burns the
-            # whole max_tokens budget on reasoning and returns empty content.
-            extra_body={"reasoning_effort": "low"},
-            max_tokens=60,
+            max_tokens=20,
             temperature=0.3,
             timeout=10,
         )

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -157,22 +157,38 @@ async def set_model(body: dict, user: dict = Depends(get_current_user)) -> dict:
     return {"model": model_id}
 
 
+_TITLE_STRIP_CHARS = str.maketrans("", "", "`*_~#[]()")
+
+
 @router.post("/title")
 async def generate_title(
     request: SubmitRequest, user: dict = Depends(get_current_user)
 ) -> dict:
-    """Generate a short title for a chat session based on the first user message."""
-    model = session_manager.config.model_name
-    llm_params = _resolve_llm_params(model, reasoning_effort="high")
+    """Generate a short title for a chat session based on the first user message.
+
+    Always uses gpt-oss-20b via Groq on the HF router. The tab headline
+    renders as plain text, so the model is told to avoid markdown and any
+    stray formatting characters are stripped before returning.
+    """
+    api_key = (
+        os.environ.get("INFERENCE_TOKEN")
+        or (user.get("hf_token") if isinstance(user, dict) else None)
+        or os.environ.get("HF_TOKEN")
+    )
     try:
         response = await acompletion(
+            model="openai/gpt-oss-20b:groq",
+            api_base="https://router.huggingface.co/v1",
+            api_key=api_key,
             messages=[
                 {
                     "role": "system",
                     "content": (
                         "Generate a very short title (max 6 words) for a chat conversation "
                         "that starts with the following user message. "
-                        "Reply with ONLY the title, no quotes, no punctuation at the end."
+                        "Reply with ONLY the title in plain text. "
+                        "Do NOT use markdown, backticks, asterisks, quotes, brackets, or any "
+                        "formatting characters. No punctuation at the end."
                     ),
                 },
                 {"role": "user", "content": request.text[:500]},
@@ -180,16 +196,14 @@ async def generate_title(
             max_tokens=20,
             temperature=0.3,
             timeout=8,
-            **llm_params,
         )
         title = response.choices[0].message.content.strip().strip('"').strip("'")
-        # Safety: cap at 50 chars
+        title = title.translate(_TITLE_STRIP_CHARS).strip()
         if len(title) > 50:
             title = title[:50].rstrip() + "…"
         return {"title": title}
     except Exception as e:
         logger.warning(f"Title generation failed: {e}")
-        # Fallback: truncate the message
         fallback = request.text.strip()
         title = fallback[:40].rstrip() + "…" if len(fallback) > 40 else fallback
         return {"title": title}

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -177,7 +177,9 @@ async def generate_title(
     )
     try:
         response = await acompletion(
-            model="openai/gpt-oss-20b:groq",
+            # Double openai/ prefix: LiteLLM strips the first as its provider
+            # prefix, leaving openai/gpt-oss-20b:groq as the HF router model id.
+            model="openai/openai/gpt-oss-20b:groq",
             api_base="https://router.huggingface.co/v1",
             api_key=api_key,
             messages=[
@@ -193,9 +195,12 @@ async def generate_title(
                 },
                 {"role": "user", "content": request.text[:500]},
             ],
-            max_tokens=20,
+            # gpt-oss-20b is a reasoning model — without this it burns the
+            # whole max_tokens budget on reasoning and returns empty content.
+            extra_body={"reasoning_effort": "low"},
+            max_tokens=60,
             temperature=0.3,
-            timeout=8,
+            timeout=10,
         )
         title = response.choices[0].message.content.strip().strip('"').strip("'")
         title = title.translate(_TITLE_STRIP_CHARS).strip()


### PR DESCRIPTION
## Summary
- Tab headline renders the LLM output as plain text, so any markdown in the response shows as literal garbage characters.
- Pins the `/api/title` endpoint to `meta-llama/Llama-3.1-8B-Instruct` on the HF router, pinned to the Cerebras provider. Bypasses `_resolve_llm_params` and calls the router directly.
- Tightens the system prompt to explicitly forbid markdown / formatting characters.
- Adds a server-side strip of `` ` * _ ~ # [ ] ( ) `` on the returned title as a safety net.

## Implementation notes
- Model id on the wire: `openai/meta-llama/Llama-3.1-8B-Instruct:cerebras`. The leading `openai/` is LiteLLM's provider prefix (it strips it and dispatches to the OpenAI-compat adapter); the remainder is the HF model id.
- `max_tokens=20`, `temperature=0.3`, 10s timeout. Fallback path truncates the user message if the router errors.

## Verification
- End-to-end against the HF router with real HF_TOKEN: ~400 ms, clean titles across varied inputs (including inputs containing backticks and `**bold**` markdown — output comes out clean).

## Scope
- Only affects the `/api/title` endpoint. No other code path touched.
- `_resolve_llm_params` is still used by `/api/llm-health` — left alone.

## Test plan
- [ ] Start a new session; verify the tab title renders without any backticks, asterisks, or brackets.
- [ ] Confirm the HF router call succeeds with the deployed inference token wiring.
- [ ] Fallback path still works if the router errors (truncated user message).