### PR TITLE
Fix _fetch_user_plan after JobsAccess.plan removal

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException, Request, status
 
 from agent.core.hf_tokens import bearer_token_from_header
 
-from agent.core.hf_access import fetch_whoami_v2, jobs_access_from_whoami
+from agent.core.hf_access import fetch_whoami_v2
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,24 @@ async def _fetch_user_plan(token: str) -> str:
 
     if not isinstance(whoami, dict):
         return "free"
-    return jobs_access_from_whoami(whoami).plan
+
+    # OAuth whoami sets `type: "user"` and surfaces Pro via the `isPro` boolean
+    # — see Space discussion #21. HF-Jobs eligibility (PR #172) ignores plan
+    # entirely; the Claude daily-cap tier is still a free vs pro/org split.
+    if whoami.get("isPro") is True or whoami.get("is_pro") is True:
+        return "pro"
+    plan_str = ""
+    for key in ("plan", "type", "accountType"):
+        value = whoami.get(key)
+        if isinstance(value, str) and value:
+            plan_str = value.lower()
+            break
+    if any(tag in plan_str for tag in ("pro", "enterprise", "team")):
+        return "pro"
+    orgs = whoami.get("orgs") or []
+    if isinstance(orgs, list) and orgs:
+        return "org"
+    return "free"
 
 
 async def _extract_user_from_token(token: str) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- PR #172 removed the `plan` attribute from `JobsAccess`, but `backend/dependencies.py:111` still called `jobs_access_from_whoami(whoami).plan`. Every authenticated request hit `AttributeError: 'JobsAccess' object has no attribute 'plan'` and returned 500 — the live Space went down right after deploying #172.
- Inline the Pro/free/org derivation directly off the whoami payload. The Claude daily-cap tier no longer depends on the HF-Jobs `JobsAccess` shape; those concerns split with #172.
- Behaviour matches the pre-#172 mapping: `isPro` / `pro|enterprise|team` plan strings → `pro`, any org membership → `org`, otherwise `free`.

## Test plan
- [x] `uv run pytest tests/unit/test_hf_access.py tests/unit/test_user_quotas.py` (18 passed)
- [x] Manual: simulated whoami payloads (Pro / free / org / None) all return the expected tier.
- [x] Smoke test on the live Space (commit `8c4f619c`, runtime logs):
  - `GET /auth/me 200 OK`
  - `GET /api/sessions 200 OK`
  - `GET /api/session/{id} 200 OK` and `GET /api/session/{id}/messages 200 OK`
  - `GET /api/user/quota 200 OK`
  - `POST /api/session 200 OK`
  - No `AttributeError: 'JobsAccess' object has no attribute 'plan'` anywhere in the log stream.