### PR TITLE
docs(readme): add Chinese localized README

### DIFF
--- a/i18n/README.zh-hans.md
+++ b/i18n/README.zh-hans.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <img src="frontend/public/smolagents.webp" alt="smolagents logo" width="160" />
+  <img src="../frontend/public/smolagents.webp" alt="smolagents logo" width="160" />
 </p>
 
 <p align="center">
-  <strong>English | <a href="i18n/README.zh-hans.md">简体中文</a> | <a href="i18n/README.zh-hant.md">繁體中文</a></strong>
+  <strong><a href="../README.md">English</a> | 简体中文 | <a href="README.zh-hant.md">繁體中文</a></strong>
 </p>
 
 # ML Intern
 
-An ML intern that autonomously researches, writes, and ships good quality ML related code using the Hugging Face ecosystem — with deep access to docs, papers, datasets, and cloud compute.
+一个能够自主调研、编写并交付高质量机器学习相关代码的 ML 实习生，基于 Hugging Face 生态构建，并可深度访问文档、论文、数据集和云计算资源。
 
-## Quick Start
+## 快速开始
 
-### Installation
+### 安装
 
 ```bash
 git clone git@github.com:huggingface/ml-intern.git
@@ -21,37 +21,38 @@ uv sync
 uv tool install -e .
 ```
 
-#### That's it. Now `ml-intern` works from any directory:
+#### 就这样。现在 `ml-intern` 可以在任意目录中运行：
 
 ```bash
 ml-intern
 ```
 
-Create a `.env` file in the project root (or export these in your shell):
+在项目根目录创建一个 `.env` 文件（或者在 shell 中导出以下环境变量）：
 
 ```bash
 ANTHROPIC_API_KEY=<your-anthropic-api-key> # if using anthropic models
 OPENAI_API_KEY=<your-openai-api-key> # if using openai models
 HF_TOKEN=<your-hugging-face-token>
-GITHUB_TOKEN=<github-personal-access-token> 
+GITHUB_TOKEN=<github-personal-access-token>
 ```
