### PR TITLE
Run jobs under user or org accounts with upgrade / org-pick UX

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -1137,6 +1137,9 @@ class Handlers:
                     tool_args["script"] = edited_script
                     was_edited = True
                     logger.info(f"Using user-edited script for {tool_name} ({tc.id})")
+                selected_namespace = approval_decision.get("namespace")
+                if selected_namespace and tool_name == "hf_jobs":
+                    tool_args["namespace"] = selected_namespace
                 approved_tasks.append((tc, tool_name, tool_args, was_edited))
             else:
                 rejected_tasks.append((tc, tool_name, approval_decision))

--- a/agent/core/hf_access.py
+++ b/agent/core/hf_access.py
@@ -1,0 +1,177 @@
+"""Helpers for Hugging Face account / org access decisions."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL", "https://huggingface.co")
+
+
+@dataclass(frozen=True)
+class JobsAccess:
+    """Jobs entitlement derived from whoami-v2."""
+
+    username: str | None
+    plan: str
+    personal_can_run_jobs: bool
+    paid_org_names: list[str]
+    eligible_namespaces: list[str]
+    default_namespace: str | None
+    access_known: bool = True
+
+    @property
+    def can_run_jobs(self) -> bool:
+        return bool(self.default_namespace)
+
+
+class JobsAccessError(Exception):
+    """Structured jobs access error for upgrade / namespace gating."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        access: JobsAccess | None = None,
+        upgrade_required: bool = False,
+        namespace_required: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.access = access
+        self.upgrade_required = upgrade_required
+        self.namespace_required = namespace_required
+
+
+def _extract_username(whoami: dict[str, Any]) -> str | None:
+    for key in ("name", "user", "preferred_username"):
+        value = whoami.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _normalize_personal_plan(whoami: dict[str, Any]) -> str:
+    plan_str = ""
+    for key in ("plan", "type", "accountType"):
+        value = whoami.get(key)
+        if isinstance(value, str) and value:
+            plan_str = value.lower()
+            break
+
+    if not plan_str and (whoami.get("isPro") is True or whoami.get("is_pro") is True):
+        return "pro"
+
+    if any(tag in plan_str for tag in ("pro", "enterprise", "team")):
+        return "pro"
+    return "free"
+
+
+def _paid_org_names(whoami: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    orgs = whoami.get("orgs") or []
+    if not isinstance(orgs, list):
+        return names
+
+    for org in orgs:
+        if not isinstance(org, dict):
+            continue
+        name = org.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        org_plan = str(org.get("plan") or org.get("type") or "").lower()
+        if any(tag in org_plan for tag in ("pro", "enterprise", "team")):
+            names.append(name)
+    return sorted(set(names))
+
+
+def jobs_access_from_whoami(whoami: dict[str, Any]) -> JobsAccess:
+    username = _extract_username(whoami)
+    personal_plan = _normalize_personal_plan(whoami)
+    paid_orgs = _paid_org_names(whoami)
+    personal_can_run = personal_plan == "pro"
+
+    eligible_namespaces: list[str] = []
+    if personal_can_run and username:
+        eligible_namespaces.append(username)
+    eligible_namespaces.extend(paid_orgs)
+
+    plan = "pro" if personal_can_run else ("org" if paid_orgs else "free")
+    default_namespace = username if personal_can_run and username else None
+
+    return JobsAccess(
+        username=username,
+        plan=plan,
+        personal_can_run_jobs=personal_can_run,
+        paid_org_names=paid_orgs,
+        eligible_namespaces=eligible_namespaces,
+        default_namespace=default_namespace,
+    )
+
+
+async def fetch_whoami_v2(token: str, timeout: float = 5.0) -> dict[str, Any] | None:
+    if not token:
+        return None
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            response = await client.get(
+                f"{OPENID_PROVIDER_URL}/api/whoami-v2",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if response.status_code != 200:
+                return None
+            payload = response.json()
+            return payload if isinstance(payload, dict) else None
+        except (httpx.HTTPError, ValueError):
+            return None
+
+
+async def get_jobs_access(token: str) -> JobsAccess | None:
+    whoami = await fetch_whoami_v2(token)
+    if whoami is None:
+        return None
+    return jobs_access_from_whoami(whoami)
+
+
+async def resolve_jobs_namespace(
+    token: str,
+    requested_namespace: str | None = None,
+) -> tuple[str, JobsAccess | None]:
+    """Return the namespace to use for jobs.
+
+    If whoami-v2 is unavailable, fall back to the token owner's username.
+    """
+    access = await get_jobs_access(token)
+    if access:
+        if requested_namespace:
+            if requested_namespace in access.eligible_namespaces:
+                return requested_namespace, access
+            raise JobsAccessError(
+                f"You can only run jobs under your own Pro account or a paid org you belong to. "
+                f"Allowed namespaces: {', '.join(access.eligible_namespaces) or '(none)'}",
+                access=access,
+            )
+        if access.default_namespace:
+            return access.default_namespace, access
+        if access.paid_org_names:
+            raise JobsAccessError(
+                "Choose which paid organization should own this job run.",
+                access=access,
+                namespace_required=True,
+            )
+        raise JobsAccessError(
+            "Hugging Face Jobs are available only to Pro users and Team or Enterprise organizations. "
+            "Upgrade to Pro, or run the job under a paid org you belong to.",
+            access=access,
+            upgrade_required=True,
+        )
+
+    # Fallback: whoami-v2 unavailable. Do not block the call pre-emptively.
+    from huggingface_hub import HfApi
+
+    username = HfApi(token=token).whoami().get("name") if token else None
+    if not username:
+        raise JobsAccessError("No HF token available to resolve a jobs namespace.")
+    return requested_namespace or username, None

--- a/agent/core/hf_access.py
+++ b/agent/core/hf_access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -171,7 +172,10 @@ async def resolve_jobs_namespace(
     # Fallback: whoami-v2 unavailable. Do not block the call pre-emptively.
     from huggingface_hub import HfApi
 
-    username = HfApi(token=token).whoami().get("name") if token else None
+    username = None
+    if token:
+        whoami = await asyncio.to_thread(HfApi(token=token).whoami)
+        username = whoami.get("name")
     if not username:
         raise JobsAccessError("No HF token available to resolve a jobs namespace.")
     return requested_namespace or username, None

--- a/agent/core/telemetry.py
+++ b/agent/core/telemetry.py
@@ -141,6 +141,7 @@ async def record_hf_job_submit(
                 "timeout": args.get("timeout", "30m"),
                 "job_type": job_type,
                 "image": image,
+                "namespace": args.get("namespace"),
                 "push_to_hub": _infer_push_to_hub(script_text),
             },
         ))
@@ -237,6 +238,43 @@ async def record_feedback(
         ))
     except Exception as e:
         logger.debug("record_feedback failed (non-fatal): %s", e)
