### PR TITLE
feat(session): include user_id + total_cost_usd in trajectory dump

### DIFF
--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -79,8 +79,10 @@ class Session:
         hf_token: str | None = None,
         local_mode: bool = False,
         stream: bool = True,
+        user_id: str | None = None,
     ):
         self.hf_token: Optional[str] = hf_token
+        self.user_id: Optional[str] = user_id
         self.tool_router = tool_router
         self.stream = stream
         tool_specs = tool_router.get_tool_specs_for_llm() if tool_router else []
@@ -199,11 +201,21 @@ class Session:
                 tools = self.tool_router.get_tool_specs_for_llm() or []
             except Exception:
                 tools = []
+        # Sum per-call cost from llm_call events so analyzers don't have to
+        # walk the events array themselves. Each `llm_call` event already
+        # carries cost_usd from `agent.core.telemetry.record_llm_call`.
+        total_cost_usd = sum(
+            float((e.get("data") or {}).get("cost_usd") or 0.0)
+            for e in self.logged_events
+            if e.get("event_type") == "llm_call"
+        )
         return {
             "session_id": self.session_id,
+            "user_id": self.user_id,
             "session_start_time": self.session_start_time,
             "session_end_time": datetime.now().isoformat(),
             "model_name": self.config.model_name,
+            "total_cost_usd": total_cost_usd,
             "messages": [msg.model_dump() for msg in self.context_manager.items],
             "events": self.logged_events,
             "tools": tools,

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -192,7 +192,7 @@ class SessionManager:
                 session_config.model_name = model
             session = Session(
                 event_queue, config=session_config, tool_router=tool_router,
-                hf_token=hf_token,
+                hf_token=hf_token, user_id=user_id,
             )
             t1 = _time.monotonic()
             logger.info(f"Session initialized in {t1 - t0:.2f}s")


### PR DESCRIPTION
## Summary

Add `user_id` (the HF username from OAuth, already stored on `AgentSession`) to the `Session` object and propagate it into the trajectory JSON that `save_trajectory_local()` writes and the session uploader sends to the dataset. Also surface a `total_cost_usd` aggregate summed from existing `llm_call` events.

## Why

Today the session dataset exposes \`session_id\` but no user binding, so \$-spend per HF user cannot be derived from the dataset alone. The only fallback is correlating timestamps between Hub access logs and the dataset / Bedrock invocation logs — that approach is noisy and breaks completely for users with long-lived browser tabs (their JWT polls inflate their attribution score independently of actual prompts).

With \`user_id\` in the dump, per-user spend analysis becomes a one-line aggregate over the dataset.

## Changes

- \`agent/core/session.py\`
  - \`Session.__init__\` accepts \`user_id: str | None = None\` and stores it
  - \`get_trajectory()\` includes \`user_id\` and a \`total_cost_usd\` aggregate (summed from the \`llm_call\` events already emitted by \`agent.core.telemetry.record_llm_call\`)
- \`backend/session_manager.py\`: pass \`user_id=user_id\` when constructing \`Session\` in \`SessionManager.create_session\`. \`AgentSession.user_id\` is already populated from the OAuth context, no other plumbing needed.

Total diff: 2 files, +13 / -1.

## Test plan

- [ ] Session uploaded to the dataset shows non-null \`user_id\` for OAuth-authenticated sessions, \`null\` (or \`"dev"\`) for CLI / dev mode
- [ ] \`total_cost_usd\` matches the sum of \`cost_usd\` across the session's \`llm_call\` events
- [ ] Existing fields (\`session_id\`, \`session_start_time\`, \`messages\`, \`events\`, \`tools\`) unchanged

## Privacy note

\`user_id\` is the public HF username (already in HF audit logs and in the access logs that ship to ES). Cost is per-session aggregate. No PII beyond what's already discoverable from the user's Space activity.