### PR TITLE
fix: add boto3 as explicit dep for LiteLLM Bedrock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     # Agent runtime dependencies
     "requests>=2.33.0",
     "litellm>=1.83.0",
+    "boto3>=1.35.0",
     "huggingface-hub>=1.0.1",
     "fastmcp>=3.2.0",
     "prompt-toolkit>=3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -997,6 +997,7 @@ name = "hf-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "datasets" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -1036,6 +1037,7 @@ eval = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "datasets", specifier = ">=4.4.1" },
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.3.0" },
     { name = "fastapi", specifier = ">=0.115.0" },


### PR DESCRIPTION
Follow-up to #82 and #89. Without `boto3` installed, LiteLLM's Bedrock adapter raises `APIConnectionError: No module named 'boto3'` at the first `InvokeModel` call. Adding it to the top-level dependencies ensures `uv sync` pulls it into the production image.

Already applied directly on the Space (`smolagents/ml-intern` main); this PR brings `huggingface/ml-intern` main back in sync.