### PR TITLE
Recognize Pro OAuth users via isPro flag

### DIFF
--- a/agent/core/hf_access.py
+++ b/agent/core/hf_access.py
@@ -55,15 +55,19 @@ def _extract_username(whoami: dict[str, Any]) -> str | None:
 
 
 def _normalize_personal_plan(whoami: dict[str, Any]) -> str:
+    # OAuth whoami responses set `type: "user"` and surface Pro status only via
+    # the `isPro` boolean. Check the boolean first so a generic `type` value
+    # doesn't shadow it — otherwise Pro OAuth users get classified as free and
+    # blocked from running Jobs (smolagents/ml-intern Space discussion #21).
+    if whoami.get("isPro") is True or whoami.get("is_pro") is True:
+        return "pro"
+
     plan_str = ""
     for key in ("plan", "type", "accountType"):
         value = whoami.get(key)
         if isinstance(value, str) and value:
             plan_str = value.lower()
             break
-
-    if not plan_str and (whoami.get("isPro") is True or whoami.get("is_pro") is True):
-        return "pro"
 
     if any(tag in plan_str for tag in ("pro", "enterprise", "team")):
         return "pro"

--- a/tests/unit/test_hf_access.py
+++ b/tests/unit/test_hf_access.py
@@ -37,3 +37,19 @@ def test_free_user_without_paid_org_cannot_run_jobs():
     assert access.can_run_jobs is False
     assert access.eligible_namespaces == []
     assert access.default_namespace is None
+
+
+def test_oauth_pro_user_recognized_via_is_pro_flag():
+    # OAuth login surfaces Pro status only as `isPro: true`; the `type` key is
+    # a generic "user" string. Regression test for Space discussion #21 — Pro
+    # OAuth users were being classified as free and blocked from Jobs.
+    access = jobs_access_from_whoami({
+        "name": "alice",
+        "type": "user",
+        "isPro": True,
+        "orgs": [],
+    })
+    assert access.plan == "pro"
+    assert access.personal_can_run_jobs is True
+    assert access.eligible_namespaces == ["alice"]
+    assert access.default_namespace == "alice"


### PR DESCRIPTION
## Summary
- `_normalize_personal_plan()` now checks the `isPro` boolean before matching plan/type strings.
- OAuth whoami sends `type: \"user\"` + `isPro: true`; under the old order the loop locked in `plan_str = \"user\"` and the `if not plan_str and isPro` guard short-circuited, so every Pro OAuth user got classified as free and blocked from Jobs.
- Added a regression test for the OAuth shape.

Reported in [smolagents/ml-intern Space discussion #21](https://huggingface.co/spaces/smolagents/ml-intern/discussions/21). Discussion #18 is the same issue and will resolve once this lands.

## Test plan
- [x] \`uv run --with pytest pytest tests/unit/test_hf_access.py\` — 4/4 pass including the new test
- [ ] Pro OAuth user logs in to the Space and can submit a Job from their personal namespace