### PR TITLE
docs: fix typo (releated → related)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # ML Intern
 
-An ML intern that autonomously researches, writes, and ships good quality ML releated code using the Hugging Face ecosystem — with deep access to docs, papers, datasets, and cloud compute.
+An ML intern that autonomously researches, writes, and ships good quality ML related code using the Hugging Face ecosystem — with deep access to docs, papers, datasets, and cloud compute.
 
 ## Quick Start
 


### PR DESCRIPTION
One-char README typo fix. Opened as draft to verify that the Claude review workflow does not trigger on drafts.