### PR TITLE
feat: add MiniMax provider with M3 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create a `.env` file in the project root (or export these in your shell):
 
 ```bash
 ANTHROPIC_API_KEY=<your-anthropic-api-key> # if using anthropic models
+MINIMAX_API_KEY=<your-minimax-api-key> # if using minimax/ prefix models (api.minimax.io)
 HF_TOKEN=<your-hugging-face-token>
 GITHUB_TOKEN=<github-personal-access-token> 
 ```
@@ -50,6 +51,7 @@ ml-intern "fine-tune llama on my dataset"
 
 ```bash
 ml-intern --model anthropic/claude-opus-4-6 "your prompt"
+ml-intern --model minimax/MiniMax-M2.7 "your prompt"
 ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ml-intern "fine-tune llama on my dataset"
 
 ```bash
 ml-intern --model anthropic/claude-opus-4-6 "your prompt"
-ml-intern --model minimax/MiniMax-M2.7 "your prompt"
+ml-intern --model minimax/MiniMax-M3 "your prompt"
 ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 ```

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -226,7 +226,7 @@ def _friendly_error_message(error: Exception) -> str | None:
     ):
         return (
             "Model not found. Use '/model' to list suggestions, or paste an "
-            "HF model id like 'MiniMaxAI/MiniMax-M2.7'. Availability is shown "
+            "HF model id like 'MiniMaxAI/MiniMax-M3'. Availability is shown "
             "when you switch."
         )
 

--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -75,6 +75,9 @@ _ANTHROPIC_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 _OPENAI_EFFORTS = {"minimal", "low", "medium", "high"}
 _HF_EFFORTS = {"low", "medium", "high"}
 
+# MiniMax API base URL (OpenAI-compatible).  Override with MINIMAX_BASE_URL.
+_MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+
 
 class UnsupportedEffortError(ValueError):
     """The requested effort isn't valid for this provider's API surface.
@@ -108,6 +111,11 @@ def _resolve_llm_params(
 
     • ``openai/<model>`` — ``reasoning_effort`` forwarded as a top-level
       kwarg (GPT-5 / o-series). LiteLLM uses the user's ``OPENAI_API_KEY``.
+
+    • ``minimax/<model>`` — MiniMax OpenAI-compatible API at
+      ``https://api.minimax.io/v1``. Reads ``MINIMAX_API_KEY`` from the
+      environment; override the endpoint with ``MINIMAX_BASE_URL``.
+      Reasoning effort is not supported and is silently ignored.
 
     • Anything else is treated as a HuggingFace router id. We hit the
       auto-routing OpenAI-compatible endpoint at
@@ -173,6 +181,20 @@ def _resolve_llm_params(
             else:
                 params["reasoning_effort"] = reasoning_effort
         return params
+
+    if model_name.startswith("minimax/"):
+        # MiniMax OpenAI-compatible API.  Strip the "minimax/" prefix to get
+        # the bare model id (e.g. "MiniMax-M2.7"), then pass it to LiteLLM
+        # as "openai/<model>" so the OpenAI adapter is used with our custom
+        # api_base.  MiniMax doesn't support reasoning effort; ignore silently.
+        minimax_model = model_name[len("minimax/"):]
+        base_url = os.environ.get("MINIMAX_BASE_URL", _MINIMAX_DEFAULT_BASE_URL)
+        api_key = os.environ.get("MINIMAX_API_KEY")
+        return {
+            "model": f"openai/{minimax_model}",
+            "api_base": base_url,
+            "api_key": api_key,
+        }
 
     hf_model = model_name.removeprefix("huggingface/")
     api_key = (

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -19,13 +19,15 @@ from agent.core.effort_probe import ProbeInconclusive, probe_effort
 
 
 # Suggested models shown by `/model` (not a gate). Users can paste any HF
-# model id (e.g. "MiniMaxAI/MiniMax-M2.7") or an `anthropic/` / `openai/`
-# prefix for direct API access. For HF ids, append ":fastest" /
+# model id (e.g. "MiniMaxAI/MiniMax-M2.7") or an `anthropic/` / `openai/` /
+# `minimax/` prefix for direct API access. For HF ids, append ":fastest" /
 # ":cheapest" / ":preferred" / ":<provider>" to override the default
 # routing policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
     {"id": "bedrock/us.anthropic.claude-opus-4-7", "label": "Claude Opus 4.7"},
     {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6"},
+    {"id": "minimax/MiniMax-M2.7", "label": "MiniMax M2.7 (direct API)"},
+    {"id": "minimax/MiniMax-M2.7-highspeed", "label": "MiniMax M2.7 Highspeed (direct API)"},
     {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": "moonshotai/Kimi-K2.6", "label": "Kimi K2.6"},
     {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},
@@ -136,7 +138,7 @@ def print_model_listing(config, console) -> None:
     console.print(
         "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M2.7').\n"
         "Add ':fastest', ':cheapest', ':preferred', or ':<provider>' to override routing.\n"
-        "Use 'anthropic/<model>' or 'openai/<model>' for direct API access.[/dim]"
+        "Use 'anthropic/<model>', 'openai/<model>', or 'minimax/<model>' for direct API access.[/dim]"
     )
 
 
@@ -146,7 +148,8 @@ def print_invalid_id(arg: str, console) -> None:
         "[dim]Expected:\n"
         "  • <org>/<model>[:tag]    (HF router — paste from huggingface.co)\n"
         "  • anthropic/<model>\n"
-        "  • openai/<model>[/dim]"
+        "  • openai/<model>\n"
+        "  • minimax/<model>        (requires MINIMAX_API_KEY)[/dim]"
     )
 
 

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -19,16 +19,17 @@ from agent.core.effort_probe import ProbeInconclusive, probe_effort
 
 
 # Suggested models shown by `/model` (not a gate). Users can paste any HF
-# model id (e.g. "MiniMaxAI/MiniMax-M2.7") or an `anthropic/` / `openai/` /
+# model id (e.g. "MiniMaxAI/MiniMax-M3") or an `anthropic/` / `openai/` /
 # `minimax/` prefix for direct API access. For HF ids, append ":fastest" /
 # ":cheapest" / ":preferred" / ":<provider>" to override the default
 # routing policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
+    {"id": "minimax/MiniMax-M3", "label": "MiniMax M3 (direct API)"},
     {"id": "bedrock/us.anthropic.claude-opus-4-7", "label": "Claude Opus 4.7"},
     {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6"},
     {"id": "minimax/MiniMax-M2.7", "label": "MiniMax M2.7 (direct API)"},
     {"id": "minimax/MiniMax-M2.7-highspeed", "label": "MiniMax M2.7 Highspeed (direct API)"},
-    {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
+    {"id": "MiniMaxAI/MiniMax-M3", "label": "MiniMax M3"},
     {"id": "moonshotai/Kimi-K2.6", "label": "Kimi K2.6"},
     {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},
 ]
@@ -136,7 +137,7 @@ def print_model_listing(config, console) -> None:
         marker = " [dim]<-- current[/dim]" if m["id"] == current else ""
         console.print(f"  {m['id']}  [dim]({m['label']})[/dim]{marker}")
     console.print(
-        "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M2.7').\n"
+        "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M3').\n"
         "Add ':fastest', ':cheapest', ':preferred', or ':<provider>' to override routing.\n"
         "Use 'anthropic/<model>', 'openai/<model>', or 'minimax/<model>' for direct API access.[/dim]"
     )

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -54,6 +54,18 @@ AVAILABLE_MODELS = [
         "recommended": True,
     },
     {
+        "id": "minimax/MiniMax-M2.7",
+        "label": "MiniMax M2.7",
+        "provider": "minimax",
+        "tier": "free",
+    },
+    {
+        "id": "minimax/MiniMax-M2.7-highspeed",
+        "label": "MiniMax M2.7 Highspeed",
+        "provider": "minimax",
+        "tier": "free",
+    },
+    {
         "id": "MiniMaxAI/MiniMax-M2.7",
         "label": "MiniMax M2.7",
         "provider": "huggingface",

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -54,6 +54,12 @@ AVAILABLE_MODELS = [
         "recommended": True,
     },
     {
+        "id": "minimax/MiniMax-M3",
+        "label": "MiniMax M3",
+        "provider": "minimax",
+        "tier": "free",
+    },
+    {
         "id": "minimax/MiniMax-M2.7",
         "label": "MiniMax M2.7",
         "provider": "minimax",
@@ -66,8 +72,8 @@ AVAILABLE_MODELS = [
         "tier": "free",
     },
     {
-        "id": "MiniMaxAI/MiniMax-M2.7",
-        "label": "MiniMax M2.7",
+        "id": "MiniMaxAI/MiniMax-M3",
+        "label": "MiniMax M3",
         "provider": "huggingface",
         "tier": "free",
     },
@@ -103,7 +109,7 @@ async def _require_hf_for_anthropic(request: Request, model_id: str) -> None:
                 "error": "anthropic_restricted",
                 "message": (
                     "Opus is gated to HF staff. Pick a free model — "
-                    "Kimi K2.6, MiniMax M2.7, or GLM 5.1 — instead."
+                    "Kimi K2.6, MiniMax M3, or GLM 5.1 — instead."
                 ),
             },
         )

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -42,11 +42,11 @@ const MODEL_OPTIONS: ModelOption[] = [
     recommended: true,
   },
   {
-    id: 'minimax-m2.7',
-    name: 'MiniMax M2.7',
+    id: 'minimax-m3',
+    name: 'MiniMax M3',
     description: 'Novita',
-    modelPath: 'MiniMaxAI/MiniMax-M2.7',
-    avatarUrl: getHfAvatarUrl('MiniMaxAI/MiniMax-M2.7'),
+    modelPath: 'MiniMaxAI/MiniMax-M3',
+    avatarUrl: getHfAvatarUrl('MiniMaxAI/MiniMax-M3'),
   },
   {
     id: 'glm-5.1',

--- a/tests/unit/test_minimax_provider.py
+++ b/tests/unit/test_minimax_provider.py
@@ -1,0 +1,130 @@
+"""Unit tests for MiniMax provider support in _resolve_llm_params."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Load agent.core.llm_params directly from its file to avoid triggering
+# agent/__init__.py (which pulls in agent_loop -> tools -> whoosh and other
+# heavy optional deps that aren't installed in all test environments).
+_AGENT_DIR = Path(__file__).resolve().parent.parent.parent
+_LLM_PARAMS_PATH = _AGENT_DIR / "agent" / "core" / "llm_params.py"
+
+spec = importlib.util.spec_from_file_location("agent.core.llm_params", _LLM_PARAMS_PATH)
+_llm_params_mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(_llm_params_mod)  # type: ignore[union-attr]
+
+_resolve_llm_params = _llm_params_mod._resolve_llm_params
+UnsupportedEffortError = _llm_params_mod.UnsupportedEffortError
+_MINIMAX_DEFAULT_BASE_URL = _llm_params_mod._MINIMAX_DEFAULT_BASE_URL
+
+
+class TestMinimaxProvider:
+    """Tests for the minimax/ prefix provider routing."""
+
+    def test_minimax_model_uses_openai_adapter(self):
+        """minimax/X is forwarded to litellm as openai/X with api_base set."""
+        params = _resolve_llm_params("minimax/MiniMax-M2.7")
+        assert params["model"] == "openai/MiniMax-M2.7"
+
+    def test_minimax_highspeed_model(self):
+        params = _resolve_llm_params("minimax/MiniMax-M2.7-highspeed")
+        assert params["model"] == "openai/MiniMax-M2.7-highspeed"
+
+    def test_minimax_default_base_url(self):
+        """Default base URL points to api.minimax.io."""
+        env = {k: v for k, v in os.environ.items() if k != "MINIMAX_BASE_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            params = _resolve_llm_params("minimax/MiniMax-M2.7")
+        assert params["api_base"] == _MINIMAX_DEFAULT_BASE_URL
+        assert params["api_base"].startswith("https://api.minimax.io")
+
+    def test_minimax_custom_base_url(self):
+        """MINIMAX_BASE_URL env var overrides the default endpoint."""
+        custom_url = "https://api.minimaxi.com/v1"
+        with patch.dict(os.environ, {"MINIMAX_BASE_URL": custom_url}):
+            params = _resolve_llm_params("minimax/MiniMax-M2.7")
+        assert params["api_base"] == custom_url
+
+    def test_minimax_api_key_from_env(self):
+        """MINIMAX_API_KEY is picked up from environment."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"}):
+            params = _resolve_llm_params("minimax/MiniMax-M2.7")
+        assert params["api_key"] == "test-key-123"
+
+    def test_minimax_no_api_key(self):
+        """When MINIMAX_API_KEY is unset, api_key is None (litellm raises later)."""
+        env = {k: v for k, v in os.environ.items() if k != "MINIMAX_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            params = _resolve_llm_params("minimax/MiniMax-M2.7")
+        assert params["api_key"] is None
+
+    def test_minimax_reasoning_effort_silently_ignored(self):
+        """Reasoning effort is not forwarded — MiniMax doesn't support it."""
+        params = _resolve_llm_params("minimax/MiniMax-M2.7", reasoning_effort="high")
+        assert "reasoning_effort" not in params
+        assert "thinking" not in params
+        assert "output_config" not in params
+        assert "extra_body" not in params
+
+    def test_minimax_reasoning_effort_strict_mode_no_error(self):
+        """strict=True doesn't raise for minimax — effort is silently dropped."""
+        params = _resolve_llm_params(
+            "minimax/MiniMax-M2.7", reasoning_effort="max", strict=True
+        )
+        assert params["model"] == "openai/MiniMax-M2.7"
+        assert "reasoning_effort" not in params
+
+    def test_minimax_does_not_include_hf_headers(self):
+        """No X-HF-Bill-To or extra_headers for minimax."""
+        params = _resolve_llm_params("minimax/MiniMax-M2.7")
+        assert "extra_headers" not in params
+
+    def test_other_prefixes_unaffected(self):
+        """anthropic/ and openai/ prefixes are unaffected by the minimax branch."""
+        anthropic_params = _resolve_llm_params("anthropic/claude-opus-4-6")
+        assert anthropic_params["model"] == "anthropic/claude-opus-4-6"
+        assert "api_base" not in anthropic_params
+
+        openai_params = _resolve_llm_params("openai/gpt-4o")
+        assert openai_params["model"] == "openai/gpt-4o"
+        assert "api_base" not in openai_params
+
+
+class TestMinimaxSuggestedModels:
+    """Tests that SUGGESTED_MODELS includes direct MiniMax entries."""
+
+    def test_minimax_direct_in_suggested_models(self):
+        # Load model_switcher directly to avoid agent/__init__.py imports
+        _SWITCHER_PATH = _AGENT_DIR / "agent" / "core" / "model_switcher.py"
+
+        # We need to stub out the effort_probe import that model_switcher uses
+        from unittest.mock import MagicMock
+        mock_module = MagicMock()
+        sys.modules.setdefault("agent.core.effort_probe", mock_module)
+        sys.modules.setdefault("agent.core", MagicMock())
+
+        spec_s = importlib.util.spec_from_file_location("model_switcher_test", _SWITCHER_PATH)
+        mod = importlib.util.module_from_spec(spec_s)  # type: ignore[arg-type]
+        spec_s.loader.exec_module(mod)  # type: ignore[union-attr]
+
+        ids = [m["id"] for m in mod.SUGGESTED_MODELS]
+        assert "minimax/MiniMax-M2.7" in ids
+        assert "minimax/MiniMax-M2.7-highspeed" in ids
+
+    def test_minimax_model_ids_are_valid(self):
+        # is_valid_model_id only does string checks, load similarly
+        _SWITCHER_PATH = _AGENT_DIR / "agent" / "core" / "model_switcher.py"
+        from unittest.mock import MagicMock
+        sys.modules.setdefault("agent.core.effort_probe", MagicMock())
+
+        spec_s = importlib.util.spec_from_file_location("model_switcher_test2", _SWITCHER_PATH)
+        mod = importlib.util.module_from_spec(spec_s)  # type: ignore[arg-type]
+        spec_s.loader.exec_module(mod)  # type: ignore[union-attr]
+
+        assert mod.is_valid_model_id("minimax/MiniMax-M2.7")
+        assert mod.is_valid_model_id("minimax/MiniMax-M2.7-highspeed")

--- a/tests/unit/test_minimax_provider.py
+++ b/tests/unit/test_minimax_provider.py
@@ -26,6 +26,11 @@ _MINIMAX_DEFAULT_BASE_URL = _llm_params_mod._MINIMAX_DEFAULT_BASE_URL
 class TestMinimaxProvider:
     """Tests for the minimax/ prefix provider routing."""
 
+    def test_minimax_m3_model_uses_openai_adapter(self):
+        """minimax/MiniMax-M3 is forwarded to litellm as openai/MiniMax-M3."""
+        params = _resolve_llm_params("minimax/MiniMax-M3")
+        assert params["model"] == "openai/MiniMax-M3"
+
     def test_minimax_model_uses_openai_adapter(self):
         """minimax/X is forwarded to litellm as openai/X with api_base set."""
         params = _resolve_llm_params("minimax/MiniMax-M2.7")
@@ -39,7 +44,7 @@ class TestMinimaxProvider:
         """Default base URL points to api.minimax.io."""
         env = {k: v for k, v in os.environ.items() if k != "MINIMAX_BASE_URL"}
         with patch.dict(os.environ, env, clear=True):
-            params = _resolve_llm_params("minimax/MiniMax-M2.7")
+            params = _resolve_llm_params("minimax/MiniMax-M3")
         assert params["api_base"] == _MINIMAX_DEFAULT_BASE_URL
         assert params["api_base"].startswith("https://api.minimax.io")
 
@@ -113,6 +118,7 @@ class TestMinimaxSuggestedModels:
         spec_s.loader.exec_module(mod)  # type: ignore[union-attr]
 
         ids = [m["id"] for m in mod.SUGGESTED_MODELS]
+        assert "minimax/MiniMax-M3" in ids
         assert "minimax/MiniMax-M2.7" in ids
         assert "minimax/MiniMax-M2.7-highspeed" in ids
 
@@ -126,5 +132,6 @@ class TestMinimaxSuggestedModels:
         mod = importlib.util.module_from_spec(spec_s)  # type: ignore[arg-type]
         spec_s.loader.exec_module(mod)  # type: ignore[union-attr]
 
+        assert mod.is_valid_model_id("minimax/MiniMax-M3")
         assert mod.is_valid_model_id("minimax/MiniMax-M2.7")
         assert mod.is_valid_model_id("minimax/MiniMax-M2.7-highspeed")


### PR DESCRIPTION
## Summary

Adds direct MiniMax API support and sets **MiniMax-M3** as the default MiniMax model.

## Changes

- **`agent/core/llm_params.py`** — adds `minimax/<model>` prefix routing that resolves to the MiniMax OpenAI-compatible endpoint (`https://api.minimax.io/v1`) using `MINIMAX_API_KEY`. Reasoning effort is silently ignored (MiniMax doesn't support thinking modes). The endpoint can be overridden via `MINIMAX_BASE_URL`.
- **`agent/core/model_switcher.py`** — adds `minimax/MiniMax-M3` (new default), `minimax/MiniMax-M2.7`, and `minimax/MiniMax-M2.7-highspeed` to `SUGGESTED_MODELS`. Updates the HF-router entry `MiniMaxAI/MiniMax-M2.7` → `MiniMaxAI/MiniMax-M3`. Updates the `/model` help text.
- **`backend/routes/agent.py`** — adds `minimax/MiniMax-M3`, `minimax/MiniMax-M2.7`, `minimax/MiniMax-M2.7-highspeed`, and updates the HF-router `MiniMaxAI/MiniMax-M2.7` → `MiniMaxAI/MiniMax-M3` in `AVAILABLE_MODELS`. Updates the user-facing free-model suggestion string.
- **`frontend/src/components/Chat/ChatInput.tsx`** — updates the MiniMax quick-pick entry to `MiniMaxAI/MiniMax-M3`.
- **`agent/core/agent_loop.py`** — updates the in-code example HF model id to `MiniMaxAI/MiniMax-M3`.
- **`README.md`** — documents `MINIMAX_API_KEY` and the `--model minimax/MiniMax-M3` usage example.
- **`tests/unit/test_minimax_provider.py`** — unit tests covering routing, env var handling, base URL override, effort passthrough, and assertions that M3 is in `SUGGESTED_MODELS` and is a valid model id.

## Model lineup

| Model | Notes |
|-------|-------|
| `MiniMax-M3` | **Default**. 512K context, 128K max output, image input |
| `MiniMax-M2.7` | Previous generation |
| `MiniMax-M2.7-highspeed` | Previous generation, low-latency variant |

Older models (M2.5/M2.1/M2/M1) are not listed.

## Why

The direct `minimax/` prefix lets users with a `MINIMAX_API_KEY` call `api.minimax.io` without HF intermediation — same pattern as `anthropic/` and `openai/` prefixes. M3 is the current flagship MiniMax model with 512K context, up to 128K output, and image input support; M2.7 and M2.7-highspeed are kept as alternatives.

## API reference
- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan
- [x] Unit tests pass (`pytest tests/unit/test_minimax_provider.py -v`)
- [x] Integration verified: `MiniMax-M3` responds correctly at `api.minimax.io/v1`