### PR TITLE
feat: add notifications when intern needs user input

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -18,6 +18,37 @@ from pydantic import BaseModel
 MCPServerConfig = Union[StdioMCPServer, RemoteMCPServer]
 
 
+class NotificationProvider(BaseModel):
+    """Configuration for a notification provider."""
+
+    provider: str  # "email", "pushbullet", "telegram", "slack", "discord", "system"
+    enabled: bool = True
+    events: list[str] = [
+        "approval_required",
+        "waiting",
+        "job_complete",
+        "job_failed",
+        "error",
+        "session_saved",
+    ]
+    # Email config
+    email_to: str | None = None
+    email_from: str | None = None
+    smtp_host: str | None = None
+    smtp_port: int | None = None
+    smtp_user: str | None = None
+    smtp_password: str | None = None
+    # Pushbullet config
+    pushbullet_api_key: str | None = None
+    # Telegram config
+    telegram_bot_token: str | None = None
+    telegram_chat_id: str | None = None
+    # Slack config
+    slack_webhook_url: str | None = None
+    # Discord config
+    discord_webhook_url: str | None = None
+
+
 class Config(BaseModel):
     """Configuration manager"""
 
@@ -42,6 +73,9 @@ class Config(BaseModel):
     # ``xhigh`` or ``max`` for Anthropic 4.6 / 4.7). ``None`` = thinking off.
     # Valid values: None | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
     reasoning_effort: str | None = "max"
+
+    # Notification settings
+    notifications: list[NotificationProvider] = []
 
 
 def substitute_env_vars(obj: Any) -> Any:

--- a/agent/config.py
+++ b/agent/config.py
@@ -12,7 +12,7 @@ from fastmcp.mcp_config import (
     RemoteMCPServer,
     StdioMCPServer,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 # These two are the canonical server config types for MCP servers.
 MCPServerConfig = Union[StdioMCPServer, RemoteMCPServer]
@@ -37,11 +37,11 @@ class NotificationProvider(BaseModel):
     smtp_host: str | None = None
     smtp_port: int | None = None
     smtp_user: str | None = None
-    smtp_password: str | None = None
+    smtp_password: SecretStr | None = None
     # Pushbullet config
-    pushbullet_api_key: str | None = None
+    pushbullet_api_key: SecretStr | None = None
     # Telegram config
-    telegram_bot_token: str | None = None
+    telegram_bot_token: SecretStr | None = None
     telegram_chat_id: str | None = None
     # Slack config
     slack_webhook_url: str | None = None

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -17,6 +17,7 @@ from agent.core.llm_params import _resolve_llm_params
 from agent.core.session import Event, OpType, Session
 from agent.core.tools import ToolRouter
 from agent.tools.jobs_tool import CPU_FLAVORS
+from agent.utils.notification_service import NotificationService
 
 logger = logging.getLogger(__name__)
 
@@ -844,6 +845,14 @@ class Handlers:
                         data={"tools": tools_data, "count": len(tools_data)},
                     ))
 
+                    # Send notification for approval required
+                    if session.notification_service:
+                        await session.notification_service.notify_approval_required(
+                            tools=tools_data,
+                            count=len(tools_data),
+                            session_id=session.session_id,
+                        )
+
                     # Store all approval-requiring tools (ToolCall objects for execution)
                     session.pending_approval = {
                         "tool_calls": [tc for tc, _, _ in approval_required_tools],
@@ -879,6 +888,8 @@ class Handlers:
                         data={"error": error_msg},
                     )
                 )
+                if session.notification_service:
+                    await session.notification_service.notify_error(error_msg, session.session_id)
                 errored = True
                 break
 
