### PR TITLE
fix(sandbox): retry cleanup on transient failures + add backstop sweeper

### DIFF
--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -724,6 +724,10 @@ class Sandbox:
             )
         print(f"Deleting sandbox: {self.space_id}...")
         self._hf_api.delete_repo(self.space_id, repo_type="space")
+        # Clear ownership so a second cleanup call (e.g. delete_session +
+        # _run_session.finally both fire) early-returns instead of retrying
+        # a 404 delete and emitting a spurious ERROR log.
+        self._owns_space = False
         self._client.close()
         print("Deleted.")
 

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -12,7 +12,10 @@ a cpu-basic sandbox is auto-created (no approval needed).
 from __future__ import annotations
 
 import asyncio
+import logging
+import re
 import threading
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from huggingface_hub import HfApi, SpaceHardware
@@ -20,6 +23,18 @@ from huggingface_hub import HfApi, SpaceHardware
 from agent.core.session import Event
 from agent.tools.sandbox_client import Sandbox
 from agent.tools.trackio_seed import ensure_trackio_dashboard
+
+logger = logging.getLogger(__name__)
+
+# Match the exact suffix pattern Sandbox.create produces: "sandbox-<8 hex>".
+# Used to identify orphan sandboxes from prior sessions safely (won't match
+# user-renamed lookalikes).
+_SANDBOX_NAME_RE = re.compile(r"^sandbox-[a-f0-9]{8}$")
+
+# How stale a sandbox must be before we treat it as definitely orphan.
+# Anything more recent could be tied to a still-live session in another tab,
+# so we leave it alone.
+_ORPHAN_STALE_AFTER = timedelta(hours=1)
 
 
 def _looks_like_path(script: str) -> bool:
@@ -88,6 +103,59 @@ async def _seed_trackio_dashboard_safe(session: Any, space_id: str) -> None:
 # ── Tool name mapping (short agent names → Sandbox client names) ──────
 
 
