### PR TITLE
feat: route Claude via Bedrock inference profile

### DIFF
--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -24,8 +24,8 @@ from agent.core.effort_probe import ProbeInconclusive, probe_effort
 # ":cheapest" / ":preferred" / ":<provider>" to override the default
 # routing policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
-    {"id": "anthropic/claude-opus-4-7", "label": "Claude Opus 4.7"},
-    {"id": "anthropic/claude-opus-4-6", "label": "Claude Opus 4.6"},
+    {"id": "bedrock/us.anthropic.claude-opus-4-7", "label": "Claude Opus 4.7"},
+    {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6"},
     {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": "moonshotai/Kimi-K2.6", "label": "Kimi K2.6"},
     {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},

--- a/agent/core/prompt_caching.py
+++ b/agent/core/prompt_caching.py
@@ -28,7 +28,7 @@ def with_prompt_caching(
     that share the underlying ``ContextManager.items`` list don't see their
     persisted history rewritten.
     """
-    if not model_name or not model_name.startswith("anthropic/"):
+    if not model_name or "anthropic" not in model_name:
         return messages, tools
 
     if tools:

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -95,7 +95,7 @@ class Session:
         self.event_queue = event_queue
         self.session_id = str(uuid.uuid4())
         self.config = config or Config(
-            model_name="anthropic/claude-sonnet-4-5-20250929",
+            model_name="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         )
         self.is_running = True
         self._cancelled = asyncio.Event()

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -216,8 +216,8 @@ RESEARCH_TOOL_SPEC = {
 
 def _get_research_model(main_model: str) -> str:
     """Pick a cheaper model for research based on the main model."""
-    if "anthropic/" in main_model:
-        return "anthropic/claude-sonnet-4-6"
+    if "anthropic" in main_model:
+        return "bedrock/us.anthropic.claude-sonnet-4-6"
     # For non-Anthropic models (HF router etc.), use the same model
     return main_model
 

--- a/agent/utils/terminal_display.py
+++ b/agent/utils/terminal_display.py
@@ -99,7 +99,7 @@ def print_banner(model: str | None = None, hf_user: str | None = None) -> None:
     _console.file.write("\033[2J\033[H")
     _console.file.flush()
 
-    model_label = model or "anthropic/claude-opus-4-6"
+    model_label = model or "bedrock/us.anthropic.claude-opus-4-6-v1"
     user_label = hf_user or "not logged in"
 
     # Warm gold palette matching the shimmer highlight (255, 200, 80)

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -47,7 +47,7 @@ AVAILABLE_MODELS = [
         "recommended": True,
     },
     {
-        "id": "anthropic/claude-opus-4-6",
+        "id": "bedrock/us.anthropic.claude-opus-4-6-v1",
         "label": "Claude Opus 4.6",
         "provider": "anthropic",
         "tier": "pro",
@@ -68,17 +68,21 @@ AVAILABLE_MODELS = [
 ]
 
 
+def _is_anthropic_model(model_id: str) -> bool:
+    return "anthropic" in model_id
+
+
 async def _require_hf_for_anthropic(request: Request, model_id: str) -> None:
     """403 if a non-``huggingface``-org user tries to select an Anthropic model.
 
     Anthropic models are billed to the Space's ``ANTHROPIC_API_KEY``; every
     other model in ``AVAILABLE_MODELS`` is routed through HF Router and
-    billed via ``X-HF-Bill-To``. The gate only fires for ``anthropic/*`` so
+    billed via ``X-HF-Bill-To``. The gate only fires for Anthropic so
     non-HF users can still freely switch between the free models.
 
     Pattern: https://github.com/huggingface/ml-intern/pull/63
     """
-    if not model_id.startswith("anthropic/"):
+    if not _is_anthropic_model(model_id):
         return
     if not await require_huggingface_org_member(request):
         raise HTTPException(
@@ -110,7 +114,7 @@ async def _enforce_claude_quota(
     if agent_session.claude_counted:
         return
     model_name = agent_session.session.config.model_name
-    if not model_name.startswith("anthropic/"):
+    if not _is_anthropic_model(model_name):
         return
     user_id = user["user_id"]
     used = await user_quotas.get_claude_used_today(user_id)

--- a/configs/main_agent_config.json
+++ b/configs/main_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "anthropic/claude-opus-4-6",
+  "model_name": "bedrock/us.anthropic.claude-opus-4-6-v1",
   "save_sessions": true,
   "session_dataset_repo": "akseljoonas/hf-agent-sessions",
   "yolo_mode": false,


### PR DESCRIPTION
## Summary

Switch the Claude endpoint IDs from the direct Anthropic API to the US cross-region inference profile (`bedrock/us.anthropic.claude-*`). LiteLLM picks up AWS credentials from the Space's secrets automatically — no code change beyond the model IDs and a couple of prefix checks.

## Changes

- `configs/main_agent_config.json`: default `model_name` updated
- `agent/core/model_switcher.py`: suggested model IDs updated
- `agent/core/session.py`: fallback session model updated
- `agent/utils/terminal_display.py`: default banner label updated
- `agent/tools/research_tool.py`: research sub-agent fallback + provider check
- `backend/routes/agent.py`:
  - `AVAILABLE_MODELS`: Claude Opus 4.6 id
  - `_is_anthropic_model()` helper to keep the HF-org gate and daily Claude quota firing for both `anthropic/*` and `bedrock/*.anthropic.*`
- `agent/core/prompt_caching.py`: prefix check relaxed to match Claude on either provider

## Test plan

- [ ] CI passes
- [ ] Space boots and serves a Claude turn (check `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` are set in Space secrets)
- [ ] Switching to a free HF model still works (gate must not mis-fire)