@@ -1207,10 +1218,20 @@ async def submission_loop(
     This is the core of the agent (like submission_loop in codex.rs:1259-1340)
     """
 
+    # Initialize notification service from config
+    notification_service = None
+    if config and config.notifications:
+        try:
+            notification_service = NotificationService(
+                [p.model_dump() for p in config.notifications]
+            )
+        except Exception as e:
+            logger.warning(f"Failed to initialize notification service: {e}")
+
     # Create session with tool router
     session = Session(
         event_queue, config=config, tool_router=tool_router, hf_token=hf_token,
-        local_mode=local_mode, stream=stream,
+        local_mode=local_mode, stream=stream, notification_service=notification_service,
     )
     if session_holder is not None:
         session_holder[0] = session

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -79,6 +79,7 @@ class Session:
         hf_token: str | None = None,
         local_mode: bool = False,
         stream: bool = True,
+        notification_service=None,
     ):
         self.hf_token: Optional[str] = hf_token
         self.tool_router = tool_router
@@ -102,6 +103,7 @@ class Session:
         self.pending_approval: Optional[dict[str, Any]] = None
         self.sandbox = None
         self._running_job_ids: set[str] = set()  # HF job IDs currently executing
+        self.notification_service = notification_service
 
         # Session trajectory logging
         self.logged_events: list[dict] = []
@@ -148,6 +150,21 @@ class Session:
         """Switch the active model and update the context window limit."""
         self.config.model_name = model_name
         self.context_manager.model_max_tokens = _get_max_tokens_safe(model_name)
+
+    async def notify_job_complete(self, job_id: str, status: str) -> None:
+        """Send notification when a job completes."""
+        if self.notification_service:
+            await self.notification_service.notify_job_complete(job_id, status, self.session_id)
+
+    async def notify_job_failed(self, job_id: str, error: str) -> None:
+        """Send notification when a job fails."""
+        if self.notification_service:
+            await self.notification_service.notify_job_failed(job_id, error, self.session_id)
+
+    async def notify_session_saved(self, repo_id: str | None = None) -> None:
+        """Send notification when session trajectory is saved."""
+        if self.notification_service:
+            await self.notification_service.notify_session_saved(self.session_id, repo_id)
 
     def effective_effort_for(self, model_name: str) -> str | None:
         """Resolve the effort level to actually send for ``model_name``.
@@ -279,6 +296,10 @@ class Session:
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,  # Detach from parent
             )
+
+            # Notify session saved
+            if self.notification_service:
+                asyncio.create_task(self.notify_session_saved(repo_id))
         except Exception as e:
             logger.warning(f"Failed to spawn upload subprocess: {e}")
 

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -299,7 +299,11 @@ class Session:
 
             # Notify session saved
             if self.notification_service:
-                asyncio.create_task(self.notify_session_saved(repo_id))
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(self.notify_session_saved(repo_id))
+                except RuntimeError:
+                    pass  # no running loop — skip notification
         except Exception as e:
             logger.warning(f"Failed to spawn upload subprocess: {e}")
 

--- a/agent/tools/jobs_tool.py
+++ b/agent/tools/jobs_tool.py
@@ -584,6 +584,13 @@ class HfJobsTool:
                     )
                 )
 
+            # Send notification for job completion/failure
+            if self.session:
+                if final_status == "COMPLETED":
+                    await self.session.notify_job_complete(job.id, final_status)
+                else:
+                    await self.session.notify_job_failed(job.id, final_status)
+
             # Filter out UV package installation output
             filtered_logs = _filter_uv_install_output(all_logs)
 

