### PR TITLE
Emit tool completion events with duration_ms

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -1103,13 +1103,15 @@ class Handlers:
                         args: dict,
                         valid: bool,
                         err: str,
-                    ) -> tuple[ToolCall, str, dict, str, bool]:
+                    ) -> tuple[ToolCall, str, dict, str, bool, int]:
                         if not valid:
-                            return (tc, name, args, err, False)
+                            return (tc, name, args, err, False, 0)
+                        t0 = time.perf_counter()
                         out, ok = await session.tool_router.call_tool(
                             name, args, session=session, tool_call_id=tc.id
                         )
-                        return (tc, name, args, out, ok)
+                        duration_ms = int((time.perf_counter() - t0) * 1000)
+                        return (tc, name, args, out, ok, duration_ms)
 
                     gather_task = asyncio.ensure_future(asyncio.gather(
                         *[
@@ -1144,7 +1146,7 @@ class Handlers:
                     results = gather_task.result()
 
                     # 4. Record results and send outputs (order preserved)
-                    for tc, tool_name, tool_args, output, success in results:
+                    for tc, tool_name, tool_args, output, success, duration_ms in results:
                         tool_msg = Message(
                             role="tool",
                             content=output,
@@ -1161,6 +1163,19 @@ class Handlers:
                                     "tool_call_id": tc.id,
                                     "output": output,
                                     "success": success,
+                                },
+                            )
+                        )
+
+                        await session.send_event(
+                            Event(
+                                event_type="tool_state_change",
+                                data={
+                                    "tool_call_id": tc.id,
+                                    "tool": tool_name,
+                                    "state": "complete",
+                                    "success": success,
+                                    "duration_ms": duration_ms,
                                 },
                             )
                         )
@@ -1381,12 +1396,18 @@ class Handlers:
                     },
                 )
             )
+            
+            t0 = time.perf_counter()
+            try: 
+                output, success = await session.tool_router.call_tool(
+                    tool_name, tool_args, session=session, tool_call_id=tc.id
+                )
+            
+            except Exception as e:
+                output, success = f"Tool execution failed: {e}", False
+            duration_ms = int((time.perf_counter() - t0) * 1000)
 
-            output, success = await session.tool_router.call_tool(
-                tool_name, tool_args, session=session, tool_call_id=tc.id
-            )
-
-            return (tc, tool_name, output, success, was_edited)
+            return (tc, tool_name, output, success, was_edited, duration_ms)
 
         # Execute all approved tools concurrently (cancellable)
         if approved_tasks:
@@ -1432,7 +1453,7 @@ class Handlers:
                     logger.error(f"Tool execution error: {result}")
                     continue
 
-                tc, tool_name, output, success, was_edited = result
+                tc, tool_name, output, success, was_edited, duration_ms = result
 
                 if was_edited:
                     output = f"[Note: The user edited the script before execution. The output below reflects the user-modified version, not your original script.]\n\n{output}"
@@ -1456,6 +1477,18 @@ class Handlers:
                             "success": success,
                         },
                     )
+                )
+                await session.send_event(
+                    Event(
+                        event_type="tool_state_change",
+                        data={
+                            "tool_call_id": tc.id,
+                            "tool": tool_name,
+                            "state": "complete",
+                            "success": success,
+                            "duration_ms": duration_ms,  
+                        },
+                    )   
                 )
 
         # Process rejected tools

--- a/tests/unit/test_doom_loop.py
+++ b/tests/unit/test_doom_loop.py
@@ -207,7 +207,7 @@ def test_check_for_doom_loop_returns_corrective_prompt_for_identical_run():
     msgs = [_assistant_call("read", '{"p": 1}')] * 3
     out = check_for_doom_loop(msgs)
     assert out is not None
-    assert "DOOM LOOP DETECTED" in out
+    assert "REPETITION GUARD" in out
     assert "'read'" in out
 
 
@@ -218,7 +218,7 @@ def test_check_for_doom_loop_returns_corrective_prompt_for_cycle():
         msgs.append(_assistant_call("b", "{}"))
     out = check_for_doom_loop(msgs)
     assert out is not None
-    assert "DOOM LOOP DETECTED" in out
+    assert "REPETITION GUARD" in out
     assert "a → b" in out
 
 

--- a/tests/unit/test_tool_completion_events.py
+++ b/tests/unit/test_tool_completion_events.py
@@ -1,0 +1,53 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.core.agent_loop import Handlers
+
+@pytest.mark.asyncio
+async def test_exec_approval_emits_complete_with_duration(monkeypatch):
+    events = []
+
+    async def send_event(ev):
+        events.append(ev)
+
+    class DummyToolRouter:
+        async def call_tool(self, tool_name, arguments, session=None, tool_call_id=None):
+            return "ok", True
+
+    async def noop_run_agent(_session, _text):
+        return None
+
+    monkeypatch.setattr(Handlers, "run_agent", noop_run_agent)
+
+    session = SimpleNamespace(
+        pending_approval={"tool_calls": [
+            SimpleNamespace(
+                id="tc-1",
+                function=SimpleNamespace(
+                    name="bash",
+                    arguments=json.dumps({"command": "date"}),
+                ),
+            )
+        ]},
+        tool_router=DummyToolRouter(),
+        context_manager=SimpleNamespace(add_message=lambda _msg: None),
+        _cancelled=asyncio.Event(),
+        send_event=send_event,
+    )
+
+    await Handlers.exec_approval(session, approvals=[{"tool_call_id": "tc-1", "approved": True}])
+
+    complete = [
+        e for e in events
+        if e.event_type == "tool_state_change" and (e.data or {}).get("state") == "complete"
+    ]
+    assert len(complete) == 1
+    assert complete[0].data["tool_call_id"] == "tc-1"
+    assert complete[0].data["success"] is True
+    assert isinstance(complete[0].data["duration_ms"], int)
+    assert complete[0].data["duration_ms"] >= 0
+
+


### PR DESCRIPTION
**THIS PR IS LINKED TO THE ISSUE_ID: #155**

## What this PR does

Emits structured `tool_state_change` completion events 
after every tool execution.

**Before:**
- Only "running" state was emitted
- No timing information anywhere in codebase
- Frontend had no structured signal for tool completion

**After:**
- "complete" state emitted after every tool execution
- duration_ms captured using time.perf_counter()
- success field included in completion event
- Both normal and approval-executed tool paths covered

## Event shape
```python
Event (
           event_type="tool_state_change",
            data={
                       "tool_call_id": tc.id,
                       "tool": tool_name,
                       "state": "complete",
                       "success": success,
                       "duration_ms": duration_ms,                   
               },
          )
```

## Evidence this was missing
Codebase-wide search for duration_ms → 0 matches before this PR.

### Summary :
What's done:
- Emit `tool_state_change` completion events with `duration_ms` for tool executions (including approval-executed tools).
- Add unit coverage for approval completion events.
- Aligned the doom-loop unit tests with the current "REPETITION GUARD" wording.

### Why
- Frontend/clients need a reliable “tool finished” signal + duration for UX and debugging.
- Doom-loop tests were asserting an old string while implementation already uses REPETITION GUARD.

### Testing
Added a unit test for this tests/test_tool_completion_events.py
- `pytest -q` (unit suite)