### PR TITLE
Add GPT-5.5 as a selectable model

### DIFF
--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -26,6 +26,7 @@ from agent.core.effort_probe import ProbeInconclusive, probe_effort
 SUGGESTED_MODELS = [
     {"id": "bedrock/us.anthropic.claude-opus-4-7", "label": "Claude Opus 4.7"},
     {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6"},
+    {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
     {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": "moonshotai/Kimi-K2.6", "label": "Kimi K2.6"},
     {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -16,6 +16,9 @@ from agent.context_manager.manager import ContextManager
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MAX_TOKENS = 200_000
+_LOCAL_MAX_TOKENS: dict[str, int] = {
+    "openai/gpt-5.5": 1_000_000,
+}
 
 
 def _get_max_tokens_safe(model_name: str) -> int:
@@ -29,6 +32,9 @@ def _get_max_tokens_safe(model_name: str) -> int:
     models not in the catalog (typically HF-router-only models).
     """
     from litellm import get_model_info
+
+    if model_name in _LOCAL_MAX_TOKENS:
+        return _LOCAL_MAX_TOKENS[model_name]
 
     candidates = [model_name]
     stripped = model_name.removeprefix("huggingface/").split(":", 1)[0]

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -54,6 +54,13 @@ AVAILABLE_MODELS = [
         "recommended": True,
     },
     {
+        "id": "openai/gpt-5.5",
+        "label": "GPT-5.5",
+        "provider": "openai",
+        "tier": "pro",
+        "recommended": True,
+    },
+    {
         "id": "MiniMaxAI/MiniMax-M2.7",
         "label": "MiniMax M2.7",
         "provider": "huggingface",
@@ -691,5 +698,4 @@ async def shutdown_session(
     if not success:
         raise HTTPException(status_code=404, detail="Session not found or inactive")
     return {"status": "shutdown_requested", "session_id": session_id}
-
 

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -42,6 +42,14 @@ const MODEL_OPTIONS: ModelOption[] = [
     recommended: true,
   },
   {
+    id: 'gpt-5-5',
+    name: 'GPT-5.5',
+    description: 'OpenAI',
+    modelPath: 'openai/gpt-5.5',
+    avatarUrl: 'https://openai.com/favicon.ico',
+    recommended: true,
+  },
+  {
     id: 'minimax-m2.7',
     name: 'MiniMax M2.7',
     description: 'Novita',


### PR DESCRIPTION
Adds OpenAI GPT-5.5 to the model picker, backend allowlist, CLI suggestions, and token-window map.