--- a/agent/utils/notification_service.py
+++ b/agent/utils/notification_service.py
@@ -1,0 +1,430 @@
+"""
+Notification service for ML Intern.
+
+Provides pluggable notification providers:
+- email: SMTP email notifications
+- pushbullet: Pushbullet mobile notifications
+- telegram: Telegram bot notifications
+- slack: Slack webhook notifications
+- discord: Discord webhook notifications
+- system: System notifications (platform-specific)
+"""
+
+import asyncio
+import logging
+import platform
+import smtplib
+from abc import ABC, abstractmethod
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationProviderBase(ABC):
+    """Base class for notification providers."""
+
+    def __init__(self, config: dict[str, Any]):
+        self.config = config
+        self.events = config.get("events", [
+            "approval_required",
+            "waiting",
+            "job_complete",
+            "job_failed",
+            "error",
+            "session_saved",
+        ])
+
+    def should_notify(self, event_type: str) -> bool:
+        """Check if this provider should send for the given event type."""
+        return event_type in self.events
+
+    @abstractmethod
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        """Send a notification. Returns True on success."""
+        pass
+
+
+class EmailProvider(NotificationProviderBase):
+    """SMTP email notification provider."""
+
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        try:
+            smtp_host = self.config.get("smtp_host")
+            smtp_port = self.config.get("smtp_port", 587)
+            smtp_user = self.config.get("smtp_user")
+            smtp_password = self.config.get("smtp_password")
+            email_to = self.config.get("email_to")
+            email_from = self.config.get("email_from", smtp_user)
+
+            if not all([smtp_host, smtp_user, smtp_password, email_to]):
+                logger.warning("Email provider: incomplete config, skipping notification")
+                return False
+
+            msg = MIMEMultipart("alternative")
+            msg["Subject"] = f"[ML Intern] {title}"
+            msg["From"] = email_from
+            msg["To"] = email_to
+
+            text_body = f"{message}\n\nEvent: {event_type}"
+            if metadata:
+                text_body += f"\nMetadata: {metadata}"
+            msg.attach(MIMEText(text_body, "plain"))
+
+            def _send():
+                with smtplib.SMTP(smtp_host, smtp_port, timeout=30) as server:
+                    server.starttls()
+                    server.login(smtp_user, smtp_password)
+                    server.send_message(msg)
+
+            await asyncio.to_thread(_send)
+            logger.info("Email notification sent successfully")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to send email notification: {e}")
+            return False
+
+
+class PushbulletProvider(NotificationProviderBase):
+    """Pushbullet mobile notification provider."""
+
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        try:
+            api_key = self.config.get("pushbullet_api_key")
+            if not api_key:
+                logger.warning("Pushbullet provider: no API key configured")
+                return False
+
+            import aiohttp
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    "https://api.pushbullet.com/v2/pushes",
+                    headers={"Access-Token": api_key},
+                    json={
+                        "type": "note",
+                        "title": f"[ML Intern] {title}",
+                        "body": message,
+                    },
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status == 200:
+                        logger.info("Pushbullet notification sent successfully")
+                        return True
+                    else:
+                        logger.error(f"Pushbullet API error: {resp.status}")
+                        return False
+        except Exception as e:
+            logger.error(f"Failed to send Pushbullet notification: {e}")
+            return False
+
+
+class TelegramProvider(NotificationProviderBase):
+    """Telegram bot notification provider."""
+
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        try:
+            bot_token = self.config.get("telegram_bot_token")
+            chat_id = self.config.get("telegram_chat_id")
+
+            if not all([bot_token, chat_id]):
+                logger.warning("Telegram provider: incomplete config")
+                return False
+
+            import aiohttp
+
+            text = f"*[ML Intern] {title}*\n\n{message}"
+            if metadata:
+                text += f"\n\nMetadata: {metadata}"
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"https://api.telegram.org/bot{bot_token}/sendMessage",
+                    json={
+                        "chat_id": chat_id,
+                        "text": text,
+                        "parse_mode": "Markdown",
+                    },
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status == 200:
+                        logger.info("Telegram notification sent successfully")
+                        return True
+                    else:
+                        logger.error(f"Telegram API error: {resp.status}")
+                        return False
+        except Exception as e:
+            logger.error(f"Failed to send Telegram notification: {e}")
+            return False
+
+
+class SlackProvider(NotificationProviderBase):
+    """Slack webhook notification provider."""
+
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        try:
+            webhook_url = self.config.get("slack_webhook_url")
+            if not webhook_url:
+                logger.warning("Slack provider: no webhook URL configured")
+                return False
+
+            import aiohttp
+
+            text = f"*[ML Intern] {title}*\n>{message}"
+            if metadata:
+                text += f"\n```json\n{metadata}\n```"
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    webhook_url,
+                    json={"text": text},
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status == 200:
+                        logger.info("Slack notification sent successfully")
+                        return True
+                    else:
+                        logger.error(f"Slack webhook error: {resp.status}")
+                        return False
+        except Exception as e:
+            logger.error(f"Failed to send Slack notification: {e}")
+            return False
+
+
+class DiscordProvider(NotificationProviderBase):
+    """Discord webhook notification provider."""
+
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        try:
+            webhook_url = self.config.get("discord_webhook_url")
+            if not webhook_url:
+                logger.warning("Discord provider: no webhook URL configured")
+                return False
+
+            import aiohttp
+
+            embed = {
+                "title": f"[ML Intern] {title}",
+                "description": message,
+                "color": 0x6366F1,  # Indigo color
+            }
+            if metadata:
+                embed["fields"] = [
+                    {"name": key, "value": str(value), "inline": True}
+                    for key, value in metadata.items()
+                ]
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    webhook_url,
+                    json={"embeds": [embed]},
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status == 200 or resp.status == 204:
+                        logger.info("Discord notification sent successfully")
+                        return True
+                    else:
+                        logger.error(f"Discord webhook error: {resp.status}")
+                        return False
+        except Exception as e:
+            logger.error(f"Failed to send Discord notification: {e}")
+            return False
+
+
+class SystemProvider(NotificationProviderBase):
+    """Platform-specific system notification provider."""
+
+    async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
+        try:
+            system = platform.system()
+
+            if system == "Darwin":  # macOS
+                import subprocess
+
+                script = f'display notification "{message}" with title "[ML Intern] {title}"'
+                await asyncio.to_thread(
+                    subprocess.run, ["osascript", "-e", script], check=False, capture_output=True
+                )
+                return True
+
+            elif system == "Windows":
+                # Use PowerShell for Windows notifications
+                import subprocess
+
+                await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        "powershell",
+                        "-Command",
+                        f'[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null; '
+                        f'$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); '
+                        f'$template.GetElementsByTagName("text")[0].AppendChild($template.CreateTextNode("[ML Intern] {title}")) | Out-Null; '
+                        f'$template.GetElementsByTagName("text")[1].AppendChild($template.CreateTextNode("{message}")) | Out-Null; '
+                        f'$toast = [Windows.UI.Notifications.ToastNotification]::new($template); '
+                        f'[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("ML Intern").Show($toast)',
+                    ],
+                    check=False,
+                    capture_output=True,
+                )
+                return True
+
+            elif system == "Linux":
+                # Try notify-send (most Linux distros)
+                import subprocess
+
+                await asyncio.to_thread(
+                    subprocess.run,
+                    ["notify-send", f"[ML Intern] {title}", message],
+                    check=False,
+                    capture_output=True,
+                )
+                return True
+
+            else:
+                logger.warning(f"System notifications not supported on {system}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Failed to send system notification: {e}")
+            return False
+
+
+_PROVIDER_CLASSES: dict[str, type[NotificationProviderBase]] = {
+    "email": EmailProvider,
+    "pushbullet": PushbulletProvider,
+    "telegram": TelegramProvider,
+    "slack": SlackProvider,
+    "discord": DiscordProvider,
+    "system": SystemProvider,
+}
+
+
+class NotificationService:
+    """
+    Central notification service that manages multiple providers.
+
+    Usage:
+        service = NotificationService(config.notifications)
+        await service.notify("approval_required", "Approval Needed", "ML Intern wants to run a job", {...})
+    """
+
+    def __init__(self, provider_configs: list[dict]):
+        self.providers: list[NotificationProviderBase] = []
+        for cfg in provider_configs:
+            provider_type = cfg.get("provider", "").lower()
+            enabled = cfg.get("enabled", True)
+            if not enabled:
+                continue
+            provider_cls = _PROVIDER_CLASSES.get(provider_type)
+            if provider_cls:
+                self.providers.append(provider_cls(cfg))
+                logger.info(f"Notification provider initialized: {provider_type}")
+            else:
+                logger.warning(f"Unknown notification provider: {provider_type}")
+
+    async def _safe_send_provider(self, coro):
+        """Execute provider coroutine, logging any errors."""
+        try:
+            await coro
+        except Exception as e:
+            logger.error(f"Notification provider error: {e}")
+
+    async def notify(
+        self,
+        event_type: str,
+        title: str,
+        message: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Send notification to all providers that want this event type.
+        Non-blocking - fire and forget.
+        """
+        if not self.providers:
+            return
+
+        # Fire all providers concurrently, don't block
+        for provider in self.providers:
+            if provider.should_notify(event_type):
+                asyncio.create_task(self._safe_send_provider(
+                    provider.send(event_type, title, message, metadata)
+                ))
+
+    async def notify_approval_required(
+        self,
+        tools: list[dict],
+        count: int,
+        session_id: str | None = None,
+    ) -> None:
+        """Notify that ML Intern needs approval for tool execution."""
+        tool_names = [t.get("tool", "unknown") for t in tools]
+        await self.notify(
+            "approval_required",
+            "Approval Required",
+            f"ML Intern needs your approval to: {', '.join(tool_names)}",
+            {"count": count, "tools": tool_names, "session_id": session_id},
+        )
+
+    async def notify_waiting(self, message: str, session_id: str | None = None) -> None:
+        """Notify that ML Intern is waiting for user input."""
+        await self.notify(
+            "waiting",
+            "Waiting for Input",
+            message,
+            {"session_id": session_id},
+        )
+
+    async def notify_job_complete(
+        self,
+        job_id: str,
+        status: str,
+        session_id: str | None = None,
+    ) -> None:
+        """Notify that a HuggingFace job has completed."""
+        await self.notify(
+            "job_complete",
+            "Job Complete",
+            f"Job {job_id} finished with status: {status}",
+            {"job_id": job_id, "status": status, "session_id": session_id},
+        )
+
+    async def notify_job_failed(
+        self,
+        job_id: str,
+        error: str,
+        session_id: str | None = None,
+    ) -> None:
+        """Notify that a HuggingFace job has failed."""
+        await self.notify(
+            "job_failed",
+            "Job Failed",
+            f"Job {job_id} failed: {error}",
+            {"job_id": job_id, "error": error, "session_id": session_id},
+        )
+
+    async def notify_error(
+        self,
+        error: str,
+        session_id: str | None = None,
+    ) -> None:
+        """Notify that an error occurred."""
+        await self.notify(
+            "error",
+            "Error Occurred",
+            f"ML Intern encountered an error: {error}",
+            {"error": error, "session_id": session_id},
+        )
+
+    async def notify_session_saved(
+        self,
+        session_id: str,
+        repo_id: str | None = None,
+    ) -> None:
+        """Notify that session trajectory was saved."""
+        await self.notify(
+            "session_saved",
+            "Session Saved",
+            f"Session {session_id} trajectory saved",
+            {"session_id": session_id, "repo_id": repo_id},
+        )

--- a/agent/utils/notification_service.py
+++ b/agent/utils/notification_service.py
@@ -11,6 +11,7 @@ Provides pluggable notification providers:
 """
 
 import asyncio
+import httpx
 import logging
 import platform
 import smtplib
@@ -58,6 +59,10 @@ class EmailProvider(NotificationProviderBase):
             email_to = self.config.get("email_to")
             email_from = self.config.get("email_from", smtp_user)
 
+            # Unwrap SecretStr if needed
+            if hasattr(smtp_password, "get_secret_value"):
+                smtp_password = smtp_password.get_secret_value()
+
             if not all([smtp_host, smtp_user, smtp_password, email_to]):
                 logger.warning("Email provider: incomplete config, skipping notification")
                 return False
@@ -92,14 +97,16 @@ class PushbulletProvider(NotificationProviderBase):
     async def send(self, event_type: str, title: str, message: str, metadata: dict[str, Any] | None = None) -> bool:
         try:
             api_key = self.config.get("pushbullet_api_key")
-            if not api_key:
+            if api_key is None:
                 logger.warning("Pushbullet provider: no API key configured")
                 return False
 
-            import aiohttp
+            # Unwrap SecretStr if needed
+            if hasattr(api_key, "get_secret_value"):
+                api_key = api_key.get_secret_value()
 
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
                     "https://api.pushbullet.com/v2/pushes",
                     headers={"Access-Token": api_key},
                     json={
@@ -107,14 +114,13 @@ class PushbulletProvider(NotificationProviderBase):
                         "title": f"[ML Intern] {title}",
                         "body": message,
                     },
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    if resp.status == 200:
-                        logger.info("Pushbullet notification sent successfully")
-                        return True
-                    else:
-                        logger.error(f"Pushbullet API error: {resp.status}")
-                        return False
+                )
+                if resp.status_code == 200:
+                    logger.info("Pushbullet notification sent successfully")
+                    return True
+                else:
+                    logger.error(f"Pushbullet API error: {resp.status_code}")
+                    return False
         except Exception as e:
             logger.error(f"Failed to send Pushbullet notification: {e}")
             return False
