### PR TITLE
fix: route bedrock/ model ids via LiteLLM Bedrock adapter

### DIFF
--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -154,6 +154,14 @@ def _resolve_llm_params(
                 params["output_config"] = {"effort": level}
         return params
 
+    if model_name.startswith("bedrock/"):
+        # LiteLLM routes ``bedrock/...`` through the Converse adapter, which
+        # picks up AWS credentials from the standard env vars
+        # (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY`` / ``AWS_REGION``).
+        # The Anthropic thinking/effort shape is not forwarded through Converse
+        # the same way, so we leave it off for now.
+        return {"model": model_name}
+
     if model_name.startswith("openai/"):
         params = {"model": model_name}
         if reasoning_effort:


### PR DESCRIPTION
Follow-up to #82 — the Bedrock switch broke prod because `_resolve_llm_params` sends any non-`anthropic/`/`openai/` prefix through the HF router (`openai/<id>` at router.huggingface.co). Add a dedicated `bedrock/` branch that passes the model id as-is so LiteLLM's Converse adapter picks it up with the standard AWS env creds.