-If no `HF_TOKEN` is set, the CLI will prompt you to paste one on first launch. To get a GITHUB_TOKEN follow the tutorial [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
 
-### Usage
+如果没有设置 `HF_TOKEN`，CLI 会在首次启动时提示你粘贴一个 token。要获取 `GITHUB_TOKEN`，请参考[这里的教程](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)。
 
-**Interactive mode** (start a chat session):
+### 使用方法
+
+**交互模式**（启动一个聊天会话）：
 
 ```bash
 ml-intern
 ```
 
-**Headless mode** (single prompt, auto-approve):
+**无头模式**（单条提示词，自动批准）：
 
 ```bash
 ml-intern "fine-tune llama on my dataset"
 ```
 
-**Options:**
+**可选参数：**
 
 ```bash
 ml-intern --model anthropic/claude-opus-4-6 "your prompt"
@@ -60,9 +61,9 @@ ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 ```
 
-## Architecture
+## 架构
 
-### Component Overview
+### 组件概览
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -132,7 +133,7 @@ ml-intern --no-stream "your prompt"
 └────────────────────────────────────────────────────┴──┘
 ```
 
-### Agentic Loop Flow
+### Agentic Loop 流程
 
 ```
 User Message
@@ -168,32 +169,32 @@ User Message
      ╚═══════════════════════════════════════════╝
 ```
 
-## Events
+## 事件
 
-The agent emits the following events via `event_queue`:
+Agent 会通过 `event_queue` 发出以下事件：
 
-- `processing` - Starting to process user input
-- `ready` - Agent is ready for input
-- `assistant_chunk` - Streaming token chunk
-- `assistant_message` - Complete LLM response text
-- `assistant_stream_end` - Token stream finished
-- `tool_call` - Tool being called with arguments
-- `tool_output` - Tool execution result
-- `tool_log` - Informational tool log message
-- `tool_state_change` - Tool execution state transition
-- `approval_required` - Requesting user approval for sensitive operations
-- `turn_complete` - Agent finished processing
-- `error` - Error occurred during processing
-- `interrupted` - Agent was interrupted
-- `compacted` - Context was compacted
-- `undo_complete` - Undo operation completed
-- `shutdown` - Agent shutting down
+- `processing` - 开始处理用户输入
+- `ready` - Agent 已准备好接收输入
+- `assistant_chunk` - 流式 token 分片
+- `assistant_message` - 完整的 LLM 响应文本
+- `assistant_stream_end` - token 流结束
+- `tool_call` - 正在调用工具及其参数
+- `tool_output` - 工具执行结果
+- `tool_log` - 工具信息日志消息
+- `tool_state_change` - 工具执行状态变化
+- `approval_required` - 请求用户批准敏感操作
+- `turn_complete` - Agent 完成当前轮处理
+- `error` - 处理过程中发生错误
+- `interrupted` - Agent 被中断
+- `compacted` - 上下文已压缩
+- `undo_complete` - 撤销操作完成
+- `shutdown` - Agent 正在关闭
 
-## Development
+## 开发
 
-### Adding Built-in Tools
+### 添加内置工具
 
-Edit `agent/core/tools.py`:
+编辑 `agent/core/tools.py`：
 
 ```python
 def create_builtin_tools() -> list[ToolSpec]:
@@ -214,10 +215,9 @@ def create_builtin_tools() -> list[ToolSpec]:
     ]
 ```
 
-### Adding MCP Servers
+### 添加 MCP 服务器
 
-Edit `configs/cli_agent_config.json` for CLI defaults, or
-`configs/frontend_agent_config.json` for web-session defaults:
+编辑 `configs/cli_agent_config.json` 以配置 CLI 默认值，或编辑 `configs/frontend_agent_config.json` 以配置 Web 会话默认值：
 
 ```json
 {
@@ -234,4 +234,4 @@ Edit `configs/cli_agent_config.json` for CLI defaults, or
 }
 ```
 
-Note: Environment variables like `${YOUR_TOKEN}` are auto-substituted from `.env`.
+注意：像 `${YOUR_TOKEN}` 这样的环境变量会自动从 `.env` 中替换。

--- a/i18n/README.zh-hant.md
+++ b/i18n/README.zh-hant.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <img src="frontend/public/smolagents.webp" alt="smolagents logo" width="160" />
+  <img src="../frontend/public/smolagents.webp" alt="smolagents logo" width="160" />
 </p>
 
 <p align="center">
-  <strong>English | <a href="i18n/README.zh-hans.md">简体中文</a> | <a href="i18n/README.zh-hant.md">繁體中文</a></strong>
+  <strong><a href="../README.md">English</a> | <a href="README.zh-hans.md">简体中文</a> | 繁體中文</strong>
 </p>
 
 # ML Intern
 
-An ML intern that autonomously researches, writes, and ships good quality ML related code using the Hugging Face ecosystem — with deep access to docs, papers, datasets, and cloud compute.
+一個能夠自主研究、撰寫並交付高品質機器學習相關程式碼的 ML 實習生，基於 Hugging Face 生態系打造，並可深度存取文件、論文、資料集與雲端運算資源。
 
-## Quick Start
+## 快速開始
 
-### Installation
+### 安裝
 
 ```bash
 git clone git@github.com:huggingface/ml-intern.git
@@ -21,37 +21,38 @@ uv sync
 uv tool install -e .
 ```
 
-#### That's it. Now `ml-intern` works from any directory:
+#### 就這樣。現在 `ml-intern` 可以在任意目錄中執行：
 
 ```bash
 ml-intern
 ```
 
-Create a `.env` file in the project root (or export these in your shell):
+在專案根目錄建立一個 `.env` 檔案（或在 shell 中匯出以下環境變數）：
 
 ```bash
 ANTHROPIC_API_KEY=<your-anthropic-api-key> # if using anthropic models
 OPENAI_API_KEY=<your-openai-api-key> # if using openai models
 HF_TOKEN=<your-hugging-face-token>
-GITHUB_TOKEN=<github-personal-access-token> 
+GITHUB_TOKEN=<github-personal-access-token>
 ```
-If no `HF_TOKEN` is set, the CLI will prompt you to paste one on first launch. To get a GITHUB_TOKEN follow the tutorial [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
 
-### Usage
+如果沒有設定 `HF_TOKEN`，CLI 會在首次啟動時提示你貼上一個 token。要取得 `GITHUB_TOKEN`，請參考[這裡的教學](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)。
 
-**Interactive mode** (start a chat session):
+### 使用方式
+
+**互動模式**（啟動一個聊天工作階段）：
 
 ```bash
 ml-intern
 ```
 
-**Headless mode** (single prompt, auto-approve):
+**無頭模式**（單一提示詞，自動核准）：
 
 ```bash
 ml-intern "fine-tune llama on my dataset"
 ```
 
-**Options:**
+**可選參數：**
 
 ```bash
 ml-intern --model anthropic/claude-opus-4-6 "your prompt"
@@ -60,9 +61,9 @@ ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 ```
 
-## Architecture
+## 架構
 
-### Component Overview
+### 元件總覽
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -132,7 +133,7 @@ ml-intern --no-stream "your prompt"
 └────────────────────────────────────────────────────┴──┘
 ```
 