@@ -132,28 +138,29 @@ class TelegramProvider(NotificationProviderBase):
                 logger.warning("Telegram provider: incomplete config")
                 return False
 
-            import aiohttp
+            # Unwrap SecretStr if needed
+            if hasattr(bot_token, "get_secret_value"):
+                bot_token = bot_token.get_secret_value()
 
             text = f"*[ML Intern] {title}*\n\n{message}"
             if metadata:
                 text += f"\n\nMetadata: {metadata}"
 
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
                     f"https://api.telegram.org/bot{bot_token}/sendMessage",
                     json={
                         "chat_id": chat_id,
                         "text": text,
                         "parse_mode": "Markdown",
                     },
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    if resp.status == 200:
-                        logger.info("Telegram notification sent successfully")
-                        return True
-                    else:
-                        logger.error(f"Telegram API error: {resp.status}")
-                        return False
+                )
+                if resp.status_code == 200:
+                    logger.info("Telegram notification sent successfully")
+                    return True
+                else:
+                    logger.error(f"Telegram API error: {resp.status_code}")
+                    return False
         except Exception as e:
             logger.error(f"Failed to send Telegram notification: {e}")
             return False
@@ -169,24 +176,21 @@ class SlackProvider(NotificationProviderBase):
                 logger.warning("Slack provider: no webhook URL configured")
                 return False
 
