### PR TITLE
fix(bedrock): force tool cachePoint via cache_control_injection_points

### DIFF
--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -166,18 +166,20 @@ def _resolve_llm_params(
         # (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY`` / ``AWS_REGION``).
         # The Anthropic thinking/effort shape is not forwarded through Converse
         # the same way, so we leave it off for now.
-        #
+        params: dict = {"model": model_name}
         # ``cache_control_injection_points`` instructs the Converse adapter to
         # append a cachePoint at the end of the tool list. Per-tool
         # ``cache_control`` blocks (set by prompt_caching.py for the Anthropic
         # native path) are otherwise silently dropped by Converse, leaving the
-        # ~16k tokens of tool defs uncached on every Bedrock turn. System-prompt
-        # caching still works via cache_control on system content blocks
-        # (Converse reads those).
-        return {
-            "model": model_name,
-            "cache_control_injection_points": [{"location": "tool_config"}],
-        }
+        # ~16k tokens of tool defs uncached on every Bedrock turn.
+        # Only enabled for Anthropic-on-Bedrock models since other Bedrock
+        # providers (Titan, Llama, Mistral...) don't support cachePoint and
+        # Bedrock returns an error if it's set on an unsupported model.
+        # System-prompt caching still works via cache_control on system content
+        # blocks (Converse reads those for any provider).
+        if "anthropic" in model_name:
+            params["cache_control_injection_points"] = [{"location": "tool_config"}]
+        return params
 
     if model_name.startswith("openai/"):
         params = {"model": model_name}

--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -166,7 +166,18 @@ def _resolve_llm_params(
         # (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY`` / ``AWS_REGION``).
         # The Anthropic thinking/effort shape is not forwarded through Converse
         # the same way, so we leave it off for now.
-        return {"model": model_name}
+        #
+        # ``cache_control_injection_points`` instructs the Converse adapter to
+        # append a cachePoint at the end of the tool list. Per-tool
+        # ``cache_control`` blocks (set by prompt_caching.py for the Anthropic
+        # native path) are otherwise silently dropped by Converse, leaving the
+        # ~16k tokens of tool defs uncached on every Bedrock turn. System-prompt
+        # caching still works via cache_control on system content blocks
+        # (Converse reads those).
+        return {
+            "model": model_name,
+            "cache_control_injection_points": [{"location": "tool_config"}],
+        }
 
     if model_name.startswith("openai/"):
         params = {"model": model_name}


### PR DESCRIPTION
## Bug

LiteLLM 1.83.0's Bedrock Converse adapter reads `cache_control` blocks on system content blocks but ignores `cache_control` on individual tool dicts. Only the native Anthropic adapter inspects tool dicts.

Result: the ~16k tokens of tool definitions are re-billed at full input price on every Bedrock turn instead of hitting the cache_read tier.

Confirmed by reading `litellm/llms/bedrock/chat/converse_transformation.py` — the tool path appends a `cachePoint` only when the kwarg `cache_control_injection_points=[{location: tool_config}]` is passed top-level. The `cache_control` on the last tool dict (set by `agent/core/prompt_caching.py`) is silently dropped.

## Fix

Pass `cache_control_injection_points` to the Converse adapter from `_resolve_llm_params` for any `bedrock/...` model.

## Expected impact

Cache-read ratio on Opus 4.6 should jump from ~17% (Bedrock auto-prefix caching only) towards 50-70% on multi-turn sessions, cutting the input bill ~25-35%.

## Test plan

- [ ] Compare CloudWatch `CacheReadInputTokenCount` / `InputTokenCount` ratio on `us.anthropic.claude-opus-4-6-v1` before vs 24h after deploy
- [ ] Verify no regression on `anthropic/claude-...` (untouched branch)

Mirror on HF Space: huggingface.co/spaces/smolagents/ml-intern/discussions/24

Diff: 1 file, +12 / -1.