### PR TITLE
ci: stop Claude PR review failing with 'Invalid OIDC token'

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,5 +62,12 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Bypass the OIDC -> Claude GitHub App token exchange. That exchange
+          # rejects OIDC tokens minted for pull_request_target events with
+          # "401 Invalid OIDC token", which broke every review after the switch
+          # away from pull_request. Using the workflow's GITHUB_TOKEN works for
+          # both same-repo and fork PRs; comments post as github-actions[bot]
+          # instead of claude[bot], which is the documented trade-off.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           prompt: ${{ steps.compose.outputs.prompt }}


### PR DESCRIPTION
## What's broken

Every Claude PR review since #123 merged has failed with:

```
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Operation failed after 3 attempts
##[error]Action failed with error: Invalid OIDC token
```

Quick scan of recent runs (`gh run list --workflow=claude-review.yml`): every \`pull_request_target\` run is \`failure\` (or \`cancelled\`). The last green runs were on \`pull_request\` before #123.

## Root cause

\`anthropics/claude-code-action@v1\` defaults to authenticating via OIDC: it asks the runner for an OIDC token (\`id-token: write\`), then POSTs it to Anthropic's GitHub App endpoint to swap it for a short-lived installation token. That endpoint **rejects OIDC tokens minted for \`pull_request_target\` events** — the OIDC succeeds, the exchange does not. Switching the trigger in #123 was what broke it; the action was always green on \`pull_request\`.

## Fix

Pass \`github_token: \${{ secrets.GITHUB_TOKEN }}\` to the action. This is the documented override (see \`docs/setup.md\` 'Custom App' section): when \`github_token\` is set, the action uses it directly and skips the OIDC exchange entirely. \`GITHUB_TOKEN\` is available on \`pull_request_target\` (including for fork PRs) with the workflow's declared permissions, so reviews work for **all** PRs — same-repo and forks alike.

Trade-off: comments post as \`github-actions[bot]\` instead of \`claude[bot]\`. Acceptable cost for reviews actually running.

## Verification caveat

\`pull_request_target\` always uses the workflow file from the **base branch**, so this PR will itself trigger the *old* (broken) workflow — that failure is expected and not a signal about the fix. The fix takes effect on the **next** PR after this one merges to main.

## Test plan
- [ ] Merge to main
- [ ] Open a follow-up PR (any small change), confirm the Claude review job goes green and posts a review
- [ ] Confirm a fork PR also runs and posts (next external contributor PR)