### PR TITLE
Use huggingface_hub.get_token() to resolve HF token

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -70,25 +70,9 @@ def _safe_get_args(arguments: dict) -> dict:
 
 
 def _get_hf_token() -> str | None:
-    """Get HF token from environment, huggingface_hub API, or cached token file."""
-    token = os.environ.get("HF_TOKEN")
-    if token:
-        return token
-    try:
-        from huggingface_hub import HfApi
-        api = HfApi()
-        token = api.token
-        if token:
-            return token
-    except Exception:
-        pass
-    # Fallback: read the cached token file directly
-    token_path = Path.home() / ".cache" / "huggingface" / "token"
-    if token_path.exists():
-        token = token_path.read_text().strip()
-        if token:
-            return token
-    return None
+    """Get HF token via huggingface_hub (checks env, keyring, and cached login)."""
+    from huggingface_hub import get_token
+    return get_token()
 
 
 async def _prompt_and_save_hf_token(prompt_session: PromptSession) -> str:


### PR DESCRIPTION
## Summary

Closes #23.

Replaces the manual three-step fallback chain (`HF_TOKEN` env → `HfApi().token` → cached token file) in `_get_hf_token()` with a single call to `huggingface_hub.get_token()`, which already implements all three lookups internally.

## Changes

- `agent/main.py`: collapse 19-line `_get_hf_token` body to 2 lines using `get_token()`

## Test plan

- [ ] `huggingface-cli login` sets a cached token; verify `ml-intern` picks it up without `HF_TOKEN` set in env
- [ ] `HF_TOKEN=hf_xxx ml-intern ...` still works (env var takes precedence inside `get_token()`)
- [ ] No token set anywhere → `get_token()` returns `None`, login prompt appears as before