### PR TITLE
feat: open links in new tab

### DIFF
--- a/frontend/src/components/Chat/MarkdownContent.tsx
+++ b/frontend/src/components/Chat/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect, type ComponentPropsWithoutRef } from 'react';
 import { Box } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -166,9 +166,17 @@ export default function MarkdownContent({ content, sx, isStreaming = false }: Ma
 
   const remarkPlugins = useMemo(() => [remarkGfm], []);
 
+  const components = useMemo(() => ({
+    a: ({ href, children, ...props }: ComponentPropsWithoutRef<'a'>) => (
+      <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+        {children}
+      </a>
+    ),
+  }), []);
+
   return (
     <Box sx={[markdownSx, ...(Array.isArray(sx) ? sx : sx ? [sx] : [])]}>
-      <ReactMarkdown remarkPlugins={remarkPlugins}>{displayContent}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={remarkPlugins} components={components}>{displayContent}</ReactMarkdown>
     </Box>
   );
 }


### PR DESCRIPTION
Closes https://github.com/huggingface/ml-intern/issues/64

Links rendered via `ReactMarkdown` inside chat messages were opening in the same tab, disrupting the user’s session and navigation flow.

#### **Solution**

* Added a custom `a` component renderer in `MarkdownContent.tsx`
* Ensured all markdown links include:

  * `target="_blank"`
  * `rel="noopener noreferrer"`

#### **Impact**

* Prevents chat session disruption when users click on links
* Improves overall UX consistency across the application

#### **Additional Context**

Other link surfaces -- `ClaudeCapDialog`, `WelcomeScreen`, and `ToolCallGroup`  already had `target="_blank"` configured correctly.
This change ensures consistent behavior across all markdown-rendered content, including agent-generated messages.

#### **Testing**

* Verified that all links rendered via markdown now open in a new tab
* Confirmed no regression in existing link behaviors across other components