+
+
+async def record_jobs_access_blocked(
+    session: Any,
+    *,
+    tool_call_ids: list[str],
+    plan: str,
+    eligible_namespaces: list[str],
+) -> None:
+    from agent.core.session import Event
+    try:
+        await session.send_event(Event(
+            event_type="jobs_access_blocked",
+            data={
+                "tool_call_ids": tool_call_ids,
+                "plan": plan,
+                "eligible_namespaces": eligible_namespaces,
+            },
+        ))
+    except Exception as e:
+        logger.debug("record_jobs_access_blocked failed (non-fatal): %s", e)
+
+
+async def record_pro_cta_click(
+    session: Any,
+    *,
+    source: str,
+    target: str = "pro_pricing",
+) -> None:
+    from agent.core.session import Event
+    try:
+        await session.send_event(Event(
+            event_type="pro_cta_click",
+            data={"source": source, "target": target},
+        ))
+    except Exception as e:
+        logger.debug("record_pro_cta_click failed (non-fatal): %s", e)
 
 
 # ── heartbeat ──────────────────────────────────────────────────────────────

--- a/agent/tools/jobs_tool.py
+++ b/agent/tools/jobs_tool.py
@@ -17,6 +17,7 @@ import httpx
 from huggingface_hub import HfApi
 from huggingface_hub.utils import HfHubHTTPError
 
+from agent.core.hf_access import JobsAccessError, resolve_jobs_namespace
 from agent.core.session import Event
 from agent.tools.types import ToolResult
 
@@ -298,6 +299,7 @@ class HfJobsTool:
         self,
         hf_token: Optional[str] = None,
         namespace: Optional[str] = None,
+        jobs_access: Any = None,
         log_callback: Optional[Callable[[str], Awaitable[None]]] = None,
         session: Any = None,
         tool_call_id: Optional[str] = None,
@@ -305,6 +307,7 @@ class HfJobsTool:
         self.hf_token = hf_token
         self.api = HfApi(token=hf_token)
         self.namespace = namespace
+        self.jobs_access = jobs_access
         self.log_callback = log_callback
         self.session = session
         self.tool_call_id = tool_call_id
@@ -565,7 +568,7 @@ class HfJobsTool:
                 from agent.core import telemetry
                 submit_ts = await telemetry.record_hf_job_submit(
                     self.session, job,
-                    {**args, "hardware_flavor": flavor, "timeout": timeout_str},
+                    {**args, "hardware_flavor": flavor, "timeout": timeout_str, "namespace": self.namespace},
                     image=image, job_type=job_type,
                 )
 
@@ -1057,6 +1060,14 @@ HF_JOBS_TOOL_SPEC = {
                 "type": "object",
                 "description": "Environment variables {'KEY': 'VALUE'}. HF_TOKEN is auto-included.",
             },