+def _cleanup_user_orphan_sandboxes(
+    api: HfApi,
+    owner: str,
+    log: Any,
+) -> int:
+    """Delete stale ``sandbox-<8hex>`` Spaces in ``owner``'s account.
+
+    "Stale" = not modified in the last hour. The naming pattern + staleness
+    filter together make this safe:
+
+    * Naming: only matches ``sandbox-<exactly 8 lowercase hex>``, the
+      pattern Sandbox.create produces. Won't touch user-renamed Spaces.
+    * Staleness: anything modified in the last hour might still be tied
+      to a live session in another tab/replica, so we leave it alone.
+
+    Runs blocking — call via ``asyncio.to_thread``. Best-effort: failures
+    are logged but never raised, so a flaky HF API never blocks creation.
+    """
+    cutoff = datetime.now(timezone.utc) - _ORPHAN_STALE_AFTER
+    deleted = 0
+    try:
+        spaces = list(api.list_spaces(author=owner, limit=200))
+    except Exception as e:
+        log(f"orphan sweep: list_spaces failed: {e}")
+        return 0
+
+    for space in spaces:
+        space_name = space.id.rsplit("/", 1)[-1]
+        if not _SANDBOX_NAME_RE.match(space_name):
+            continue
+
+        last_mod = getattr(space, "lastModified", None) or getattr(space, "last_modified", None)
+        if isinstance(last_mod, str):
+            try:
+                last_mod = datetime.fromisoformat(last_mod.replace("Z", "+00:00"))
+            except ValueError:
+                last_mod = None
+        if last_mod and last_mod > cutoff:
+            # Recent — could be a concurrent live session. Skip.
+            continue
+
+        try:
+            api.delete_repo(repo_id=space.id, repo_type="space")
+            deleted += 1
+            log(f"orphan sweep: deleted {space.id}")
+        except Exception as e:
+            log(f"orphan sweep: failed to delete {space.id}: {e}")
+
+    if deleted:
+        log(f"orphan sweep: cleaned up {deleted} stale sandbox(es) before create")
+    return deleted
+
+
 async def _ensure_sandbox(
     session: Any,
     hardware: str = "cpu-basic",
@@ -134,6 +202,23 @@ async def _ensure_sandbox(
             session.event_queue.put_nowait,
             Event(event_type="tool_log", data={"tool": "sandbox", "log": msg}),
         )
+
+    # Before we create a new sandbox, sweep this user's stale sandboxes from
+    # prior sessions. ``_cleanup_sandbox`` in session_manager fires only on
+    # clean session exit; pod kills, WebSocket drops, etc. leave orphans
+    # behind, and they accumulate on every new session forever (observed
+    # 2310 leaked across the Hub on 2026-04-27). Doing the cleanup here at
+    # session start = self-healing, no separate cron needed.
+    #
+    # The 1h staleness filter is the safety: a sandbox modified in the last
+    # hour might still be tied to a live session in another tab, so we skip.
+    # Anything older has no realistic chance of being active given typical
+    # session lengths.
+    try:
+        await asyncio.to_thread(_cleanup_user_orphan_sandboxes, api, owner, _log)
+    except Exception as e:
+        # Cleanup is best-effort — never block sandbox_create on it.
+        _log(f"orphan sandbox sweep failed (non-fatal): {e}")
 
     # Bridge asyncio cancel event to a threading.Event for the blocking create call.
     # We poll session._cancelled from the main loop in a background task and set

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -301,17 +301,33 @@ class SessionManager:
 
     @staticmethod
     async def _cleanup_sandbox(session: Session) -> None:
-        """Delete the sandbox Space if one was created for this session."""
+        """Delete the sandbox Space if one was created for this session.
+
+        Retries on transient failures (HF API 5xx, rate-limit, network blips)
+        with exponential backoff. A single missed delete = a permanently
+        orphaned Space, so the cost of an extra retry beats the alternative.
+        """
         sandbox = getattr(session, "sandbox", None)
-        if sandbox and getattr(sandbox, "_owns_space", False):
-            space_id = getattr(sandbox, "space_id", None)
+        if not (sandbox and getattr(sandbox, "_owns_space", False)):
+            return
+
+        space_id = getattr(sandbox, "space_id", None)
+        last_err: Exception | None = None
+        for attempt in range(3):
             try:
-                logger.info(f"Deleting sandbox {space_id}...")
+                logger.info(f"Deleting sandbox {space_id} (attempt {attempt + 1}/3)...")
                 await asyncio.to_thread(sandbox.delete)
                 from agent.core import telemetry
                 await telemetry.record_sandbox_destroy(session, sandbox)
+                return
             except Exception as e:
-                logger.warning(f"Failed to delete sandbox {space_id}: {e}")
+                last_err = e
+                if attempt < 2:
+                    await asyncio.sleep(2 ** attempt)
+        logger.error(
+            f"Failed to delete sandbox {space_id} after 3 attempts: {last_err}. "
+            f"Orphan — sweep script will pick it up."
+        )
 
     async def _run_session(
         self,

--- a/scripts/sweep_orphan_sandboxes.py
+++ b/scripts/sweep_orphan_sandboxes.py
@@ -84,17 +84,19 @@ def log(record: dict) -> None:
 
 
 def is_sandbox_fork(space) -> bool:
-    """Filter: name pattern + originRepo == burtenshaw/sandbox."""
-    if not SANDBOX_NAME_RE.match(space.id):
-        return False
-    # ``cardData`` carries ``duplicated_from`` for HF Spaces duplicated via UI/API.
-    # ``originRepo`` is the underlying field; both names appear depending on
-    # the API version. We match either.
-    card = getattr(space, "cardData", None) or {}
-    origin = card.get("duplicated_from") or getattr(space, "originRepo", None)
-    if isinstance(origin, dict):
-        origin = origin.get("name") or origin.get("id")
-    return origin == TEMPLATE_REPO
+    """Filter: matches the ml-intern sandbox naming pattern.
+
+    NOTE: We initially tried filtering on ``duplicated_from == burtenshaw/sandbox``
+    too, for extra safety. That doesn't work — the HF REST API does not expose
+    ``duplicated_from`` on ``SpaceInfo`` (verified against ``huggingface-hub``
+    1.11+ and direct ``GET /api/spaces/{id}``: the field is None). The origin
+    repo lives in MongoDB but isn't surfaced. So we rely on the naming pattern
+    alone, which is specific enough: ``Sandbox.create()`` is the sole producer
+    of ``<owner>/sandbox-<8 lowercase hex>``, and that pattern is unlikely to
+    collide with user-created Spaces in practice. The ``--dry-run`` default
+    is the user-facing safety net for the rare false-positive.
+    """
+    return bool(SANDBOX_NAME_RE.match(space.id))
 
 
 def main() -> int:
@@ -145,6 +147,7 @@ def main() -> int:
     deleted = 0
     failed = 0
     skipped_too_recent = 0
+    skipped_capped = 0
 
     for space in candidates:
         scanned += 1
@@ -165,10 +168,13 @@ def main() -> int:
         if not args.apply:
             continue
 
+        # When we hit the deletion cap, keep scanning so the final ``matched``
+        # count reflects the *true* orphan size — not just what was scanned
+        # before we stopped deleting. Operators planning multi-pass cleanups
+        # need an accurate denominator to know when they're done.
         if deleted >= args.max_deletes:
-            log({"level": "warn", "msg": "max_deletes_reached",
-                 "deleted": deleted, "remaining": "stopped"})
-            break
+            skipped_capped += 1
+            continue
 
         try:
             api.delete_repo(repo_id=space.id, repo_type="space", token=token)
@@ -188,7 +194,9 @@ def main() -> int:
     log({"level": "info", "msg": "sweep_end",
          "scanned": scanned, "matched": matched,
          "skipped_too_recent": skipped_too_recent,
+         "skipped_capped": skipped_capped,
          "deleted": deleted, "failed": failed,
+         "capped": skipped_capped > 0,
          "apply": args.apply})
 
     return 0 if failed == 0 else 2

--- a/scripts/sweep_orphan_sandboxes.py
+++ b/scripts/sweep_orphan_sandboxes.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Backstop sweeper for orphan ml-intern sandbox Spaces.
+
+================================================================================
+ Why this script exists
+================================================================================
+
+The agent creates a sandbox Space per session (template duplicated from
+``burtenshaw/sandbox`` into the user's account, named ``<owner>/sandbox-<8hex>``).
+``backend.session_manager.SessionManager._cleanup_sandbox`` deletes it at end of
+session. In practice the cleanup misses some sandboxes:
+
+- pod killed / OOM / pre-emption / deploy rollouts → ``finally`` block skipped
+- WebSocket dropped without ``/shutdown`` from the client
+- HF API transient failure on ``delete_repo`` (we retry now, but not infinitely)
+
+The result observed 2026-04-27 was 2,310 orphan ``sandbox-*`` Spaces — every
+sandbox ever created was still around. This script is the backstop: list every
+``sandbox-*`` fork of ``burtenshaw/sandbox`` that hasn't been touched in N days
+and delete it.
+
+================================================================================
+ Identification rules
+================================================================================
+
+A Space is considered an orphan ml-intern sandbox iff ALL hold:
+
+1. Repo type = ``space``
+2. Name matches ``<owner>/sandbox-[a-f0-9]{8}$`` (the agent's naming convention)
+3. ``originRepo`` points at ``burtenshaw/sandbox`` (so we don't touch
+   user-renamed lookalikes)
+4. ``lastModified`` older than ``--max-age-days`` (default 7)
+
+We DO NOT use the ``runtime.stage`` (sleeping/running) as a filter — a sandbox
+that has been sleeping for 7 days is just as orphan as a deleted one but uses
+no compute. The cleanup is about repo/storage hygiene, not about waking
+something up to kill it.
+
+================================================================================
+ Safety
+================================================================================
+
+- ``--dry-run`` (default) prints what would be deleted, deletes nothing.
+- ``--apply`` actually calls ``HfApi.delete_repo``.
+- Hard cap ``--max-deletes`` (default 200) so a misconfigured run can't nuke
+  thousands at once.
+- Requires a token with admin rights via ``HF_ADMIN_TOKEN`` env var (the only
+  way to delete a Space owned by another user).
+- Logs every action to stdout in JSON Lines for downstream auditing.
+
+================================================================================
+ Cron suggestion
+================================================================================
+
+GitHub Actions, daily at 04:00 UTC:
+
+    schedule:
+      - cron: "0 4 * * *"
+    env:
+      HF_ADMIN_TOKEN: ${{ secrets.HF_ADMIN_TOKEN }}
+    steps:
+      - run: python scripts/sweep_orphan_sandboxes.py --apply --max-age-days 7
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+
+from huggingface_hub import HfApi
+from huggingface_hub.utils import HfHubHTTPError
+
+SANDBOX_NAME_RE = re.compile(r"^[^/]+/sandbox-[a-f0-9]{8}$")
+TEMPLATE_REPO = "burtenshaw/sandbox"
+
+
+def log(record: dict) -> None:
+    """JSON Lines log so downstream tooling can grep / parse."""
+    record["ts"] = datetime.now(timezone.utc).isoformat()
+    print(json.dumps(record), flush=True)
+
+
+def is_sandbox_fork(space) -> bool:
+    """Filter: name pattern + originRepo == burtenshaw/sandbox."""
+    if not SANDBOX_NAME_RE.match(space.id):
+        return False
+    # ``cardData`` carries ``duplicated_from`` for HF Spaces duplicated via UI/API.
+    # ``originRepo`` is the underlying field; both names appear depending on
+    # the API version. We match either.
+    card = getattr(space, "cardData", None) or {}
+    origin = card.get("duplicated_from") or getattr(space, "originRepo", None)
+    if isinstance(origin, dict):
+        origin = origin.get("name") or origin.get("id")
+    return origin == TEMPLATE_REPO
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=7,
+        help="Delete sandboxes whose lastModified is older than this many days (default: 7)",
+    )
+    parser.add_argument(
+        "--max-deletes",
+        type=int,
+        default=200,
+        help="Hard cap on deletions per run, safety guard (default: 200)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete. Without this flag, dry-run only.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10000,
+        help="Max number of candidate Spaces to scan via list_spaces (default: 10000)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("HF_ADMIN_TOKEN")
+    if not token:
+        log({"level": "error", "msg": "HF_ADMIN_TOKEN env var not set"})
+        return 1
+
+    api = HfApi(token=token)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.max_age_days)
+    log({"level": "info", "msg": "sweep_start", "cutoff": cutoff.isoformat(),
+         "max_deletes": args.max_deletes, "apply": args.apply})
+
+    # ``list_spaces`` doesn't filter by name pattern — we scan and filter
+    # client-side. ``search="sandbox"`` narrows the network payload.
+    candidates = api.list_spaces(
+        search="sandbox", full=True, limit=args.limit
+    )
+
+    scanned = 0
+    matched = 0
+    deleted = 0
+    failed = 0
+    skipped_too_recent = 0
+
+    for space in candidates:
+        scanned += 1
+        if not is_sandbox_fork(space):
+            continue
+        matched += 1
+
+        last_mod = getattr(space, "lastModified", None) or getattr(space, "last_modified", None)
+        if isinstance(last_mod, str):
+            last_mod = datetime.fromisoformat(last_mod.replace("Z", "+00:00"))
+        if last_mod and last_mod > cutoff:
+            skipped_too_recent += 1
+            continue
+
+        log({"level": "info", "msg": "candidate", "space_id": space.id,
+             "last_modified": last_mod.isoformat() if last_mod else None})
+
+        if not args.apply:
+            continue
+
+        if deleted >= args.max_deletes:
+            log({"level": "warn", "msg": "max_deletes_reached",
+                 "deleted": deleted, "remaining": "stopped"})
+            break
+
+        try:
+            api.delete_repo(repo_id=space.id, repo_type="space", token=token)
+            deleted += 1
+            log({"level": "info", "msg": "deleted", "space_id": space.id})
+            # Light throttle to avoid hitting HF API rate limits.
+            time.sleep(0.2)
+        except HfHubHTTPError as e:
+            failed += 1
+            log({"level": "error", "msg": "delete_failed", "space_id": space.id,
+                 "status": e.response.status_code, "error": str(e)[:200]})
+        except Exception as e:
+            failed += 1
+            log({"level": "error", "msg": "delete_failed", "space_id": space.id,
+                 "error": str(e)[:200]})
+
+    log({"level": "info", "msg": "sweep_end",
+         "scanned": scanned, "matched": matched,
+         "skipped_too_recent": skipped_too_recent,
+         "deleted": deleted, "failed": failed,
+         "apply": args.apply})
+
+    return 0 if failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

A scan of `prod-111`/`prod-112` (free CPU pool) on 2026-04-27 found **2,310 orphan `sandbox-*` Spaces** — every sandbox ever created by the agent was still around. The cleanup logic in `_cleanup_sandbox` exists but was firing only on the happy path. Two failure modes were causing the leak:

1. **Pod killed / WebSocket dropped** → `finally` block in `_run_session` doesn't run, sandbox stays orphaned forever.
2. **`HfApi.delete_repo` transient failure** (5xx / rate-limit / network) → previous code logged a warning and moved on. No retry, no recovery.

Each session creates ~1 sandbox; over ~6 months of operation, the leak compounded. Spread:
- 7 sandboxes for `yun2022` over 3 days, all orphaned, creation timestamps spread by hours → confirms the leak is per-session-cleanup, not intra-session re-creation.
- 9 sandboxes for `EPSAGR` from a single session of 147 turns — same root cause across multiple sessions.

## Changes

### 1. Retry on `_cleanup_sandbox` (`backend/session_manager.py`)
3 attempts with exponential backoff (1s, 2s). Logs at ERROR level if all fail. Closes the transient HF API failure path.

### 2. Self-healing sweep at sandbox create (`agent/tools/sandbox_tool.py`)
**Primary fix.** At session start, before creating a new sandbox, sweep the user's pre-existing `sandbox-<8hex>` Spaces that haven't been touched in > 1h. Each new session guarantees a clean state for that user — no separate cron, no admin token required, uses the user's own auth.

Safety:
- Naming filter `sandbox-<exactly 8 lowercase hex>` matches only what `Sandbox.create` produces. Won't touch user-renamed Spaces.
- `lastModified > 1h ago` filter avoids breaking concurrent live sessions in another tab/replica.
- Best-effort: failures during sweep never block sandbox creation.

### 3. Optional retroactive sweeper (`scripts/sweep_orphan_sandboxes.py`)
Standalone script for one-off retroactive cleanup if anyone wants to clear the existing 2310 orphans manually. Defaults to dry-run, hard cap on deletions, requires `HF_ADMIN_TOKEN`. Not wired to any cron — kept in the repo as opt-in tooling.

## Why all three

| Scenario | retry on cleanup | session-start sweep | retroactive script |
|---|---|---|---|
| HF API transient failure during clean exit | ✅ | (catches next session) | ✅ |
| Pod kill / WebSocket drop mid-session | ❌ | ✅ next session | ✅ |
| User opens new session days later | (n/a) | ✅ catches their orphans | ✅ |
| One-off cleanup of existing 2310 | ❌ | (would take months as users return) | ✅ |

The first two close the leak going forward. The third is opt-in for retroactive cleanup if/when desired.

## What this does NOT do

- **Does not retroactively clean up the existing 2310 orphans by default.** They'll be cleaned up gradually as their owners come back for new sessions, OR can be cleared in one shot via the standalone script under supervision.
- **Does not delete sandboxes from the same user's concurrent sessions** — the 1h staleness filter explicitly avoids this.

## Test plan

- [ ] Manual: start a session as a test user with a known stale sandbox, verify it gets deleted before the new one is created
- [ ] Manual: with two concurrent tabs, verify the second tab's session-start sweep doesn't touch the first tab's active sandbox
- [ ] Read-through: confirm the regex + staleness filter are correct
- [ ] (Optional) Run sweeper script with `--dry-run` against prod, sanity-check candidate list

cc @AkselReedi