### PR TITLE
Switch from Bedrock to Anthropic endpoint as default. Include support for gpt-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create a `.env` file in the project root (or export these in your shell):
 
 ```bash
 ANTHROPIC_API_KEY=<your-anthropic-api-key> # if using anthropic models
+OPENAI_API_KEY=<your-openai-api-key> # if using openai models
 HF_TOKEN=<your-hugging-face-token>
 GITHUB_TOKEN=<github-personal-access-token> 
 ```
@@ -50,6 +51,7 @@ ml-intern "fine-tune llama on my dataset"
 
 ```bash
 ml-intern --model anthropic/claude-opus-4-6 "your prompt"
+ml-intern --model openai/gpt-5.5 "your prompt"
 ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 ```

--- a/agent/core/effort_probe.py
+++ b/agent/core/effort_probe.py
@@ -32,9 +32,10 @@ logger = logging.getLogger(__name__)
 
 
 # Cascade: for each user-stated preference, the ordered list of levels to
-# try. First success wins. ``max`` / ``xhigh`` are Anthropic-only; providers
-# that don't accept them raise ``UnsupportedEffortError`` synchronously (no
-# wasted network round-trip) and we advance to the next level.
+# try. First success wins. ``max`` is Anthropic-only; ``xhigh`` is also
+# supported on current OpenAI GPT-5 models. Providers that don't accept a
+# requested level raise ``UnsupportedEffortError`` synchronously (no wasted
+# network round-trip) and we advance to the next level.
 _EFFORT_CASCADE: dict[str, list[str]] = {
     "max":     ["max", "xhigh", "high", "medium", "low"],
     "xhigh":   ["xhigh", "high", "medium", "low"],

--- a/agent/core/effort_probe.py
+++ b/agent/core/effort_probe.py
@@ -45,7 +45,10 @@ _EFFORT_CASCADE: dict[str, list[str]] = {
 }
 
 _PROBE_TIMEOUT = 15.0
-_PROBE_MAX_TOKENS = 16
+# Keep the probe cheap, but high enough that frontier reasoning models can
+# finish a trivial reply instead of tripping a false "output limit reached"
+# error during capability detection.
+_PROBE_MAX_TOKENS = 64
 
 
 class ProbeInconclusive(Exception):

--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -66,13 +66,13 @@ _patch_litellm_effort_validation()
 
 # Effort levels accepted on the wire.
 #   Anthropic (4.6+):  low | medium | high | xhigh | max   (output_config.effort)
-#   OpenAI direct:     minimal | low | medium | high       (reasoning_effort top-level)
+#   OpenAI direct:     minimal | low | medium | high | xhigh (reasoning_effort top-level)
 #   HF router:         low | medium | high                 (extra_body.reasoning_effort)
 #
 # We validate *shape* here and let the probe cascade walk down on rejection;
 # we deliberately do NOT maintain a per-model capability table.
 _ANTHROPIC_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
-_OPENAI_EFFORTS = {"minimal", "low", "medium", "high"}
+_OPENAI_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
 _HF_EFFORTS = {"low", "medium", "high"}
 
 

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -24,8 +24,9 @@ from agent.core.effort_probe import ProbeInconclusive, probe_effort
 # ":cheapest" / ":preferred" / ":<provider>" to override the default
 # routing policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
-    {"id": "bedrock/us.anthropic.claude-opus-4-7", "label": "Claude Opus 4.7"},
-    {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6"},
+    {"id": "anthropic/claude-opus-4-7", "label": "Claude Opus 4.7"},
+    {"id": "anthropic/claude-opus-4-6", "label": "Claude Opus 4.6"},
+    {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6 via Bedrock"},
     {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": "moonshotai/Kimi-K2.6", "label": "Kimi K2.6"},
     {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -24,6 +24,8 @@ from agent.core.effort_probe import ProbeInconclusive, probe_effort
 # ":cheapest" / ":preferred" / ":<provider>" to override the default
 # routing policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
+    {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
+    {"id": "openai/gpt-5.4", "label": "GPT-5.4"},
     {"id": "anthropic/claude-opus-4-7", "label": "Claude Opus 4.7"},
     {"id": "anthropic/claude-opus-4-6", "label": "Claude Opus 4.6"},
     {"id": "bedrock/us.anthropic.claude-opus-4-6-v1", "label": "Claude Opus 4.6 via Bedrock"},

--- a/agent/main.py
+++ b/agent/main.py
@@ -771,8 +771,9 @@ async def _handle_slash_command(
                     console.print(f"  [dim]{m}: {eff or 'off'}[/dim]")
             console.print(
                 "[dim]Set with '/effort minimal|low|medium|high|xhigh|max|off'. "
-                "'max' and 'xhigh' are Anthropic-only; the cascade falls back "
-                "to whatever the model actually accepts.[/dim]"
+                "'max' is Anthropic-only; 'xhigh' is also supported by current "
+                "OpenAI GPT-5 models. The cascade falls back to whatever the "
+                "model actually accepts.[/dim]"
             )
             return None
         level = arg.lower()

--- a/configs/main_agent_config.json
+++ b/configs/main_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "bedrock/us.anthropic.claude-opus-4-6-v1",
+  "model_name": "anthropic/claude-opus-4-6",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "yolo_mode": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hf-agent"
+name = "ml-intern"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
@@ -46,7 +46,7 @@ dev = [
 
 # All dependencies (eval + dev)
 all = [
-    "hf-agent[eval,dev]",
+    "ml-intern[eval,dev]",
 ]
 
 [project.scripts]

--- a/tests/unit/test_llm_params.py
+++ b/tests/unit/test_llm_params.py
@@ -1,0 +1,25 @@
+from agent.core.llm_params import UnsupportedEffortError, _resolve_llm_params
+
+
+def test_openai_xhigh_effort_is_forwarded():
+    params = _resolve_llm_params(
+        "openai/gpt-5.5",
+        reasoning_effort="xhigh",
+        strict=True,
+    )
+
+    assert params["model"] == "openai/gpt-5.5"
+    assert params["reasoning_effort"] == "xhigh"
+
+
+def test_openai_max_effort_is_still_rejected():
+    try:
+        _resolve_llm_params(
+            "openai/gpt-5.4",
+            reasoning_effort="max",
+            strict=True,
+        )
+    except UnsupportedEffortError as exc:
+        assert "OpenAI doesn't accept effort='max'" in str(exc)
+    else:
+        raise AssertionError("Expected UnsupportedEffortError for max effort")

--- a/uv.lock
+++ b/uv.lock
@@ -229,6 +229,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -993,78 +1005,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hf-agent"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "boto3" },
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "fastmcp" },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "litellm" },
-    { name = "nbconvert" },
-    { name = "nbformat" },
-    { name = "prompt-toolkit" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "thefuzz" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "websockets" },
-    { name = "whoosh" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "datasets" },
-    { name = "inspect-ai" },
-    { name = "pandas" },
-    { name = "pytest" },
-    { name = "tenacity" },
-]
-dev = [
-    { name = "pytest" },
-]
-eval = [
-    { name = "datasets" },
-    { name = "inspect-ai" },
-    { name = "pandas" },
-    { name = "tenacity" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "boto3", specifier = ">=1.35.0" },
-    { name = "datasets", specifier = ">=4.4.1" },
-    { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.3.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "fastmcp", specifier = ">=3.2.0" },
-    { name = "hf-agent", extras = ["eval", "dev"], marker = "extra == 'all'" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "huggingface-hub", specifier = ">=1.0.1" },
-    { name = "inspect-ai", marker = "extra == 'eval'", specifier = ">=0.3.149" },
-    { name = "litellm", specifier = ">=1.83.0" },
-    { name = "nbconvert", specifier = ">=7.16.6" },
-    { name = "nbformat", specifier = ">=5.10.4" },
-    { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.3.3" },
-    { name = "prompt-toolkit", specifier = ">=3.0.0" },
-    { name = "pydantic", specifier = ">=2.12.3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "requests", specifier = ">=2.33.0" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "tenacity", marker = "extra == 'eval'", specifier = ">=8.0.0" },
-    { name = "thefuzz", specifier = ">=0.22.1" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
-    { name = "websockets", specifier = ">=13.0" },
-    { name = "whoosh", specifier = ">=2.7.4" },
-]
-provides-extras = ["eval", "dev", "all"]
-
-[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1826,6 +1766,80 @@ sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
 ]
+
+[[package]]
+name = "ml-intern"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "apscheduler" },
+    { name = "boto3" },
+    { name = "datasets" },
+    { name = "fastapi" },
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "litellm" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "prompt-toolkit" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "thefuzz" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
+    { name = "whoosh" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "datasets" },
+    { name = "inspect-ai" },
+    { name = "pandas" },
+    { name = "pytest" },
+    { name = "tenacity" },
+]
+dev = [
+    { name = "pytest" },
+]
+eval = [
+    { name = "datasets" },
+    { name = "inspect-ai" },
+    { name = "pandas" },
+    { name = "tenacity" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "apscheduler", specifier = ">=3.10,<4" },
+    { name = "boto3", specifier = ">=1.35.0" },
+    { name = "datasets", specifier = ">=4.4.1" },
+    { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.3.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "huggingface-hub", specifier = ">=1.0.1" },
+    { name = "inspect-ai", marker = "extra == 'eval'", specifier = ">=0.3.149" },
+    { name = "litellm", specifier = ">=1.83.0" },
+    { name = "ml-intern", extras = ["eval", "dev"], marker = "extra == 'all'" },
+    { name = "nbconvert", specifier = ">=7.16.6" },
+    { name = "nbformat", specifier = ">=5.10.4" },
+    { name = "pandas", marker = "extra == 'eval'", specifier = ">=2.3.3" },
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
+    { name = "pydantic", specifier = ">=2.12.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "requests", specifier = ">=2.33.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "tenacity", marker = "extra == 'eval'", specifier = ">=8.0.0" },
+    { name = "thefuzz", specifier = ">=0.22.1" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+    { name = "websockets", specifier = ">=13.0" },
+    { name = "whoosh", specifier = ">=2.7.4" },
+]
+provides-extras = ["eval", "dev", "all"]
 
 [[package]]
 name = "mmh3"
@@ -3617,6 +3631,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

When running `ml-intern` with the default config, the CLI was using `bedrock/us.anthropic.claude-opus-4-6-v1`. On machines without permission to invoke that Bedrock inference profile, even a trivial prompt failed with a `litellm.APIConnectionError` wrapping a Bedrock authorization error for `bedrock:InvokeModelWithResponseStream`.

This PR switches the default path away from Bedrock, adds direct OpenAI GPT-5 model support to the suggested model list and effort validation, and fixes a probe edge case that showed up while testing GPT-5.5.

## What changed

- switch the default model from Bedrock to direct Anthropic (`anthropic/claude-opus-4-6`)
- update `/model` suggestions to surface direct Anthropic and OpenAI options
- add direct OpenAI suggestions for `openai/gpt-5.4` and `openai/gpt-5.5`
- widen OpenAI effort validation so `xhigh` is accepted for GPT-5.4 / GPT-5.5
- raise the effort probe token budget so GPT-5 models do not fail capability detection with a false output-limit error
- document `OPENAI_API_KEY` usage in the README

## Testing

Live smoke tests were run against:

- `anthropic/claude-opus-4-6`
- `anthropic/claude-opus-4-7`
- `openai/gpt-5.4`
- `openai/gpt-5.5`

Results:

- Opus 4.6 and 4.7 both accepted `max` reasoning effort and returned a successful response in streaming and non-streaming modes
- GPT-5.4 and GPT-5.5 both correctly fell back from `max` to `xhigh` and returned a successful response in streaming and non-streaming modes
- unit tests: `uv run pytest tests/unit/test_llm_params.py`

cc @jagwar for viz
