### PR TITLE
ci: add automatic Claude Code review on PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  id-token: write
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,40 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            Review this pull request against the main branch. Focus on:
+            - Correctness and likely bugs
+            - Security issues (auth, input validation, secrets, injection)
+            - Performance regressions, especially in the agent loop and streaming paths
+            - Breakages in LiteLLM / Bedrock routing (model ids, params, prompt caching)
+            - Test coverage for new behavior
+            - Backend/frontend contract drift (FastAPI routes ↔ React client)
+
+            Be concise. Prefer inline comments over long summaries. Skip nitpicks on
+            style that ruff already catches. If the PR looks good, say so briefly
+            instead of inventing issues.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,34 @@
+name: Claude on Mention
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` — runs `anthropics/claude-code-action@v1` on every non-draft PR (`opened`, `synchronize`, `ready_for_review`) and leaves inline review comments. Concurrency-grouped per PR so a quick re-push cancels the stale run.
- Adds `.github/workflows/claude.yml` — on-demand `@claude` mentions in issues, PR comments, and PR reviews. Lets you ask follow-up questions or request a re-review without re-pushing.

Both workflows use `ANTHROPIC_API_KEY` for auth. We can swap to AWS Bedrock later (the repo already routes Claude via Bedrock in app code) by adding `anthropic_model` + AWS creds — kept simple for v1.

## Required setup before this works
Add a repo secret named **`ANTHROPIC_API_KEY`** under Settings → Secrets and variables → Actions. Without it both jobs will no-op on first run.

## Notes
- The review prompt is tuned to this repo: flags bugs, security, LiteLLM/Bedrock routing breakage, backend↔frontend contract drift, and skips style nits that ruff already covers.
- Draft PRs are skipped; mark ready-for-review to trigger.
- Re-trigger a review anytime by commenting `@claude please re-review`.

## Test plan
- [x] Add `ANTHROPIC_API_KEY` secret
- [ ] Merge this PR, then open a throwaway PR and confirm the review job runs and posts a comment
- [ ] Comment `@claude` on an issue and confirm the mention workflow responds
- [ ] Confirm draft PRs do not trigger a review