+            "namespace": {
+                "type": "string",
+                "description": (
+                    "Optional namespace to run the job under. Must be your own Pro account "
+                    "or a paid org you belong to. If omitted, the tool prefers your personal "
+                    "account when eligible, otherwise the first eligible paid org."
+                ),
+            },
             "job_id": {
                 "type": "string",
                 "description": "Job ID. Required for: logs, inspect, cancel.",
@@ -1099,11 +1110,18 @@ async def hf_jobs_handler(
                 arguments = {**arguments, "script": content}
 
         hf_token = session.hf_token if session else None
-        namespace = os.environ.get("HF_NAMESPACE") or (HfApi(token=hf_token).whoami().get("name") if hf_token else None)
+        try:
+            namespace, jobs_access = await resolve_jobs_namespace(
+                hf_token or "",
+                arguments.get("namespace"),
+            )
+        except JobsAccessError as e:
+            return str(e), False
 
         tool = HfJobsTool(
             namespace=namespace,
             hf_token=hf_token,
+            jobs_access=jobs_access,
             log_callback=log_callback if session else None,
             session=session,
             tool_call_id=tool_call_id,

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -12,6 +12,8 @@ from typing import Any
 import httpx
 from fastapi import HTTPException, Request, status
 
+from agent.core.hf_access import fetch_whoami_v2, jobs_access_from_whoami
+
 logger = logging.getLogger(__name__)
 
 OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL", "https://huggingface.co")
@@ -80,41 +82,6 @@ def _user_from_info(user_info: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _normalize_plan(whoami: dict[str, Any]) -> str:
-    """Map an HF /api/whoami-v2 payload to one of: 'free' | 'pro' | 'org'.
-
-    The exact field shape in whoami-v2 isn't documented for our purposes,
-    so we try a handful of likely keys and fall back to 'free'. The first
-    call logs the raw shape at DEBUG (see `_fetch_user_plan`) so we can
-    pin the real key post-deploy.
-    """
-    plan_str = ""
-    for key in ("plan", "type", "accountType"):
-        val = whoami.get(key)
-        if isinstance(val, str) and val:
-            plan_str = val.lower()
-            break
-
-    if not plan_str:
-        if whoami.get("isPro") is True or whoami.get("is_pro") is True:
-            return "pro"
-
-    if "pro" in plan_str or "enterprise" in plan_str or "team" in plan_str:
-        return "pro"
-
-    # Org tier: anyone in a paid / enterprise org. We don't pay for this
-    # right now, but the "pro" cap applies identically.
-    orgs = whoami.get("orgs") or []
-    if isinstance(orgs, list):
-        for org in orgs:
-            if isinstance(org, dict):
-                org_plan = str(org.get("plan") or org.get("type") or "").lower()
-                if "pro" in org_plan or "enterprise" in org_plan or "team" in org_plan:
-                    return "org"
-
-    return "free"
-
-
 async def _fetch_user_plan(token: str) -> str:
     """Look up the user's HF plan via /api/whoami-v2.
 
@@ -123,19 +90,9 @@ async def _fetch_user_plan(token: str) -> str:
     grant the Pro cap than over-grant it on bad data.
     """
     global _WHOAMI_SHAPE_LOGGED
-    async with httpx.AsyncClient(timeout=5.0) as client:
-        try:
-            resp = await client.get(
-                f"{OPENID_PROVIDER_URL}/api/whoami-v2",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-            if resp.status_code != 200:
-                return "free"
-            whoami = resp.json()
-        except httpx.HTTPError:
-            return "free"
-        except ValueError:
-            return "free"
+    whoami = await fetch_whoami_v2(token)
+    if whoami is None:
+        return "free"
 
     if not _WHOAMI_SHAPE_LOGGED:
         _WHOAMI_SHAPE_LOGGED = True
@@ -149,7 +106,7 @@ async def _fetch_user_plan(token: str) -> str:
 
     if not isinstance(whoami, dict):
         return "free"
-    return _normalize_plan(whoami)
+    return jobs_access_from_whoami(whoami).plan
 
 
 async def _extract_user_from_token(token: str) -> dict[str, Any] | None:
@@ -245,5 +202,4 @@ async def require_huggingface_org_member(request: Request) -> bool:
     if not token:
         return False
     return await check_org_membership(token, HF_EMPLOYEE_ORG)
-
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -38,6 +38,7 @@ class ToolApproval(BaseModel):
     approved: bool
     feedback: str | None = None
     edited_script: str | None = None
+    namespace: str | None = None
 
 
 class ApprovalRequest(BaseModel):

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -213,9 +213,6 @@ async def _enforce_jobs_access_for_approvals(
             )
         return
 
-    if access.can_run_jobs:
-        return
-
     from agent.core import telemetry
     await telemetry.record_jobs_access_blocked(
         agent_session.session,

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -32,6 +32,7 @@ from session_manager import MAX_SESSIONS, AgentSession, SessionCapacityError, se
 
 import user_quotas
 
+from agent.core.hf_access import get_jobs_access
 from agent.core.llm_params import _resolve_llm_params
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,108 @@ async def _enforce_claude_quota(
         )
     await user_quotas.increment_claude(user_id)
     agent_session.claude_counted = True
+
+
+async def _enforce_jobs_access_for_approvals(
+    user: dict[str, Any],
+    agent_session: AgentSession,
+    approvals: list[dict[str, Any]],
+) -> None:
+    """Block approved hf_jobs tool calls when the user has no eligible jobs namespace."""
+    pending = agent_session.session.pending_approval or {}
+    tool_calls = pending.get("tool_calls") or []
+    if not tool_calls:
+        return
+
+    approved_ids = {
+        a.get("tool_call_id")
+        for a in approvals
+        if a.get("approved")
+    }
+    if not approved_ids:
+        return
+
+    hf_job_ids = [
+        tc.id for tc in tool_calls
+        if tc.id in approved_ids and tc.function.name == "hf_jobs"
+    ]
+    if not hf_job_ids:
+        return
+
+    token = agent_session.hf_token or agent_session.session.hf_token
+    if not token:
+        return
+
+    access = await get_jobs_access(token)
+    if access is None:
+        return
+
+    approval_map = {a.get("tool_call_id"): a for a in approvals}
+    if access.personal_can_run_jobs:
+        return
+
+    if access.paid_org_names:
+        invalid_namespace = [
+            tool_call_id
+            for tool_call_id in hf_job_ids
+            if (
+                approval_map.get(tool_call_id, {}).get("namespace")
+                and approval_map.get(tool_call_id, {}).get("namespace") not in access.paid_org_names
+            )
+        ]
+        if invalid_namespace:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "hf_jobs_invalid_namespace",
+                    "message": (
+                        "The selected jobs namespace is not one of your eligible paid organizations. "
+                        f"Allowed namespaces: {', '.join(access.paid_org_names)}"
+                    ),
+                },
+            )
+        missing_namespace = [
+            tool_call_id
+            for tool_call_id in hf_job_ids
+            if not approval_map.get(tool_call_id, {}).get("namespace")
+        ]
+        if missing_namespace:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "hf_jobs_namespace_required",
+                    "message": "Choose which paid organization should own this job run.",
+                    "plan": user.get("plan", "free"),
+                    "tool_call_ids": missing_namespace,
+                    "eligible_namespaces": access.paid_org_names,
+                },
+            )
+        return
+
+    if access.can_run_jobs:
+        return
+
+    from agent.core import telemetry
+    await telemetry.record_jobs_access_blocked(
+        agent_session.session,
+        tool_call_ids=hf_job_ids,
+        plan=user.get("plan", "free"),
+        eligible_namespaces=access.eligible_namespaces,
+    )
+
+    raise HTTPException(
+        status_code=402,
+        detail={
+            "error": "hf_jobs_upgrade_required",
+            "message": (
+                "Hugging Face Jobs are available only to Pro users and Team or Enterprise organizations. "
+                "Upgrade to Pro, or decline the job tool call so the agent can choose another path."
+            ),
+            "plan": user.get("plan", "free"),
+            "tool_call_ids": hf_job_ids,
+            "eligible_namespaces": access.eligible_namespaces,
+        },
+    )
 
 
 def _check_session_access(session_id: str, user: dict[str, Any]) -> None:
@@ -442,6 +545,27 @@ async def get_user_quota(user: dict = Depends(get_current_user)) -> dict:
     }
 
 
+@router.get("/user/jobs-access")
+async def get_jobs_access_info(request: Request, user: dict = Depends(get_current_user)) -> dict:
+    """Return whether the current token can run HF Jobs and under which namespaces."""
+    token = None
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+    if not token:
+        token = request.cookies.get("hf_access_token")
+    if not token:
+        token = os.environ.get("HF_TOKEN")
+
+    access = await get_jobs_access(token or "")
+    return {
+        "plan": user.get("plan", "free"),
+        "can_run_jobs": bool(access and (access.personal_can_run_jobs or access.paid_org_names)),
+        "eligible_namespaces": access.eligible_namespaces if access else [],
+        "default_namespace": access.default_namespace if access else None,
+    }
+
+
 @router.get("/sessions", response_model=list[SessionInfo])
 async def list_sessions(user: dict = Depends(get_current_user)) -> list[SessionInfo]:
     """List sessions belonging to the authenticated user."""
@@ -482,15 +606,20 @@ async def submit_approval(
 ) -> dict:
     """Submit tool approvals to a session. Only accessible by the session owner."""
     _check_session_access(request.session_id, user)
+    agent_session = session_manager.sessions.get(request.session_id)
+    if agent_session is None:
+        raise HTTPException(status_code=404, detail="Session not found or inactive")
     approvals = [
         {
             "tool_call_id": a.tool_call_id,
             "approved": a.approved,
             "feedback": a.feedback,
             "edited_script": a.edited_script,
+            "namespace": a.namespace,
         }
         for a in request.approvals
     ]
+    await _enforce_jobs_access_for_approvals(user, agent_session, approvals)
     success = await session_manager.submit_approval(request.session_id, approvals)
     if not success:
         raise HTTPException(status_code=404, detail="Session not found or inactive")
@@ -540,9 +669,11 @@ async def chat_sse(
                     "approved": a["approved"],
                     "feedback": a.get("feedback"),
                     "edited_script": a.get("edited_script"),
+                    "namespace": a.get("namespace"),
                 }
                 for a in approvals
             ]
+            await _enforce_jobs_access_for_approvals(user, agent_session, formatted)
             success = await session_manager.submit_approval(session_id, formatted)
         elif text is not None:
             success = await session_manager.submit_user_input(session_id, text)
