### PR TITLE
fix(packaging): ship configs/ directory so non-editable installs work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ include = ["agent*", "configs"]
 
 [tool.setuptools.package-data]
 configs = ["*.json"]
+# Agent data files: system prompts loaded by ContextManager._load_system_prompt
+# at runtime (`<site-packages>/agent/prompts/system_prompt_v3.yaml`), plus the
+# package README. Without these, headless_main hangs forever — submission_loop
+# crashes with FileNotFoundError but headless_main doesn't check agent_task.done()
+# and just keeps awaiting the "ready" event_queue item that will never come.
+agent = ["README.md", "prompts/*.yaml"]
 
 [tool.uv]
 package = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,14 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["agent*"]
+# `configs` ships the JSON files loaded by agent.main.CLI_CONFIG_PATH at
+# runtime (resolves to <site-packages>/configs/cli_agent_config.json).
+# Without it, `uv tool install` / `pip install` produce a broken install
+# that imports fine but crashes at startup with FileNotFoundError.
+include = ["agent*", "configs"]
+
+[tool.setuptools.package-data]
+configs = ["*.json"]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
## Summary

Non-editable installs of ml-intern (\`uv tool install\`, \`pip install\` without \`-e\`) crash at startup because the \`configs/\` directory next to the \`agent/\` package never gets copied into \`site-packages/\`.

## Root cause

\`agent.main.CLI_CONFIG_PATH\` resolves to \`<site-packages>/configs/cli_agent_config.json\` via:

\`\`\`python
CLI_CONFIG_PATH = Path(__file__).parent.parent / "configs" / "cli_agent_config.json"
\`\`\`

But \`[tool.setuptools.packages.find]\` only included \`"agent*"\`, so the build skipped \`configs/\`. Editable installs worked by accident — they reference the source tree directly, so they found \`configs/\` at the repo root.

## Repro (before this patch)

\`\`\`bash
uv tool install --from . ml-intern --reinstall --force
ml-intern "hi"
# → FileNotFoundError: [Errno 2] No such file or directory:
#   '<...>/site-packages/configs/cli_agent_config.json'
\`\`\`

## Fix

Make \`configs/\` a real package (empty \`__init__.py\`) and ship its JSON via \`[tool.setuptools.package-data]\`. Two-line change.

\`\`\`toml
[tool.setuptools.packages.find]
include = ["agent*", "configs"]

[tool.setuptools.package-data]
configs = ["*.json"]
\`\`\`

## Verified

\`\`\`bash
rm -rf <site-packages>/configs
uv tool install --from . ml-intern --reinstall --force
ls <site-packages>/configs/
# __init__.py  cli_agent_config.json  frontend_agent_config.json
ml-intern --help    # works
\`\`\`

## Test plan

- [x] Wipe installed configs, reinstall with new pyproject, confirm configs land in site-packages
- [x] \`ml-intern --help\` launches without FileNotFoundError
- [ ] Maintainers verify same behaviour in their CI / Bedrock paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)