### PR TITLE
Make X-HF-Bill-To configurable via HF_BILL_TO env

### DIFF
--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -68,7 +68,8 @@ def _resolve_llm_params(
         "api_key": api_key,
     }
     if os.environ.get("INFERENCE_TOKEN"):
-        params["extra_headers"] = {"X-HF-Bill-To": "huggingface"}
+        bill_to = os.environ.get("HF_BILL_TO", "smolagents")
+        params["extra_headers"] = {"X-HF-Bill-To": bill_to}
     if reasoning_effort:
         hf_level = "low" if reasoning_effort == "minimal" else reasoning_effort
         if hf_level in _HF_ALLOWED_EFFORTS:


### PR DESCRIPTION
## Summary
- `agent/core/llm_params.py` hardcoded `X-HF-Bill-To: huggingface` when `INFERENCE_TOKEN` is set, so any deployment whose `INFERENCE_TOKEN` doesn't have inference-billing rights on the `huggingface` org gets 401 from the router.
- Now reads `HF_BILL_TO` env (default `smolagents`, matching the current Space owner) so each deployment can bill the org its token is authorized for.

## Test plan
- [ ] Unset `HF_BILL_TO` → header falls back to `smolagents`
- [ ] Set `HF_BILL_TO=huggingface` → header sends `huggingface`
- [ ] Leave `INFERENCE_TOKEN` unset → no `X-HF-Bill-To` header at all (unchanged behavior)