### PR TITLE
Title gen: swap Llama-3.1-8B for gpt-oss-120b via Cerebras

### DIFF
--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -166,9 +166,11 @@ async def generate_title(
 ) -> dict:
     """Generate a short title for a chat session based on the first user message.
 
-    Always uses Llama-3.1-8B-Instruct via Cerebras on the HF router. The tab
-    headline renders as plain text, so the model is told to avoid markdown
-    and any stray formatting characters are stripped before returning.
+    Always uses gpt-oss-120b via Cerebras on the HF router. The tab headline
+    renders as plain text, so the model is told to avoid markdown and any
+    stray formatting characters are stripped before returning. gpt-oss is a
+    reasoning model — reasoning_effort=low keeps the reasoning budget small
+    so the 60-token output budget isn't consumed before the title is written.
     """
     api_key = (
         os.environ.get("INFERENCE_TOKEN")
@@ -179,7 +181,7 @@ async def generate_title(
         response = await acompletion(
             # Double openai/ prefix: LiteLLM strips the first as its provider
             # prefix, leaving the HF model id on the wire for the router.
-            model="openai/meta-llama/Llama-3.1-8B-Instruct:cerebras",
+            model="openai/openai/gpt-oss-120b:cerebras",
             api_base="https://router.huggingface.co/v1",
             api_key=api_key,
             messages=[
@@ -195,9 +197,10 @@ async def generate_title(
                 },
                 {"role": "user", "content": request.text[:500]},
             ],
-            max_tokens=20,
+            max_tokens=60,
             temperature=0.3,
             timeout=10,
+            reasoning_effort="low",
         )
         title = response.choices[0].message.content.strip().strip('"').strip("'")
         title = title.translate(_TITLE_STRIP_CHARS).strip()


### PR DESCRIPTION
## Summary
- Swaps the title-generation model from `meta-llama/Llama-3.1-8B-Instruct:cerebras` to `openai/gpt-oss-120b:cerebras` on the HF router.
- gpt-oss is a reasoning model, so re-adds `reasoning_effort="low"` and widens `max_tokens` from 20 → 60 (matching the behavior #53 originally used for gpt-oss-20b before we switched to Llama). Without those, reasoning eats the whole output budget and the title comes back empty.
- Keeps the double `openai/` prefix so LiteLLM strips its provider prefix and the correct HF id reaches the router.

## Test plan
- [ ] Start a new session with a non-trivial first message → tab title renders plain text, no markdown, under 6 words
- [ ] Watch backend logs for `Title generation failed` — should not appear under normal load
- [ ] Latency sanity: Cerebras gpt-oss-120b with reasoning_effort=low should be well under the 10s timeout