### PR TITLE
fix(auth): restrict model-switch endpoints to huggingface org members

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL", "https://huggingface.co")
 AUTH_ENABLED = bool(os.environ.get("OAUTH_CLIENT_ID", ""))
+HF_EMPLOYEE_ORG = os.environ.get("HF_EMPLOYEE_ORG", "huggingface")
 
 # Simple in-memory token cache: token -> (user_info, expiry_time)
 _token_cache: dict[str, tuple[dict[str, Any], float]] = {}
@@ -140,4 +141,47 @@ async def get_current_user(request: Request) -> dict[str, Any]:
         headers={"WWW-Authenticate": "Bearer"},
     )
 
+
+def _extract_token(request: Request) -> str | None:
+    """Pull the HF access token from the Authorization header or cookie.
+
+    Mirrors the lookup order used by ``get_current_user``.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        return auth_header[7:]
+    return request.cookies.get("hf_access_token")
+
+
+async def require_huggingface_member(request: Request) -> dict[str, Any]:
+    """FastAPI dependency: require that the caller belongs to the ``huggingface`` org.
+
+    Used on endpoints that can push a session onto a model billed to the
+    Space's server-side API key (e.g. ``anthropic/claude-opus-4-6`` via
+    ``ANTHROPIC_API_KEY``). Non-HF users keep the default HF Router model,
+    which is billed via ``X-HF-Bill-To``.
+
+    In dev mode (``AUTH_ENABLED=False``), returns the dev user unchanged.
+    """
+    user = await get_current_user(request)
+    if not AUTH_ENABLED:
+        return user
+
+    token = _extract_token(request)
+    if not token:
+        # Defensive: get_current_user would have raised already.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not await check_org_membership(token, HF_EMPLOYEE_ORG):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Switching model requires membership of the '{HF_EMPLOYEE_ORG}' org."
+            ),
+        )
+    return user
 

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -10,7 +10,7 @@ import logging
 import os
 from typing import Any
 
-from dependencies import get_current_user
+from dependencies import get_current_user, require_huggingface_member
 from fastapi import (
     APIRouter,
     Depends,
@@ -144,8 +144,13 @@ async def get_model() -> dict:
 
 
 @router.post("/config/model")
-async def set_model(body: dict, user: dict = Depends(get_current_user)) -> dict:
-    """Set the LLM model. Applies to new conversations."""
+async def set_model(body: dict, user: dict = Depends(require_huggingface_member)) -> dict:
+    """Set the LLM model. Applies to new conversations.
+
+    Restricted to HF org members — switching the default to an Anthropic-billed
+    model would otherwise let any authenticated user drive spend on the Space's
+    ``ANTHROPIC_API_KEY``.
+    """
     model_id = body.get("model")
     if not model_id:
         raise HTTPException(status_code=400, detail="Missing 'model' field")
@@ -302,12 +307,18 @@ async def get_session(
 
 @router.post("/session/{session_id}/model")
 async def set_session_model(
-    session_id: str, body: dict, user: dict = Depends(get_current_user)
+    session_id: str,
+    body: dict,
+    user: dict = Depends(require_huggingface_member),
 ) -> dict:
     """Switch the active model for a single session (tab-scoped).
 
     Takes effect on the next LLM call in that session — other sessions
     (including other browser tabs) are unaffected.
+
+    Restricted to HF org members — this endpoint can push a session onto an
+    Anthropic-billed model (``anthropic/claude-opus-4-6``) that is paid for by
+    the Space's ``ANTHROPIC_API_KEY`` rather than the caller's HF token.
     """
     _check_session_access(session_id, user)
     model_id = body.get("model")


### PR DESCRIPTION
## Summary

`POST /api/config/model` and `POST /api/session/{id}/model` currently accept any authenticated HF user. A non-member of `ml-agent-explorers` (any HF account with a valid OAuth token or PAT) can flip their session onto `anthropic/claude-opus-4-6`, which is billed to the Space's server-side `ANTHROPIC_API_KEY`.

Empirically confirmed today with a test account not in the org — 20 consecutive `/api/chat` calls on Opus went through with zero rate-limiting.

## Change

- Add a `require_huggingface_member` FastAPI dependency in `backend/dependencies.py`. Org name is overridable via `HF_EMPLOYEE_ORG` env var (default: `huggingface`).
- Apply the new dep to the two model-switch endpoints in `backend/routes/agent.py`.
- `check_org_membership` already caches positive results for 5 minutes, so the added round-trip to `/api/whoami-v2` is amortized after the first hit.

## Behavior

| Call | Before | After |
|---|---|---|
| HF staff flips their own session | allowed | allowed |
| Non-member flips their session to Opus | allowed (abuse) | 403 |
| Non-member mutates the global default | allowed (abuse) | 403 |
| Session creation / `/api/chat` / other LLM endpoints | unchanged | unchanged |
