### PR TITLE
Fix Claude review on external PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,8 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review]
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
 
 permissions:
   contents: read
@@ -22,6 +22,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # On pull_request_target, keep checkout on the trusted base-repo ref.
+          # The Claude action can review the PR via GitHub context/API without
+          # executing untrusted fork code with repository secrets.
+          persist-credentials: false
 
       - name: Compose review prompt
         id: compose


### PR DESCRIPTION
Switch Claude PR review to
  pull_request_target so fork PRs can use repo secrets safely without checking out untrusted
  head code.