-### Agentic Loop Flow
+### Agentic Loop 流程
 
 ```
 User Message
@@ -168,32 +169,32 @@ User Message
      ╚═══════════════════════════════════════════╝
 ```
 
-## Events
+## 事件
 
-The agent emits the following events via `event_queue`:
+Agent 會透過 `event_queue` 發出以下事件：
 
-- `processing` - Starting to process user input
-- `ready` - Agent is ready for input
-- `assistant_chunk` - Streaming token chunk
-- `assistant_message` - Complete LLM response text
-- `assistant_stream_end` - Token stream finished
-- `tool_call` - Tool being called with arguments
-- `tool_output` - Tool execution result
-- `tool_log` - Informational tool log message
-- `tool_state_change` - Tool execution state transition
-- `approval_required` - Requesting user approval for sensitive operations
-- `turn_complete` - Agent finished processing
-- `error` - Error occurred during processing
-- `interrupted` - Agent was interrupted
-- `compacted` - Context was compacted
-- `undo_complete` - Undo operation completed
-- `shutdown` - Agent shutting down
+- `processing` - 開始處理使用者輸入
+- `ready` - Agent 已準備好接收輸入
+- `assistant_chunk` - 串流 token 片段
+- `assistant_message` - 完整的 LLM 回應文字
+- `assistant_stream_end` - token 串流結束
+- `tool_call` - 正在呼叫工具及其參數
+- `tool_output` - 工具執行結果
+- `tool_log` - 工具資訊日誌訊息
+- `tool_state_change` - 工具執行狀態變更
+- `approval_required` - 請求使用者核准敏感操作
+- `turn_complete` - Agent 完成目前輪次處理
+- `error` - 處理過程中發生錯誤
+- `interrupted` - Agent 被中斷
+- `compacted` - 上下文已壓縮
+- `undo_complete` - 復原操作完成
+- `shutdown` - Agent 正在關閉
 
-## Development
+## 開發
 
-### Adding Built-in Tools
+### 新增內建工具
 
-Edit `agent/core/tools.py`:
+編輯 `agent/core/tools.py`：
 
 ```python
 def create_builtin_tools() -> list[ToolSpec]:
@@ -214,10 +215,9 @@ def create_builtin_tools() -> list[ToolSpec]:
     ]
 ```
 
-### Adding MCP Servers
+### 新增 MCP 伺服器
 
-Edit `configs/cli_agent_config.json` for CLI defaults, or
-`configs/frontend_agent_config.json` for web-session defaults:
+編輯 `configs/cli_agent_config.json` 以設定 CLI 預設值，或編輯 `configs/frontend_agent_config.json` 以設定 Web 工作階段預設值：
 
 ```json
 {
@@ -234,4 +234,4 @@ Edit `configs/cli_agent_config.json` for CLI defaults, or
 }
 ```
 
-Note: Environment variables like `${YOUR_TOKEN}` are auto-substituted from `.env`.
+注意：像 `${YOUR_TOKEN}` 這樣的環境變數會自動從 `.env` 代入。


### PR DESCRIPTION
Issue #147 

## Summary

This PR adds Chinese-localized README documentation and introduces a consistent language switcher across all README entry points.

Specifically, it adds:

- a Simplified Chinese README (`zh-Hans`, Mainland China)
- a Traditional Chinese README (`zh-Hant`, Taiwan)
- a centered, bold language navigation block rendered in HTML below the hero image

## What changed

- Added `i18n/README.zh-hans.md` as the Simplified Chinese translation of the main README
- Added `i18n/README.zh-hant.md` as the Traditional Chinese translation of the main README
- Updated the main `README.md` to link to both Chinese variants
- Added the same cross-language navigation to all three README files
- Rendered the language switcher with HTML so it is centered and visually consistent
- Adjusted relative asset/link paths in the localized READMEs so the hero image and navigation work correctly from the `i18n/` directory

## Why

The project currently only exposes English documentation at the main entry point. Adding Chinese variants makes onboarding and discovery easier for Chinese-speaking users while keeping the main README structure and presentation consistent across languages.

Placing the language switcher directly below the hero image also makes alternate language access more visible without changing the rest of the README layout.

## Scope

This change is documentation-only. It does not modify runtime behavior, application logic, configuration, or tests.

## Testing

- Not tested (README-only change)

## Notes

- The language switcher follows the existing README presentation style and is shared across all localized variants.
- The localized documents are cross-linked so users can move between English, Simplified Chinese, and Traditional Chinese from the top of each page.
