### PR TITLE
Keep repetition guard internal

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -681,18 +681,6 @@ class Handlers:
                 session.context_manager.add_message(
                     Message(role="user", content=doom_prompt)
                 )
-                await session.send_event(
-                    Event(
-                        event_type="tool_log",
-                        data={
-                            "tool": "system",
-                            "log": (
-                                "Repetition guard activated - steering the agent "
-                                "away from repeated tool calls"
-                            ),
-                        },
-                    )
-                )
 
             malformed_tool = _detect_repeated_malformed(session.context_manager.items)
             if malformed_tool:

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -686,7 +686,10 @@ class Handlers:
                         event_type="tool_log",
                         data={
                             "tool": "system",
-                            "log": "Doom loop detected — injecting corrective prompt",
+                            "log": (
+                                "Repetition guard activated - steering the agent "
+                                "away from repeated tool calls"
+                            ),
                         },
                     )
                 )

--- a/agent/core/doom_loop.py
+++ b/agent/core/doom_loop.py
@@ -129,9 +129,13 @@ def check_for_doom_loop(messages: list[Message]) -> str | None:
     # Check for identical consecutive calls
     tool_name = detect_identical_consecutive(signatures, threshold=3)
     if tool_name:
-        logger.warning("Doom loop detected: %d+ identical consecutive calls to '%s'", 3, tool_name)
+        logger.warning(
+            "Repetition guard activated: %d+ identical consecutive calls to '%s'",
+            3,
+            tool_name,
+        )
         return (
-            f"[SYSTEM: DOOM LOOP DETECTED] You have called '{tool_name}' with the same "
+            f"[SYSTEM: REPETITION GUARD] You have called '{tool_name}' with the same "
             f"arguments multiple times in a row, getting the same result each time. "
             f"STOP repeating this approach — it is not working. "
             f"Step back and try a fundamentally different strategy. "
@@ -143,9 +147,9 @@ def check_for_doom_loop(messages: list[Message]) -> str | None:
     pattern = detect_repeating_sequence(signatures)
     if pattern:
         pattern_desc = " → ".join(s.name for s in pattern)
-        logger.warning("Doom loop detected: repeating sequence [%s]", pattern_desc)
+        logger.warning("Repetition guard activated: repeating sequence [%s]", pattern_desc)
         return (
-            f"[SYSTEM: DOOM LOOP DETECTED] You are stuck in a repeating cycle of tool calls: "
+            f"[SYSTEM: REPETITION GUARD] You are stuck in a repeating cycle of tool calls: "
             f"[{pattern_desc}]. This pattern has repeated multiple times without progress. "
             f"STOP this cycle and try a fundamentally different approach. "
             f"Consider: breaking down the problem differently, using alternative tools, "

--- a/agent/sft/tagger.py
+++ b/agent/sft/tagger.py
@@ -248,7 +248,7 @@ def tag_session(trajectory: dict) -> list[str]:
             had_compact = True
         elif et == "tool_log":
             log_text = (data.get("log") or "").lower()
-            if "doom loop" in log_text:
+            if "doom loop" in log_text or "repetition guard" in log_text:
                 had_doom_loop = True
 
     if had_error and outcome not in ("completed", "interrupted"):

--- a/agent/sft/tagger.py
+++ b/agent/sft/tagger.py
@@ -248,7 +248,7 @@ def tag_session(trajectory: dict) -> list[str]:
             had_compact = True
         elif et == "tool_log":
             log_text = (data.get("log") or "").lower()
-            if "doom loop" in log_text or "repetition guard" in log_text:
+            if "doom loop" in log_text:
                 had_doom_loop = True
 
     if had_error and outcome not in ("completed", "interrupted"):

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -306,8 +306,14 @@ async def research_handler(
         # ── Doom-loop detection ──
         doom_prompt = check_for_doom_loop(messages)
         if doom_prompt:
-            logger.warning("Research sub-agent doom loop detected at iteration %d", _iteration)
-            await _log("Doom loop detected — injecting corrective prompt")
+            logger.warning(
+                "Research sub-agent repetition guard activated at iteration %d",
+                _iteration,
+            )
+            await _log(
+                "Repetition guard activated - steering the research sub-agent "
+                "away from repeated tool calls"
+            )
             messages.append(Message(role="user", content=doom_prompt))
 
         # ── Context budget: warn at 75%, hard-stop at 95% ──

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -310,10 +310,6 @@ async def research_handler(
                 "Research sub-agent repetition guard activated at iteration %d",
                 _iteration,
             )
-            await _log(
-                "Repetition guard activated - steering the research sub-agent "
-                "away from repeated tool calls"
-            )
             messages.append(Message(role="user", content=doom_prompt))
 
         # ── Context budget: warn at 75%, hard-stop at 95% ──

--- a/tests/unit/test_doom_loop_polling.py
+++ b/tests/unit/test_doom_loop_polling.py
@@ -5,7 +5,7 @@ Reproduces the failure mode in observatory sessions 40fcb414 ($32.59),
 long-running job with `bash sleep 300 && wc -l output` four times in a
 row. The arguments were byte-identical, but the results moved (27210 →
 36454 → 45770 → 55138 — actual progress). The detector hashed args only
-and false-fired DOOM LOOP, which made the agent abandon perfectly valid
+and false-fired the repetition guard, which made the agent abandon perfectly valid
 polling.
 
 After the fix the signature includes the tool result hash, so identical
@@ -66,7 +66,7 @@ def test_truly_stuck_polling_with_identical_results_still_fires():
     ]
     prompt = check_for_doom_loop(msgs)
     assert prompt is not None
-    assert "DOOM LOOP" in prompt
+    assert "REPETITION GUARD" in prompt
     assert "bash" in prompt
 
 
@@ -80,7 +80,7 @@ def test_identical_calls_with_no_results_yet_still_fires():
     ]
     prompt = check_for_doom_loop(msgs)
     assert prompt is not None
-    assert "DOOM LOOP" in prompt
+    assert "REPETITION GUARD" in prompt
     assert "write" in prompt
 
 

--- a/tests/unit/test_sft_tagger.py
+++ b/tests/unit/test_sft_tagger.py
@@ -79,16 +79,7 @@ def test_outcome_ongoing():
 
 def test_outcome_doom_loop_and_context():
     events = [
-        _ev(
-            "tool_log",
-            {
-                "tool": "system",
-                "log": (
-                    "Repetition guard activated - steering the agent away "
-                    "from repeated tool calls"
-                ),
-            },
-        ),
+        _ev("tool_log", {"tool": "system", "log": "Doom loop detected"}),
         _ev("compacted", {"old_tokens": 100, "new_tokens": 50}),
         _ev("turn_complete", {"history_size": 10}),
     ]

--- a/tests/unit/test_sft_tagger.py
+++ b/tests/unit/test_sft_tagger.py
@@ -79,7 +79,16 @@ def test_outcome_ongoing():
 
 def test_outcome_doom_loop_and_context():
     events = [
-        _ev("tool_log", {"tool": "system", "log": "Doom loop detected — injecting corrective prompt"}),
+        _ev(
+            "tool_log",
+            {
+                "tool": "system",
+                "log": (
+                    "Repetition guard activated - steering the agent away "
+                    "from repeated tool calls"
+                ),
+            },
+        ),
         _ev("compacted", {"old_tokens": 100, "new_tokens": 50}),
         _ev("turn_complete", {"history_size": 10}),
     ]


### PR DESCRIPTION
## Summary
- stop emitting user-visible tool_log events when the loop guard fires
- keep the internal corrective prompt so behavior still recovers from repeated tool calls
- keep SFT tagger compatibility for historical doom-loop logs

Fixes #128

## Tests
- UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/unit/test_doom_loop_polling.py tests/unit/test_sft_tagger.py