-            import aiohttp
-
             text = f"*[ML Intern] {title}*\n>{message}"
             if metadata:
                 text += f"\n```json\n{metadata}\n```"
 
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
                     webhook_url,
                     json={"text": text},
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    if resp.status == 200:
-                        logger.info("Slack notification sent successfully")
-                        return True
-                    else:
-                        logger.error(f"Slack webhook error: {resp.status}")
-                        return False
+                )
+                if resp.status_code == 200:
+                    logger.info("Slack notification sent successfully")
+                    return True
+                else:
+                    logger.error(f"Slack webhook error: {resp.status_code}")
+                    return False
         except Exception as e:
             logger.error(f"Failed to send Slack notification: {e}")
             return False
@@ -202,8 +206,6 @@ class DiscordProvider(NotificationProviderBase):
                 logger.warning("Discord provider: no webhook URL configured")
                 return False
 
-            import aiohttp
-
             embed = {
                 "title": f"[ML Intern] {title}",
                 "description": message,
@@ -215,18 +217,17 @@ class DiscordProvider(NotificationProviderBase):
                     for key, value in metadata.items()
                 ]
 
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
                     webhook_url,
                     json={"embeds": [embed]},
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    if resp.status == 200 or resp.status == 204:
-                        logger.info("Discord notification sent successfully")
-                        return True
-                    else:
-                        logger.error(f"Discord webhook error: {resp.status}")
-                        return False
+                )
+                if resp.status_code == 200 or resp.status_code == 204:
+                    logger.info("Discord notification sent successfully")
+                    return True
+                else:
+                    logger.error(f"Discord webhook error: {resp.status_code}")
+                    return False
         except Exception as e:
             logger.error(f"Failed to send Discord notification: {e}")
             return False