@@ -554,12 +685,38 @@ async def chat_sse(
             broadcaster.unsubscribe(sub_id)
             raise HTTPException(status_code=404, detail="Session not found or inactive")
     except HTTPException:
+        broadcaster.unsubscribe(sub_id)
         raise
     except Exception:
         broadcaster.unsubscribe(sub_id)
         raise
 
     return _sse_response(broadcaster, event_queue, sub_id)
+
+
+@router.post("/pro-click/{session_id}")
+async def record_pro_click(
+    session_id: str,
+    body: dict,
+    user: dict = Depends(get_current_user),
+) -> dict:
+    """Record a click on a Pro upgrade CTA shown from inside a session."""
+    _check_session_access(session_id, user)
+    agent_session = session_manager.sessions.get(session_id)
+    if not agent_session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    from agent.core import telemetry
+    await telemetry.record_pro_cta_click(
+        agent_session.session,
+        source=str(body.get("source") or "unknown"),
+        target=str(body.get("target") or "pro_pricing"),
+    )
+    if agent_session.session.config.save_sessions:
+        agent_session.session.save_and_upload_detached(
+            agent_session.session.config.session_dataset_repo
+        )
+    return {"status": "ok"}
 
 
 # ---------------------------------------------------------------------------
@@ -729,5 +886,3 @@ async def submit_feedback(
             agent_session.session.config.session_dataset_repo
         )
     return {"status": "ok"}
-
-

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -6,6 +6,7 @@ import StopIcon from '@mui/icons-material/Stop';
 import { apiFetch } from '@/utils/api';
 import { useUserQuota } from '@/hooks/useUserQuota';
 import ClaudeCapDialog from '@/components/ClaudeCapDialog';
+import JobsUpgradeDialog from '@/components/JobsUpgradeDialog';
 import { useAgentStore } from '@/store/agentStore';
 import { CLAUDE_MODEL_PATH, FIRST_FREE_MODEL_PATH, isClaudePath } from '@/utils/model';
 
@@ -65,6 +66,8 @@ interface ChatInputProps {
   sessionId?: string;
   onSend: (text: string) => void;
   onStop?: () => void;
+  onDeclineBlockedJobs?: () => Promise<boolean>;
+  onContinueBlockedJobsWithNamespace?: (namespace: string) => Promise<boolean>;
   isProcessing?: boolean;
   disabled?: boolean;
   placeholder?: string;
@@ -73,7 +76,7 @@ interface ChatInputProps {
 const isClaudeModel = (m: ModelOption) => isClaudePath(m.modelPath);
 const firstFreeModel = () => MODEL_OPTIONS.find(m => !isClaudeModel(m)) ?? MODEL_OPTIONS[0];
 
-export default function ChatInput({ sessionId, onSend, onStop, isProcessing = false, disabled = false, placeholder = 'Ask anything...' }: ChatInputProps) {
+export default function ChatInput({ sessionId, onSend, onStop, onDeclineBlockedJobs, onContinueBlockedJobsWithNamespace, isProcessing = false, disabled = false, placeholder = 'Ask anything...' }: ChatInputProps) {
   const [input, setInput] = useState('');
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [selectedModelId, setSelectedModelId] = useState<string>(MODEL_OPTIONS[0].id);
@@ -86,6 +89,8 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   // the hook layer can flip it without threading props through.
   const claudeQuotaExhausted = useAgentStore((s) => s.claudeQuotaExhausted);
   const setClaudeQuotaExhausted = useAgentStore((s) => s.setClaudeQuotaExhausted);
+  const jobsUpgradeRequired = useAgentStore((s) => s.jobsUpgradeRequired);
+  const setJobsUpgradeRequired = useAgentStore((s) => s.setJobsUpgradeRequired);
   const lastSentRef = useRef<string>('');
 
   // Model is per-session: fetch this tab's current model every time the
@@ -196,6 +201,44 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
       }
     } catch { /* ignore */ }
   }, [sessionId, onSend, setClaudeQuotaExhausted]);
+
+  const handleClaudeUpgradeClick = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      await apiFetch(`/api/pro-click/${sessionId}`, {
+        method: 'POST',
+        body: JSON.stringify({ source: 'claude_cap_dialog', target: 'pro_pricing' }),
+      });
+    } catch {
+      /* tracking is best-effort */
+    }
+  }, [sessionId]);
+
+  const handleJobsUpgradeClose = useCallback(() => {
+    setJobsUpgradeRequired(null);
+  }, [setJobsUpgradeRequired]);
+
+  const handleJobsUpgradeClick = useCallback(async () => {
+    if (!sessionId || !jobsUpgradeRequired) return;
+    try {
+      await apiFetch(`/api/pro-click/${sessionId}`, {
+        method: 'POST',
+        body: JSON.stringify({ source: 'hf_jobs_upgrade_dialog', target: 'pro_pricing' }),
+      });
+    } catch {
+      /* tracking is best-effort */
+    }
+  }, [sessionId, jobsUpgradeRequired]);
+
+  const handleDeclineBlockedJobs = useCallback(async () => {
+    if (!onDeclineBlockedJobs) return;
+    await onDeclineBlockedJobs();
+  }, [onDeclineBlockedJobs]);
+
+  const handleContinueBlockedJobsWithNamespace = useCallback(async (namespace: string) => {
+    if (!onContinueBlockedJobsWithNamespace) return;
+    await onContinueBlockedJobsWithNamespace(namespace);
+  }, [onContinueBlockedJobsWithNamespace]);
 
   // Hide the chip until the user has actually burned quota — an unused
   // Opus session shouldn't populate a counter.
@@ -435,6 +478,17 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
           cap={quota?.claudeDailyCap ?? 1}
           onClose={handleCapDialogClose}
           onUseFreeModel={handleUseFreeModel}
+          onUpgrade={handleClaudeUpgradeClick}
+        />
+        <JobsUpgradeDialog
+          open={!!jobsUpgradeRequired}
+          mode={jobsUpgradeRequired?.mode || 'upgrade'}
+          message={jobsUpgradeRequired?.message || ''}
+          eligibleNamespaces={jobsUpgradeRequired?.eligibleNamespaces || []}
+          onClose={handleJobsUpgradeClose}
+          onUpgrade={handleJobsUpgradeClick}
+          onDecline={handleDeclineBlockedJobs}
+          onContinueWithNamespace={handleContinueBlockedJobsWithNamespace}
         />
       </Box>
     </Box>

