### PR TITLE
Clarify repetitive tool pattern log messages

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -686,7 +686,7 @@ class Handlers:
                         event_type="tool_log",
                         data={
                             "tool": "system",
-                            "log": "Doom loop detected — injecting corrective prompt",
+                            "log": "Repetitive tool pattern detected — redirecting agent",
                         },
                     )
                 )

--- a/agent/core/doom_loop.py
+++ b/agent/core/doom_loop.py
@@ -129,7 +129,7 @@ def check_for_doom_loop(messages: list[Message]) -> str | None:
     # Check for identical consecutive calls
     tool_name = detect_identical_consecutive(signatures, threshold=3)
     if tool_name:
-        logger.warning("Doom loop detected: %d+ identical consecutive calls to '%s'", 3, tool_name)
+        logger.info("Repetitive tool pattern: %d+ identical consecutive calls to '%s' — redirecting agent", 3, tool_name)
         return (
             f"[SYSTEM: DOOM LOOP DETECTED] You have called '{tool_name}' with the same "
             f"arguments multiple times in a row, getting the same result each time. "
@@ -143,7 +143,7 @@ def check_for_doom_loop(messages: list[Message]) -> str | None:
     pattern = detect_repeating_sequence(signatures)
     if pattern:
         pattern_desc = " → ".join(s.name for s in pattern)
-        logger.warning("Doom loop detected: repeating sequence [%s]", pattern_desc)
+        logger.info("Repetitive tool pattern: repeating sequence [%s] — redirecting agent", pattern_desc)
         return (
             f"[SYSTEM: DOOM LOOP DETECTED] You are stuck in a repeating cycle of tool calls: "
             f"[{pattern_desc}]. This pattern has repeated multiple times without progress. "

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -306,8 +306,8 @@ async def research_handler(
         # ── Doom-loop detection ──
         doom_prompt = check_for_doom_loop(messages)
         if doom_prompt:
-            logger.warning("Research sub-agent doom loop detected at iteration %d", _iteration)
-            await _log("Doom loop detected — injecting corrective prompt")
+            logger.info("Research sub-agent repetitive tool pattern at iteration %d — redirecting", _iteration)
+            await _log("Repetitive tool pattern detected — redirecting agent")
             messages.append(Message(role="user", content=doom_prompt))
 
         # ── Context budget: warn at 75%, hard-stop at 95% ──


### PR DESCRIPTION
## Summary

Closes #128.

The `Doom loop detected — injecting corrective prompt` log was alarming users into thinking the agent had broken or was in an unrecoverable failure state. The behaviour is intentional and the agent self-corrects. This PR replaces the user-facing message and logger calls with clearer, less alarming language.

## Changes

- `agent/core/doom_loop.py`: downgrade `logger.warning` → `logger.info`; rename log text to "Repetitive tool pattern: ..."
- `agent/core/agent_loop.py`: rename TUI log event to "Repetitive tool pattern detected — redirecting agent"
- `agent/tools/research_tool.py`: same rename for research sub-agent path

## Test plan

- [ ] Trigger the pattern (run a prompt that causes repeated identical tool calls) and confirm the new message appears
- [ ] Confirm the corrective prompt injected into the model context is unchanged (only the user-visible log text changed)
- [ ] Confirm no `WARNING`-level log lines fire for this event in production log output