### PR TITLE
feat: support Azure OpenAI via azure/ prefix

### DIFF
--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -106,8 +106,8 @@ def _resolve_llm_params(
       will reject this; the probe's cascade catches that and falls back
       to no thinking.
 
-    • ``openai/<model>`` — ``reasoning_effort`` forwarded as a top-level
-      kwarg (GPT-5 / o-series). LiteLLM uses the user's ``OPENAI_API_KEY``.
+    • ``openai/<model>`` or ``azure/<model>`` — ``reasoning_effort`` forwarded
+      as a top-level kwarg. LiteLLM uses the user's API key or Azure credentials.
 
     • Anything else is treated as a HuggingFace router id. We hit the
       auto-routing OpenAI-compatible endpoint at
@@ -162,13 +162,14 @@ def _resolve_llm_params(
         # the same way, so we leave it off for now.
         return {"model": model_name}
 
-    if model_name.startswith("openai/"):
+    if model_name.startswith(("openai/", "azure/")):
         params = {"model": model_name}
         if reasoning_effort:
             if reasoning_effort not in _OPENAI_EFFORTS:
                 if strict:
+                    provider = "Azure" if model_name.startswith("azure/") else "OpenAI"
                     raise UnsupportedEffortError(
-                        f"OpenAI doesn't accept effort={reasoning_effort!r}"
+                        f"{provider} doesn't accept effort={reasoning_effort!r}"
                     )
             else:
                 params["reasoning_effort"] = reasoning_effort

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -44,6 +44,7 @@ def is_valid_model_id(model_id: str) -> bool:
     Accepts:
       • anthropic/<model>
       • openai/<model>
+      • azure/<model>
       • <org>/<model>[:<tag>]            (HF router; tag = provider or policy)
       • huggingface/<org>/<model>[:<tag>] (same, accepts legacy prefix)
 
@@ -63,10 +64,10 @@ def _print_hf_routing_info(model_id: str, console) -> bool:
     proceed with the switch, ``False`` to indicate a hard problem the user
     should notice before we fire the effort probe.
 
-    Anthropic / OpenAI ids return ``True`` without printing anything —
+    Anthropic / OpenAI / Azure ids return ``True`` without printing anything —
     the probe below covers "does this model exist".
     """
-    if model_id.startswith(("anthropic/", "openai/")):
+    if model_id.startswith(("anthropic/", "openai/", "azure/")):
         return True
 
     from agent.core import hf_router_catalog as cat
@@ -139,7 +140,7 @@ def print_model_listing(config, console) -> None:
     console.print(
         "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M2.7').\n"
         "Add ':fastest', ':cheapest', ':preferred', or ':<provider>' to override routing.\n"
-        "Use 'anthropic/<model>' or 'openai/<model>' for direct API access.[/dim]"
+        "Use 'anthropic/<model>', 'openai/<model>', or 'azure/<model>' for direct API access.[/dim]"
     )
 
 
@@ -149,7 +150,8 @@ def print_invalid_id(arg: str, console) -> None:
         "[dim]Expected:\n"
         "  • <org>/<model>[:tag]    (HF router — paste from huggingface.co)\n"
         "  • anthropic/<model>\n"
-        "  • openai/<model>[/dim]"
+        "  • openai/<model>\n"
+        "  • azure/<model>[/dim]"
     )
 
 

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -68,6 +68,13 @@ def _print_hf_routing_info(model_id: str, console) -> bool:
     the probe below covers "does this model exist".
     """
     if model_id.startswith(("anthropic/", "openai/", "azure/")):
+        import os
+        if model_id.startswith("azure/") and not os.environ.get("AZURE_API_BASE"):
+            console.print(
+                "[bold yellow]Warning:[/bold yellow] AZURE_API_BASE is not set. "
+                "Ensure AZURE_API_BASE, AZURE_API_KEY (or AZURE_AD_TOKEN), and "
+                "AZURE_API_VERSION are in your environment."
+            )
         return True
 
     from agent.core import hf_router_catalog as cat


### PR DESCRIPTION
**Summary**: Adds support for Azure OpenAI models (including OAuth/Entra ID) by recognizing the `azure/` model prefix.

**The Fix**:
- **Routing**: Added `azure/` as a recognized direct API prefix in `llm_params.py` and `model_switcher.py`. This stops the agent from incorrectly treating Azure models as Hugging Face router models.
- **Auth**: This change allows `litellm` to natively handle Azure credentials (like `AZURE_AD_TOKEN` or `DefaultAzureCredential`).
- **UX**: Updated CLI help text and docstrings to include `azure/<model>` as a supported format.

**Verification**: Verified locally that `ml-intern --model azure/gpt-4o` now bypasses the HF router check and correctly attempts to initialize the Azure client.

Fixes #59 