--- a/frontend/src/components/ClaudeCapDialog.tsx
+++ b/frontend/src/components/ClaudeCapDialog.tsx
@@ -19,6 +19,7 @@ interface ClaudeCapDialogProps {
   cap: number;
   onClose: () => void;
   onUseFreeModel: () => void;
+  onUpgrade: () => void;
 }
 
 export default function ClaudeCapDialog({
@@ -27,6 +28,7 @@ export default function ClaudeCapDialog({
   cap,
   onClose,
   onUseFreeModel,
+  onUpgrade,
 }: ClaudeCapDialogProps) {
   // plan not surfaced in copy right now — Pro users see the same dialog and
   // can upgrade their org if they're also capped.
@@ -100,6 +102,7 @@ export default function ClaudeCapDialog({
           href={HF_PRICING_URL}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={onUpgrade}
           variant="contained"
           size="small"
           sx={{

--- a/frontend/src/components/JobsUpgradeDialog.tsx
+++ b/frontend/src/components/JobsUpgradeDialog.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
+
+const HF_PRICING_URL = 'https://huggingface.co/pricing';
+
+interface JobsUpgradeDialogProps {
+  open: boolean;
+  mode: 'upgrade' | 'namespace';
+  message: string;
+  eligibleNamespaces: string[];
+  onUpgrade: () => void;
+  onDecline: () => void;
+  onClose: () => void;
+  onContinueWithNamespace: (namespace: string) => void;
+}
+
+export default function JobsUpgradeDialog({
+  open,
+  mode,
+  message,
+  eligibleNamespaces,
+  onUpgrade,
+  onDecline,
+  onClose,
+  onContinueWithNamespace,
+}: JobsUpgradeDialogProps) {
+  const [selectedNamespace, setSelectedNamespace] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedNamespace(eligibleNamespaces[0] || '');
+  }, [open, eligibleNamespaces]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      slotProps={{
+        backdrop: { sx: { backgroundColor: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(4px)' } },
+      }}
+      PaperProps={{
+        sx: {
+          bgcolor: 'var(--panel)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-md)',
+          boxShadow: 'var(--shadow-1)',
+          maxWidth: 500,
+          mx: 2,
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{ color: 'var(--text)', fontWeight: 700, fontSize: '1rem', pt: 2.5, pb: 0, px: 3 }}
+      >
+        {mode === 'namespace' ? 'Choose the org for this job' : 'Jobs need Pro or a paid org'}
+      </DialogTitle>
+      <DialogContent sx={{ px: 3, pt: 1.25, pb: 0 }}>
+        <DialogContentText
+          sx={{ color: 'var(--muted-text)', fontSize: '0.85rem', lineHeight: 1.6 }}
+        >
+          {message}
+        </DialogContentText>
+        {eligibleNamespaces.length > 0 && (
+          <Box
+            sx={{
+              mt: 2,
+              p: 1.5,
+              borderRadius: '8px',
+              bgcolor: 'var(--accent-yellow-weak)',
+              border: '1px solid var(--border)',
+            }}
+          >
+            <Typography
+              variant="caption"
+              sx={{
+                display: 'block',
+                fontWeight: 700,
+                color: 'var(--text)',
+                fontSize: '0.78rem',
+                mb: 1,
+                letterSpacing: '0.02em',
+              }}
+            >
+              Eligible namespaces
+            </Typography>
+            {mode === 'namespace' ? (
+              <FormControl fullWidth size="small">
+                <InputLabel id="jobs-namespace-label">Organization</InputLabel>
+                <Select
+                  labelId="jobs-namespace-label"
+                  value={selectedNamespace}
+                  label="Organization"
+                  onChange={(e) => setSelectedNamespace(String(e.target.value))}
+                >
+                  {eligibleNamespaces.map((namespace) => (
+                    <MenuItem key={namespace} value={namespace}>
+                      {namespace}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            ) : (
+              <Typography
+                variant="caption"
+                sx={{ display: 'block', color: 'var(--muted-text)', fontSize: '0.78rem', lineHeight: 1.55 }}
+              >
+                {eligibleNamespaces.join(', ')}
+              </Typography>
+            )}
+          </Box>
+        )}
+        <Typography
+          variant="caption"
+          sx={{ display: 'block', mt: 2, color: 'var(--muted-text)', fontSize: '0.78rem', lineHeight: 1.55 }}
+        >
+          If you decline, the agent will have to find another way forward without `hf_jobs`.
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 2, gap: 1 }}>
+        {mode === 'namespace' ? (
+          <Button
+            onClick={() => onContinueWithNamespace(selectedNamespace)}
+            disabled={!selectedNamespace}
+            variant="contained"
+            size="small"
+            sx={{
+              fontSize: '0.82rem',
+              px: 2.5,
+              bgcolor: 'var(--accent-yellow)',
+              color: '#000',
+              textTransform: 'none',
+              fontWeight: 700,
+              boxShadow: 'none',
+              '&:hover': { bgcolor: '#FFB340', boxShadow: 'none' },
+            }}
+          >
+            Run under selected org
+          </Button>
+        ) : (
+          <Button
+            component="a"
+            href={HF_PRICING_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onUpgrade}
+            variant="contained"
+            size="small"
+            sx={{
+              fontSize: '0.82rem',
+              px: 2.5,
+              bgcolor: 'var(--accent-yellow)',
+              color: '#000',
+              textTransform: 'none',
+              fontWeight: 700,
+              boxShadow: 'none',
+              '&:hover': { bgcolor: '#FFB340', boxShadow: 'none' },
+            }}
+          >
+            Upgrade to Pro
+          </Button>
+        )}
+        <Button
+          onClick={onDecline}
+          size="small"
+          sx={{
+            color: 'var(--muted-text)',
+            fontSize: '0.82rem',
+            px: 2,
+            textTransform: 'none',
+            '&:hover': { bgcolor: 'var(--hover-bg)' },
+          }}
+        >
+          Decline tool call
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -26,7 +26,7 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
   const { updateSessionTitle, sessions } = useSessionStore();
   const isExpired = sessions.find((s) => s.id === sessionId)?.expired === true;
 
-  const { messages, sendMessage, stop, status, undoLastTurn, editAndRegenerate, approveTools } = useAgentChat({
+  const { messages, sendMessage, stop, status, undoLastTurn, editAndRegenerate, approveTools, declineBlockedJobs, continueBlockedJobsWithNamespace } = useAgentChat({
     sessionId,
     isActive,
     onReady: () => logger.log(`Session ${sessionId} ready`),
@@ -114,6 +114,8 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
           sessionId={sessionId}
           onSend={handleSendMessage}
           onStop={handleStop}
+          onDeclineBlockedJobs={declineBlockedJobs}
+          onContinueBlockedJobsWithNamespace={continueBlockedJobsWithNamespace}
           isProcessing={busy}
           disabled={!isConnected || activityStatus.type === 'waiting-approval'}
           placeholder={

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -330,6 +330,49 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
     messages: UIMessage[];
   }>({ setMessages: null, messages: [] });
 
+  const hydrateFromBackend = useCallback(async () => {
+    try {
+      const [msgsRes, infoRes] = await Promise.all([
+        apiFetch(`/api/session/${sessionId}/messages`),
+        apiFetch(`/api/session/${sessionId}`),
+      ]);
+      if (!msgsRes.ok) return null;
+      const data = await msgsRes.json();
+      if (!Array.isArray(data) || data.length === 0) return null;
+
+      saveBackendMessages(sessionId, data);
+
+      let pendingIds: Set<string> | undefined;
+      let info: Record<string, unknown> | null = null;
+      if (infoRes.ok) {
+        info = await infoRes.json();
+        const pendingApproval = info?.pending_approval;
+        if (pendingApproval && Array.isArray(pendingApproval)) {
+          pendingIds = new Set(
+            pendingApproval.map((t: { tool_call_id: string }) => t.tool_call_id),
+          );
+          if (pendingIds.size > 0) {
+            setNeedsAttention(sessionId, true);
+          }
+        }
+      }
+
+      const uiMsgs = llmMessagesToUIMessages(data, pendingIds, chatActionsRef.current.messages);
+      if (uiMsgs.length > 0) {
+        chatActionsRef.current.setMessages?.(uiMsgs);
+        saveMessages(sessionId, uiMsgs);
+      }
+
+      if (pendingIds && pendingIds.size > 0) {
+        updateSession(sessionId, { activityStatus: { type: 'waiting-approval' }, isProcessing: false });
+      }
+
+      return { data, pendingIds, info };
+    } catch {
+      return null;
+    }
+  }, [sessionId, setNeedsAttention]);
+
   // -- useChat from Vercel AI SDK -----------------------------------------
   const chat = useChat({
     id: sessionId,
@@ -351,6 +394,56 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
       if (error.message === 'CLAUDE_QUOTA_EXHAUSTED') {
         if (isActiveRef.current) {
           useAgentStore.getState().setClaudeQuotaExhausted(true);
+        }
+        return;
+      }
+      if (error.message === 'HF_JOBS_UPGRADE_REQUIRED') {
+        const typed = error as Error & {
+          detail?: Record<string, unknown>;
+          approvals?: Array<{
+            tool_call_id: string;
+            approved: boolean;
+            feedback?: string | null;
+            edited_script?: string | null;
+          }>;
+        };
+        void hydrateFromBackend();
+        if (isActiveRef.current) {
+          useAgentStore.getState().setJobsUpgradeRequired({
+            approvals: typed.approvals || [],
+            toolCallIds: (typed.detail?.tool_call_ids as string[]) || [],
+            message: String(
+              typed.detail?.message
+                || 'Hugging Face Jobs are available only to Pro users and Team or Enterprise organizations.',
+            ),
+            eligibleNamespaces: (typed.detail?.eligible_namespaces as string[]) || [],
+            plan: ((typed.detail?.plan as 'free' | 'pro' | 'org') || 'free'),
+            mode: 'upgrade',
+          });
+        }
+        return;
+      }
+      if (error.message === 'HF_JOBS_NAMESPACE_REQUIRED') {
+        const typed = error as Error & {
+          detail?: Record<string, unknown>;
+          approvals?: Array<{
+            tool_call_id: string;
+            approved: boolean;
+            feedback?: string | null;
+            edited_script?: string | null;
+            namespace?: string | null;
+          }>;
+        };
+        void hydrateFromBackend();
+        if (isActiveRef.current) {
+          useAgentStore.getState().setJobsUpgradeRequired({
+            approvals: typed.approvals || [],
+            toolCallIds: (typed.detail?.tool_call_ids as string[]) || [],
+            message: String(typed.detail?.message || 'Choose which organization should own this job run.'),
+            eligibleNamespaces: (typed.detail?.eligible_namespaces as string[]) || [],
+            plan: ((typed.detail?.plan as 'free' | 'pro' | 'org') || 'free'),
+            mode: 'namespace',
+          });
         }
         return;
       }
@@ -672,11 +765,14 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
 
   // -- Approve tools ------------------------------------------------------
   const approveTools = useCallback(
-    async (approvals: Array<{ tool_call_id: string; approved: boolean; feedback?: string | null; edited_script?: string | null }>) => {
+    async (approvals: Array<{ tool_call_id: string; approved: boolean; feedback?: string | null; edited_script?: string | null; namespace?: string | null }>) => {
       // Store edited scripts so the transport can read them when sendMessages is called
       for (const a of approvals) {
         if (a.edited_script) {
           useAgentStore.getState().setEditedScript(a.tool_call_id, a.edited_script);
+        }
+        if (a.namespace) {
+          useAgentStore.getState().setApprovalNamespace(a.tool_call_id, a.namespace);
         }
       }
 
@@ -706,6 +802,37 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
     },
     [sessionId, chat, updateSession, setNeedsAttention],
   );
+
+  const declineBlockedJobs = useCallback(async () => {
+    const blocked = useAgentStore.getState().jobsUpgradeRequired;
+    if (!blocked) return false;
+
+    const approvals = blocked.approvals.map((approval) => ({
+      ...approval,
+      approved: blocked.toolCallIds.includes(approval.tool_call_id) ? false : approval.approved,
+      feedback: blocked.toolCallIds.includes(approval.tool_call_id)
+        ? 'Rejected because this account cannot launch Hugging Face Jobs.'
+        : approval.feedback,
+    }));
+
+    useAgentStore.getState().setJobsUpgradeRequired(null);
+    return approveTools(approvals);
+  }, [approveTools]);
+
+  const continueBlockedJobsWithNamespace = useCallback(async (namespace: string) => {
+    const blocked = useAgentStore.getState().jobsUpgradeRequired;
+    if (!blocked) return false;
+
+    const approvals = blocked.approvals.map((approval) => ({
+      ...approval,
+      namespace: blocked.toolCallIds.includes(approval.tool_call_id)
+        ? namespace
+        : approval.namespace,
+    }));
+
+    useAgentStore.getState().setJobsUpgradeRequired(null);
+    return approveTools(approvals);
+  }, [approveTools]);
 
   // -- Stop (interrupt backend agent loop, keep SSE open for events) --------
   const stop = useCallback(() => {
@@ -763,5 +890,7 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
     undoLastTurn,
     editAndRegenerate,
     approveTools,
+    declineBlockedJobs,
+    continueBlockedJobsWithNamespace,
   };
 }

--- a/frontend/src/lib/sse-chat-transport.ts
+++ b/frontend/src/lib/sse-chat-transport.ts
@@ -320,11 +320,13 @@ export class SSEChatTransport implements ChatTransport<UIMessage> {
         const approved = p.approval?.approved ?? true;
         // Get edited script from agentStore if available
         const editedScript = useAgentStore.getState().getEditedScript(p.toolCallId);
+        const namespace = useAgentStore.getState().getApprovalNamespace(p.toolCallId);
         return {
           tool_call_id: p.toolCallId,
           approved,
           feedback: approved ? null : (p.approval?.reason || 'Rejected by user'),
           edited_script: editedScript ?? null,
+          namespace: namespace ?? null,
         };
       }).filter(Boolean);
       body = { approvals };
@@ -361,6 +363,30 @@ export class SSEChatTransport implements ChatTransport<UIMessage> {
       // for useAgentChat's onError handler, which surfaces the cap dialog
       // instead of a generic error banner.
       throw new Error('CLAUDE_QUOTA_EXHAUSTED');
+    }
+    if (response.status === 402) {
+      const payload = await response.json().catch(() => null);
+      if (payload?.detail?.error === 'hf_jobs_upgrade_required') {
+        const err = new Error('HF_JOBS_UPGRADE_REQUIRED') as Error & {
+          detail?: Record<string, unknown>;
+          approvals?: Array<Record<string, unknown>>;
+        };
+        err.detail = payload.detail as Record<string, unknown>;
+        err.approvals = (body.approvals as Array<Record<string, unknown>> | undefined) || [];
+        throw err;
+      }
+    }
+    if (response.status === 409) {
+      const payload = await response.json().catch(() => null);
+      if (payload?.detail?.error === 'hf_jobs_namespace_required') {
+        const err = new Error('HF_JOBS_NAMESPACE_REQUIRED') as Error & {
+          detail?: Record<string, unknown>;
+          approvals?: Array<Record<string, unknown>>;
+        };
+        err.detail = payload.detail as Record<string, unknown>;
+        err.approvals = (body.approvals as Array<Record<string, unknown>> | undefined) || [];
+        throw err;
+      }
     }
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'Request failed');

--- a/frontend/src/store/agentStore.ts
+++ b/frontend/src/store/agentStore.ts
@@ -45,6 +45,21 @@ export interface LLMHealthError {
   model: string;
 }
 
+export interface JobsUpgradeState {
+  approvals: Array<{
+    tool_call_id: string;
+    approved: boolean;
+    feedback?: string | null;
+    edited_script?: string | null;
+    namespace?: string | null;
+  }>;
+  toolCallIds: string[];
+  message: string;
+  eligibleNamespaces: string[];
+  plan: 'free' | 'pro' | 'org';
+  mode: 'upgrade' | 'namespace';
+}
+
 export type ActivityStatus =
   | { type: 'idle' }
   | { type: 'thinking' }
@@ -110,6 +125,7 @@ interface AgentStore {
   llmHealthError: LLMHealthError | null;
   /** Set when a Claude-send hits the daily quota — ChatInput opens the cap dialog in response. */
   claudeQuotaExhausted: boolean;
+  jobsUpgradeRequired: JobsUpgradeState | null;
 
   // Right panel (single-artifact pattern)
   panelData: PanelData | null;
@@ -121,6 +137,9 @@ interface AgentStore {
 
   // Edited scripts (tool_call_id -> edited content)
   editedScripts: Record<string, string>;
+
+  // Namespace overrides chosen for hf_jobs approvals (tool_call_id -> namespace)
+  approvalNamespaces: Record<string, string>;
 
   // Job URLs (tool_call_id -> job URL) for HF jobs
   jobUrls: Record<string, string>;
@@ -156,6 +175,7 @@ interface AgentStore {
   setError: (error: string | null) => void;
   setLlmHealthError: (error: LLMHealthError | null) => void;
   setClaudeQuotaExhausted: (exhausted: boolean) => void;
+  setJobsUpgradeRequired: (state: JobsUpgradeState | null) => void;
 
   setPanel: (data: PanelData, view?: PanelView, editable?: boolean) => void;
   setPanelView: (view: PanelView) => void;
@@ -169,6 +189,10 @@ interface AgentStore {
   setEditedScript: (toolCallId: string, content: string) => void;
   getEditedScript: (toolCallId: string) => string | undefined;
   clearEditedScripts: () => void;
+
+  setApprovalNamespace: (toolCallId: string, namespace: string) => void;
+  getApprovalNamespace: (toolCallId: string) => string | undefined;
+  clearApprovalNamespaces: () => void;
 
   setJobUrl: (toolCallId: string, jobUrl: string) => void;
   getJobUrl: (toolCallId: string) => string | undefined;
@@ -251,6 +275,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
   error: null,
   llmHealthError: null,
   claudeQuotaExhausted: false,
+  jobsUpgradeRequired: null,
 
   panelData: null,
   panelView: 'script',
@@ -259,6 +284,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
   plan: [],
 
   editedScripts: {},
+  approvalNamespaces: {},
   jobUrls: {},
   jobStatuses: {},
   toolErrors: loadToolErrors(),
@@ -363,6 +389,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
   setError: (error) => set({ error }),
   setLlmHealthError: (error) => set({ llmHealthError: error }),
   setClaudeQuotaExhausted: (exhausted) => set({ claudeQuotaExhausted: exhausted }),
+  setJobsUpgradeRequired: (state) => set({ jobsUpgradeRequired: state }),
 
   // ── Panel (single-artifact) ───────────────────────────────────────
   // Each setter also patches the active session's snapshot so that
@@ -427,6 +454,16 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
   getEditedScript: (toolCallId) => get().editedScripts[toolCallId],
 
   clearEditedScripts: () => set({ editedScripts: {} }),
+
+  setApprovalNamespace: (toolCallId, namespace) => {
+    set((state) => ({
+      approvalNamespaces: { ...state.approvalNamespaces, [toolCallId]: namespace },
+    }));
+  },
+
+  getApprovalNamespace: (toolCallId) => get().approvalNamespaces[toolCallId],
+
+  clearApprovalNamespaces: () => set({ approvalNamespaces: {} }),
 
   // ── Job URLs ────────────────────────────────────────────────────────
 

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -27,6 +27,7 @@ export interface ToolApproval {
   tool_call_id: string;
   approved: boolean;
   feedback?: string | null;
+  namespace?: string | null;
 }
 
 export interface User {

--- a/scripts/build_kpis.py
+++ b/scripts/build_kpis.py
@@ -44,7 +44,8 @@ re-running the same hour overwrites.
     regenerate_rate     — sessions with any `undo_complete` event / sessions
     time_to_first_action_s_p50 / _p95  — from session_start to first tool_call
     thumbs_up / thumbs_down
-    hf_jobs_submitted / _succeeded
+    hf_jobs_submitted / _succeeded / _blocked
+    pro_cta_clicks
     gpu_hours_by_flavor_json   — JSON-serialised {flavor: gpu-hours}
 
 ================================================================================
@@ -210,7 +211,8 @@ def _session_metrics(session: dict) -> dict:
         "tool_calls_total": 0, "tool_calls_success": 0,
         "failures": 0, "regenerate_sessions": 0,
         "thumbs_up": 0, "thumbs_down": 0,
-        "hf_jobs_submitted": 0, "hf_jobs_succeeded": 0,
+        "hf_jobs_submitted": 0, "hf_jobs_succeeded": 0, "hf_jobs_blocked": 0,
+        "pro_cta_clicks": 0,
         "first_tool_s": -1,
     }
     events = session.get("events") or []
@@ -229,8 +231,11 @@ def _session_metrics(session: dict) -> dict:
     gpu_hours_by_flavor: dict[str, float] = defaultdict(float)
     jobs_submitted = 0
     jobs_succeeded = 0
+    jobs_blocked = 0
     thumbs_up = 0
     thumbs_down = 0
+    pro_cta_clicks = 0
+    pro_cta_by_source: dict[str, int] = defaultdict(int)
 
     start_dt = _parse_ts(session_start)
 
@@ -283,6 +288,14 @@ def _session_metrics(session: dict) -> dict:
             if status in ("completed", "succeeded", "success"):
                 jobs_succeeded += 1
 
+        elif et == "jobs_access_blocked":
+            jobs_blocked += 1
+
+        elif et == "pro_cta_click":
+            pro_cta_clicks += 1
+            source = str(data.get("source") or "unknown")
+            pro_cta_by_source[source] += 1
+
     out["tool_calls_total"] = tool_total
     out["tool_calls_success"] = tool_success
     out["failures"] = 1 if had_error else 0
@@ -291,8 +304,11 @@ def _session_metrics(session: dict) -> dict:
     out["thumbs_down"] = thumbs_down
     out["hf_jobs_submitted"] = jobs_submitted
     out["hf_jobs_succeeded"] = jobs_succeeded
+    out["hf_jobs_blocked"] = jobs_blocked
+    out["pro_cta_clicks"] = pro_cta_clicks
     out["first_tool_s"] = first_tool_ts if first_tool_ts is not None else -1
     out["_gpu_hours_by_flavor"] = dict(gpu_hours_by_flavor)
+    out["_pro_cta_by_source"] = dict(pro_cta_by_source)
     out["_user"] = session.get("user_id") or session.get("session_id")
     return dict(out)
 
@@ -301,9 +317,12 @@ def _aggregate(per_session: list[dict]) -> dict:
     """Collapse a bucket's worth of session rollups into the final KPI row."""
     ttfa_values = [s["first_tool_s"] for s in per_session if s.get("first_tool_s", -1) >= 0]
     gpu_hours: dict[str, float] = defaultdict(float)
+    pro_cta_by_source: dict[str, int] = defaultdict(int)
     for s in per_session:
         for f, h in (s.get("_gpu_hours_by_flavor") or {}).items():
             gpu_hours[f] += h
+        for source, count in (s.get("_pro_cta_by_source") or {}).items():
+            pro_cta_by_source[source] += int(count)
 
     total_sessions = sum(s["sessions"] for s in per_session)
     total_turns = sum(s["turns"] for s in per_session)
@@ -340,7 +359,10 @@ def _aggregate(per_session: list[dict]) -> dict:
         "thumbs_down": int(sum(s["thumbs_down"] for s in per_session)),
         "hf_jobs_submitted": int(sum(s["hf_jobs_submitted"] for s in per_session)),
         "hf_jobs_succeeded": int(sum(s["hf_jobs_succeeded"] for s in per_session)),
+        "hf_jobs_blocked": int(sum(s["hf_jobs_blocked"] for s in per_session)),
+        "pro_cta_clicks": int(sum(s["pro_cta_clicks"] for s in per_session)),
         "gpu_hours_by_flavor_json": json.dumps(dict(gpu_hours), sort_keys=True),
+        "pro_cta_by_source_json": json.dumps(dict(pro_cta_by_source), sort_keys=True),
     }
 
 

--- a/tests/unit/test_build_kpis.py
+++ b/tests/unit/test_build_kpis.py
@@ -88,6 +88,22 @@ def test_hf_job_gpu_hours():
     assert abs(m["_gpu_hours_by_flavor"]["a100-large"] - 1.0) < 1e-6
 
 
+def test_hf_job_blocked_and_pro_clicks_are_counted():
+    mod = _load()
+    events = [
+        _ev("jobs_access_blocked", {"tool_call_ids": ["tc1"], "plan": "free"}),
+        _ev("pro_cta_click", {"source": "hf_jobs_upgrade_dialog"}),
+        _ev("pro_cta_click", {"source": "claude_cap_dialog"}),
+    ]
+    m = mod._session_metrics(_session(events))
+    assert m["hf_jobs_blocked"] == 1
+    assert m["pro_cta_clicks"] == 2
+    assert m["_pro_cta_by_source"] == {
+        "hf_jobs_upgrade_dialog": 1,
+        "claude_cap_dialog": 1,
+    }
+
+
 def test_feedback_counts():
     mod = _load()
     events = [
@@ -118,6 +134,22 @@ def test_aggregate_day_cache_hit_and_users():
     # 500 / (500 + 300) = 0.625
     assert abs(row["cache_hit_ratio"] - 0.625) < 1e-9
     assert abs(row["cost_usd"] - 1.5) < 1e-9
+
+
+def test_aggregate_day_sums_pro_click_sources():
+    mod = _load()
+    s1 = mod._session_metrics(_session([
+        _ev("pro_cta_click", {"source": "hf_jobs_upgrade_dialog"}),
+        _ev("pro_cta_click", {"source": "hf_jobs_upgrade_dialog"}),
+    ], user_id="u1"))
+    s2 = mod._session_metrics(_session([
+        _ev("pro_cta_click", {"source": "claude_cap_dialog"}),
+    ], user_id="u2"))
+    row = mod._aggregate_day([s1, s2])
+    assert row["pro_cta_clicks"] == 3
+    assert row["pro_cta_by_source_json"] == (
+        '{"claude_cap_dialog": 1, "hf_jobs_upgrade_dialog": 2}'
+    )
 
 
 def test_failure_and_regenerate_rates():

--- a/tests/unit/test_hf_access.py
+++ b/tests/unit/test_hf_access.py
@@ -1,0 +1,39 @@
+from agent.core.hf_access import jobs_access_from_whoami
+
+
+def test_personal_pro_prefers_username_namespace():
+    access = jobs_access_from_whoami({
+        "name": "alice",
+        "plan": "pro",
+        "orgs": [],
+    })
+    assert access.plan == "pro"
+    assert access.eligible_namespaces == ["alice"]
+    assert access.default_namespace == "alice"
+
+
+def test_free_user_with_paid_org_uses_org_namespace():
+    access = jobs_access_from_whoami({
+        "name": "alice",
+        "plan": "free",
+        "orgs": [
+            {"name": "team-a", "plan": "team"},
+            {"name": "oss-friends", "plan": "free"},
+        ],
+    })
+    assert access.plan == "org"
+    assert access.personal_can_run_jobs is False
+    assert access.eligible_namespaces == ["team-a"]
+    assert access.default_namespace is None
+
+
+def test_free_user_without_paid_org_cannot_run_jobs():
+    access = jobs_access_from_whoami({
+        "name": "alice",
+        "plan": "free",
+        "orgs": [{"name": "community", "plan": "free"}],
+    })
+    assert access.plan == "free"
+    assert access.can_run_jobs is False
+    assert access.eligible_namespaces == []
+    assert access.default_namespace is None


### PR DESCRIPTION
## Summary
- run `hf_jobs` under the caller's own Pro account or a paid org they belong to instead of any stale shared-org assumption
- if a free user has paid orgs, require them to choose the org from a dropdown before continuing the approved job tool call
- if the user has no eligible jobs namespace, show an upgrade-or-decline dialog and let the agent continue without `hf_jobs` when declined
- preserve the existing org-join onboarding gate for frontend funnel observability
- record jobs gating and Pro CTA clicks in session telemetry and KPI rollups, while preserving correct `hf_jobs` attribution

## Testing
- `python -m compileall agent backend scripts`
- `./frontend/node_modules/.bin/tsc -p frontend/tsconfig.json --noEmit`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with pytest-asyncio python -m pytest -q`
