### PR TITLE
fix(backend): make /api/health/llm cheap and cached

### DIFF
--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from typing import Any
 
 from dependencies import get_current_user
@@ -81,26 +82,51 @@ async def health_check() -> HealthResponse:
     )
 
 
+# Cached result of the last LLM health probe, keyed by model name.
+# Every frontend mount fires this endpoint, so without a cache we pay the
+# full probe cost for every page load. 60 s is short enough that a real
+# outage is surfaced within a minute, long enough to collapse concurrent
+# mounts to ~1 probe / model / minute across all users.
+_LLM_HEALTH_CACHE: dict[str, tuple[float, "LLMHealthResponse"]] = {}
+_LLM_HEALTH_CACHE_TTL_SEC = 60
+
+
 @router.get("/health/llm", response_model=LLMHealthResponse)
-async def llm_health_check() -> LLMHealthResponse:
+async def llm_health_check(
+    user: dict = Depends(get_current_user),
+) -> LLMHealthResponse:
     """Check if the LLM provider is reachable and the API key is valid.
 
-    Makes a minimal 1-token completion call.  Catches common errors:
-    - 401 → invalid API key
-    - 402/insufficient_quota → out of credits
-    - 429 → rate limited
-    - timeout / network → provider unreachable
+    The probe is a bare "hi" / max_tokens=1 completion with:
+      * no system prompt
+      * no tools
+      * no reasoning_effort / thinking (previously "high", which triggered
+        adaptive thinking and burned thousands of tokens per probe — root
+        cause of the 2026-04-23 cost incident)
+
+    The routing kwargs (api_base / api_key / Anthropic thinking kwargs) are
+    resolved via ``_resolve_llm_params`` without reasoning_effort, so the
+    probe stays at ~tens of input tokens on every provider we support.
+
+    Results are cached per-model for ``_LLM_HEALTH_CACHE_TTL_SEC`` seconds
+    so concurrent frontend mounts collapse to ~1 real probe / model / TTL.
     """
     model = session_manager.config.model_name
+    now = time.monotonic()
+    cached = _LLM_HEALTH_CACHE.get(model)
+    if cached and now - cached[0] < _LLM_HEALTH_CACHE_TTL_SEC:
+        return cached[1]
+
     try:
-        llm_params = _resolve_llm_params(model, reasoning_effort="high")
+        llm_params = _resolve_llm_params(model)
         await acompletion(
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=1,
+            temperature=0,
             timeout=10,
             **llm_params,
         )
-        return LLMHealthResponse(status="ok", model=model)
+        resp = LLMHealthResponse(status="ok", model=model)
     except Exception as e:
         err_str = str(e).lower()
         error_type = "unknown"
@@ -126,12 +152,15 @@ async def llm_health_check() -> LLMHealthResponse:
             error_type = "network"
 
         logger.warning(f"LLM health check failed ({error_type}): {e}")
-        return LLMHealthResponse(
+        resp = LLMHealthResponse(
             status="error",
             model=model,
             error=str(e)[:500],
             error_type=error_type,
         )
+
+    _LLM_HEALTH_CACHE[model] = (now, resp)
+    return resp
 
 
 @router.get("/config/model")


### PR DESCRIPTION
## Context

Hosted Space is burning ~200M Anthropic input tokens per hour (~\$2k/hour on Opus at list price), even after a WAF rate limit on POST /api/chat dropped abusive traffic to near zero. Token usage stayed flat because the real cost driver is not POST /api/chat but \`GET /api/health/llm\`, which the frontend fires on every mount.

## Root cause

\`backend/routes/agent.py::llm_health_check\` calls \`_resolve_llm_params(model, reasoning_effort="high")\`. On Claude 4.6 / 4.7 that resolves to:

\`\`\`python
{"model": "anthropic/claude-opus-4-6",
 "thinking": {"type": "adaptive"},
 "output_config": {"effort": "high"}}
\`\`\`

Adaptive thinking runs the model through its full reasoning budget before producing the final answer, **regardless of \`max_tokens\`** (max_tokens only caps the final output, not thinking tokens). So a "hi" / max_tokens=1 probe still burns tens of thousands of tokens per call.

Observed on ml-agent-demo API key on 2026-04-23 (UTC):

| Hour | Input tokens | Probe rate | Cost (Opus list) |
|---|---:|---:|---:|
| 05h | 209 M | ~999 mounts/h | ~\$3.1k |

999 probes/hour \* ~200k tokens/probe matches the observed hourly spend.

Compounding factors:
- endpoint has no auth, so crawlers and anonymous page loads trigger it
- endpoint has no server-side throttle, so every mount pays
- the frontend \`useEffect\` fires on every mount, no dedup across tabs

## Fix

Three changes in \`llm_health_check\`:

1. **Drop \`reasoning_effort\`** on the probe. The probe only needs to detect 401/402/429/timeout — it doesn't need thinking. Pass \`temperature=0\` and no system prompt / no tools.
2. **Per-model in-memory cache** with \`TTL=60s\`. Concurrent mounts across all users collapse to at most one real probe per model per minute. 60 s is short enough to surface a real outage within a minute, long enough to make mount-storms free.
3. **Require auth** via \`Depends(get_current_user)\`. Anonymous mounts and crawlers stop triggering LLM calls. No user-facing regression — the UI already requires auth to do anything useful.

Routing kwargs (HF router \`api_base\` / \`api_key\` / Anthropic model id) still come from \`_resolve_llm_params\`, so the probe still targets the correct provider without paying for thinking.

## Impact

Expected cost per probe after fix (Opus):
- 1 cache-hit: \$0
- 1 cache-miss: ~10 input + ~1 output tokens ≈ \$0.0002

At steady state: ~60 real probes/hour globally, \~\$0.01/hour vs \~\$2k/hour today. **6-orders-of-magnitude reduction.**

## Frontend

No change. The existing \`useEffect\` in \`AppLayout.tsx:86-106\` keeps working, error categorization is unchanged, the Snackbar still pops on real errors. Cache-hit responses are returned instantly, so UX improves slightly (no more 200-ms probe latency on every mount).

## Follow-up

- The underlying auth bypass on the Space is still tracked separately (see Remy's report). WAF mitigations stay in place for defence in depth.
- Consider lazy-only health check in the future: trigger the probe only when a real user message fails, not on mount. That would drop probes to ~0 in the normal case.