@@ -242,7 +243,10 @@ class SystemProvider(NotificationProviderBase):
             if system == "Darwin":  # macOS
                 import subprocess
 
-                script = f'display notification "{message}" with title "[ML Intern] {title}"'
+                # Escape special characters to prevent command injection
+                safe_msg = message.replace("\\", "\\\\").replace('"', '\\"')
+                safe_title = title.replace("\\", "\\\\").replace('"', '\\"')
+                script = f'display notification "{safe_msg}" with title "[ML Intern] {safe_title}"'
                 await asyncio.to_thread(
                     subprocess.run, ["osascript", "-e", script], check=False, capture_output=True
                 )
@@ -252,6 +256,9 @@ class SystemProvider(NotificationProviderBase):
                 # Use PowerShell for Windows notifications
                 import subprocess
 
+                # Escape double-quotes to prevent PowerShell injection
+                safe_title = title.replace('"', '`"').replace("'", "''")
+                safe_msg = message.replace('"', '`"').replace("'", "''")
                 await asyncio.to_thread(
                     subprocess.run,
                     [
@@ -259,8 +266,8 @@ class SystemProvider(NotificationProviderBase):
                         "-Command",
                         f'[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null; '
                         f'$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); '
-                        f'$template.GetElementsByTagName("text")[0].AppendChild($template.CreateTextNode("[ML Intern] {title}")) | Out-Null; '
-                        f'$template.GetElementsByTagName("text")[1].AppendChild($template.CreateTextNode("{message}")) | Out-Null; '
+                        f'$template.GetElementsByTagName("text")[0].AppendChild($template.CreateTextNode("[ML Intern] {safe_title}")) | Out-Null; '
+                        f'$template.GetElementsByTagName("text")[1].AppendChild($template.CreateTextNode("{safe_msg}")) | Out-Null; '
                         f'$toast = [Windows.UI.Notifications.ToastNotification]::new($template); '
                         f'[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("ML Intern").Show($toast)',
                     ],

--- a/configs/main_agent_config.example.json
+++ b/configs/main_agent_config.example.json
@@ -1,0 +1,56 @@
+{
+  "model_name": "anthropic/claude-opus-4-6",
+  "save_sessions": true,
+  "session_dataset_repo": "akseljoonas/hf-agent-sessions",
+  "yolo_mode": false,
+  "confirm_cpu_jobs": true,
+  "auto_file_upload": true,
+  "mcpServers": {
+    "hf-mcp-server": {
+      "transport": "http",
+      "url": "https://huggingface.co/mcp?login"
+    }
+  },
+  "notifications": [
+    {
+      "provider": "email",
+      "enabled": true,
+      "events": ["approval_required", "job_complete", "job_failed", "error"],
+      "email_to": "your@email.com",
+      "smtp_host": "smtp.gmail.com",
+      "smtp_port": 587,
+      "smtp_user": "your@email.com",
+      "smtp_password": "${SMTP_PASSWORD}"
+    },
+    {
+      "provider": "pushbullet",
+      "enabled": false,
+      "events": ["approval_required", "job_complete", "error"],
+      "pushbullet_api_key": "${PUSHBULLET_API_KEY}"
+    },
+    {
+      "provider": "telegram",
+      "enabled": false,
+      "events": ["approval_required", "job_complete", "error"],
+      "telegram_bot_token": "${TELEGRAM_BOT_TOKEN}",
+      "telegram_chat_id": "${TELEGRAM_CHAT_ID}"
+    },
+    {
+      "provider": "slack",
+      "enabled": false,
+      "events": ["approval_required", "job_complete", "error"],
+      "slack_webhook_url": "${SLACK_WEBHOOK_URL}"
+    },
+    {
+      "provider": "discord",
+      "enabled": false,
+      "events": ["approval_required", "job_complete", "error"],
+      "discord_webhook_url": "${DISCORD_WEBHOOK_URL}"
+    },
+    {
+      "provider": "system",
+      "enabled": false,
+      "events": ["approval_required", "job_complete", "job_failed", "error"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `NotificationProvider` config supporting email, pushbullet, telegram, slack, discord, and system notifications
- Add `NotificationService` for async non-blocking notifications
- Send notifications on: `approval_required`, `job_complete`, `job_failed`, `error`, `session_saved`

## Changes

| File | Change |
|------|--------|
| `agent/config.py` | Added `NotificationProvider` model |
| `agent/utils/notification_service.py` | New file with 6 notification providers |
| `agent/core/session.py` | Added `notification_service` param and `notify_*` methods |
| `agent/core/agent_loop.py` | Initialize NotificationService, emit on approval/error |
| `agent/tools/jobs_tool.py` | Call `notify_job_complete/failed` after job finishes |
| `configs/main_agent_config.example.json` | Example notification config |

## Test plan

- [x] All 6 modified files compile without errors
- [x] AST syntax tests pass (16/16)
- [x] NotificationService tested directly - empty config, providers, all notify methods work
- [ ] Tested locally with actual notification providers (need credentials)

Closes #65