### PR TITLE
feat: add MCP server wrapping ToolSpecs

### DIFF
--- a/agent/mcp_server.py
+++ b/agent/mcp_server.py
@@ -1,0 +1,80 @@
+"""FastMCP server exposing ml-intern's built-in ToolSpecs as MCP tools."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.tools import FunctionTool
+
+from agent.core.tools import ToolSpec, create_builtin_tools
+
+logger = logging.getLogger(__name__)
+
+EXCLUDED: frozenset[str] = frozenset({"plan_tool", "bash", "read", "write", "edit"})
+
+
+@dataclass
+class _Server:
+    mcp: FastMCP
+    specs: dict[str, ToolSpec]
+
+    def list_tool_names(self) -> list[str]:
+        return list(self.specs.keys())
+
+    def tool_schemas(self) -> dict[str, dict[str, Any]]:
+        return {
+            name: {"description": spec.description, "parameters": spec.parameters}
+            for name, spec in self.specs.items()
+        }
+
+    async def invoke(self, name: str, arguments: dict[str, Any]) -> Any:
+        spec = self.specs[name]
+        if spec.handler is None:
+            raise RuntimeError(f"Tool '{name}' has no handler")
+        return await spec.handler(arguments)
+
+    def run(self) -> None:
+        self.mcp.run()
+
+
+def _make_handler(spec: ToolSpec):
+    async def handler(**kwargs: Any) -> Any:
+        if spec.handler is None:
+            raise RuntimeError(f"Tool '{spec.name}' has no handler")
+        return await spec.handler(kwargs)
+
+    handler.__name__ = spec.name
+    return handler
+
+
+def build_server() -> _Server:
+    mcp = FastMCP("ml-intern")
+    specs: dict[str, ToolSpec] = {}
+    for spec in create_builtin_tools():
+        if spec.name in EXCLUDED:
+            continue
+        specs[spec.name] = spec
+        mcp.add_tool(
+            FunctionTool(
+                name=spec.name,
+                description=spec.description,
+                parameters=spec.parameters,
+                fn=_make_handler(spec),
+            )
+        )
+    logger.info("ml-intern MCP server registered %d tools", len(specs))
+    return _Server(mcp=mcp, specs=specs)
+
+
+def main() -> None:
+    level = os.environ.get("ML_INTERN_LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    build_server().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ all = [
 
 [project.scripts]
 ml-intern = "agent.main:cli"
+ml-intern-mcp = "agent.mcp_server:main"
 
 [build-system]
 requires = ["setuptools>=64"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,59 @@
+"""Tests for agent.mcp_server — FastMCP wrapper around ToolSpecs."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from agent.core.tools import ToolSpec, create_builtin_tools
+from agent.mcp_server import EXCLUDED, build_server
+
+
+def _expected_registered_names() -> set[str]:
+    return {t.name for t in create_builtin_tools() if t.name not in EXCLUDED}
+
+
+def test_build_server_registers_every_toolspec() -> None:
+    server = build_server()
+    registered = set(server.list_tool_names())
+    assert registered == _expected_registered_names()
+
+
+def test_build_server_preserves_tool_schema() -> None:
+    server = build_server()
+    schemas = server.tool_schemas()
+    specs_by_name = {t.name: t for t in create_builtin_tools() if t.name not in EXCLUDED}
+
+    assert set(schemas.keys()) == set(specs_by_name.keys())
+    for name, spec in specs_by_name.items():
+        registered = schemas[name]
+        assert registered["description"] == spec.description
+        assert registered["parameters"] == spec.parameters
+
+
+def test_plan_tool_is_excluded() -> None:
+    assert {"plan_tool", "bash", "read", "write", "edit"} <= EXCLUDED
+    server = build_server()
+    registered = set(server.list_tool_names())
+    for excluded in {"plan_tool", "bash", "read", "write", "edit"}:
+        assert excluded not in registered
+
+
+def test_tool_invocation_dispatches_to_handler() -> None:
+    mock_handler = AsyncMock(return_value=("result-output", True))
+    fake_spec = ToolSpec(
+        name="research",
+        description="mocked research",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=mock_handler,
+    )
+    real_tools = create_builtin_tools()
+    patched_tools = [fake_spec if t.name == "research" else t for t in real_tools]
+
+    with patch("agent.mcp_server.create_builtin_tools", return_value=patched_tools):
+        server = build_server()
+        result: Any = asyncio.run(server.invoke("research", {"query": "hello"}))
+
+    mock_handler.assert_awaited_once_with({"query": "hello"})
+    assert result == ("result-output", True)


### PR DESCRIPTION
Adds agent/mcp_server.py exposing ToolSpecs as FastMCP tools. Powers a Claude Code plugin.