### PR TITLE
fix(session-uploader): forward user_id + total_cost_usd to dataset row

### DIFF
--- a/agent/core/session_uploader.py
+++ b/agent/core/session_uploader.py
@@ -90,9 +90,11 @@ def upload_session_as_file(
         # across sessions with different tool rosters.
         session_row = {
             "session_id": data["session_id"],
+            "user_id": data.get("user_id"),
             "session_start_time": data["session_start_time"],
             "session_end_time": data["session_end_time"],
             "model_name": data["model_name"],
+            "total_cost_usd": data.get("total_cost_usd"),
             "messages": json.dumps(scrubbed_messages),
             "events": json.dumps(scrubbed_events),
             "tools": json.dumps(scrubbed_tools),


### PR DESCRIPTION
Follow-up to #136.

#136 added \`user_id\` + \`total_cost_usd\` to \`Session.get_trajectory()\`, but the upload path in \`agent/core/session_uploader.py\` builds \`session_row\` with hardcoded fields and silently drops anything extra. Rows in \`smolagents/ml-intern-sessions\` continued showing \`user_id=null\` even though the trajectory dict carries the values.

Confirmed by \`kubectl exec\` on the running pod: \`session.py\` is patched correctly, but uploaded sessions had null fields because they go through this hardcoded shape.

## Change

Add \`user_id\` and \`total_cost_usd\` to the \`session_row\` dict using \`.get()\` so pre-#136 sessions still upload cleanly with null.

Diff: 1 file, +2 lines.

Mirrored on the HF Space: huggingface.co/spaces/smolagents/ml-intern/discussions/23