### PR TITLE
Add GPT-5.5 and Gemini 3.1 Pro model selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Create a `.env` file in the project root (or export these in your shell):
 ```bash
 ANTHROPIC_API_KEY=<your-anthropic-api-key> # if using anthropic models
 OPENAI_API_KEY=<your-openai-api-key> # if using openai models
+GEMINI_API_KEY=<your-gemini-api-key> # if using gemini models
 HF_TOKEN=<your-hugging-face-token>
 GITHUB_TOKEN=<github-personal-access-token> 
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ ml-intern "fine-tune llama on my dataset"
 ```bash
 ml-intern --model anthropic/claude-opus-4-6 "your prompt"
 ml-intern --model openai/gpt-5.5 "your prompt"
+ml-intern --model gemini/gemini-3.1-pro-preview "your prompt"
 ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 ```

--- a/agent/config.py
+++ b/agent/config.py
@@ -45,8 +45,9 @@ class Config(BaseModel):
     # → …) and caches per-model what the provider actually accepted in
     # ``Session.model_effective_effort``. Default ``max`` because we'd rather
     # burn tokens thinking than ship a wrong ML recipe; the cascade lands on
-    # whichever level the model supports (``high`` for GPT-5 / HF router,
-    # ``xhigh`` or ``max`` for Anthropic 4.6 / 4.7). ``None`` = thinking off.
+    # whichever level the model supports (``high`` for GPT-5.5, Gemini, and
+    # HF router, ``xhigh`` or ``max`` for Anthropic 4.6 / 4.7).
+    # ``None`` = thinking off.
     # Valid values: None | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
     reasoning_effort: str | None = "max"
     messaging: MessagingConfig = MessagingConfig()

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -309,6 +309,7 @@ def _friendly_error_message(error: Exception) -> str | None:
             "Authentication failed — your API key is missing or invalid.\n\n"
             "To fix this, set the API key for your model provider:\n"
             "  • Anthropic:   export ANTHROPIC_API_KEY=sk-...\n"
+            "  • Gemini:      export GEMINI_API_KEY=...\n"
             "  • OpenAI:      export OPENAI_API_KEY=sk-...\n"
             "  • HF Router:   export HF_TOKEN=hf_...\n\n"
             "You can also add it to a .env file in the project root.\n"

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -322,6 +322,18 @@ def _friendly_error_message(error: Exception) -> str | None:
             "at your model provider's dashboard."
         )
 
+    if (
+        "resource_exhausted" in err_str
+        or "quota exceeded" in err_str
+        or "rate limit" in err_str
+        or "too many requests" in err_str
+        or "429" in err_str
+    ):
+        return (
+            "Provider quota or rate limit exhausted. Please check the model's "
+            "quota and billing settings at your provider dashboard, then retry."
+        )
+
     if "not supported by provider" in err_str or "no provider supports" in err_str:
         return (
             "The model isn't served by the provider you pinned.\n\n"
@@ -1215,10 +1227,11 @@ class Handlers:
 
             except Exception as e:
                 import traceback
+                from agent.core.redact import scrub_string
 
                 error_msg = _friendly_error_message(e)
                 if error_msg is None:
-                    error_msg = str(e) + "\n" + traceback.format_exc()
+                    error_msg = scrub_string(str(e) + "\n" + traceback.format_exc())
 
                 await session.send_event(
                     Event(

--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -71,12 +71,14 @@ _patch_litellm_effort_validation()
 
 # Effort levels accepted on the wire.
 #   Anthropic (4.6+):  low | medium | high | xhigh | max   (output_config.effort)
+#   Gemini direct:     minimal | low | medium | high        (reasoning_effort top-level)
 #   OpenAI direct:     minimal | low | medium | high | xhigh (reasoning_effort top-level)
 #   HF router:         low | medium | high                 (extra_body.reasoning_effort)
 #
 # We validate *shape* here and let the probe cascade walk down on rejection;
 # we deliberately do NOT maintain a per-model capability table.
 _ANTHROPIC_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+_GEMINI_EFFORTS = {"minimal", "low", "medium", "high"}
 _OPENAI_EFFORTS = {"minimal", "low", "medium", "high", "xhigh"}
 _HF_EFFORTS = {"low", "medium", "high"}
 
@@ -111,8 +113,12 @@ def _resolve_llm_params(
       will reject this; the probe's cascade catches that and falls back
       to no thinking.
 
+    • ``gemini/<model>`` — ``reasoning_effort`` forwarded as a top-level
+      kwarg; LiteLLM maps it to Gemini 3 thinking levels and uses
+      ``GEMINI_API_KEY``.
+
     • ``openai/<model>`` — ``reasoning_effort`` forwarded as a top-level
-      kwarg (GPT-5 / o-series). LiteLLM uses the user's ``OPENAI_API_KEY``.
+      kwarg (GPT-5 / o-series). LiteLLM uses ``OPENAI_API_KEY``.
 
     • Anything else is treated as a HuggingFace router id. We hit the
       auto-routing OpenAI-compatible endpoint at
@@ -167,6 +173,18 @@ def _resolve_llm_params(
         # The Anthropic thinking/effort shape is not forwarded through Converse
         # the same way, so we leave it off for now.
         return {"model": model_name}
+
+    if model_name.startswith("gemini/"):
+        params = {"model": model_name}
+        if reasoning_effort:
+            if reasoning_effort not in _GEMINI_EFFORTS:
+                if strict:
+                    raise UnsupportedEffortError(
+                        f"Gemini doesn't accept effort={reasoning_effort!r}"
+                    )
+            else:
+                params["reasoning_effort"] = reasoning_effort
+        return params
 
     if model_name.startswith("openai/"):
         params = {"model": model_name}

--- a/agent/core/model_defaults.py
+++ b/agent/core/model_defaults.py
@@ -1,0 +1,23 @@
+"""Model-specific defaults shared by CLI and web sessions."""
+
+MODEL_REASONING_EFFORT_DEFAULTS = {
+    # Product selector entry is intentionally the high-reasoning variant.
+    "openai/gpt-5.5": "high",
+    "gemini/gemini-3.1-pro-preview": "high",
+}
+
+
+def preferred_reasoning_effort(
+    model_name: str,
+    requested_effort: str | None,
+) -> str | None:
+    """Apply model defaults when the user left effort at the global maximum.
+
+    ``max`` is a cross-provider preference meaning "use the strongest sensible
+    reasoning level." Some providers either do not accept that literal value
+    or expose a stronger level than we want in the product selector, so these
+    model entries cap the default without overriding explicit user choices.
+    """
+    if requested_effort == "max":
+        return MODEL_REASONING_EFFORT_DEFAULTS.get(model_name, requested_effort)
+    return requested_effort

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -16,15 +16,17 @@ glues it to CLI output + session state.
 from __future__ import annotations
 
 from agent.core.effort_probe import ProbeInconclusive, probe_effort
+from agent.core.model_defaults import preferred_reasoning_effort
 
 
 # Suggested models shown by `/model` (not a gate). Users can paste any HF
-# model id (e.g. "MiniMaxAI/MiniMax-M2.7") or an `anthropic/` / `openai/`
-# prefix for direct API access. For HF ids, append ":fastest" /
+# model id (e.g. "MiniMaxAI/MiniMax-M2.7") or an `anthropic/` / `gemini/` /
+# `openai/` prefix for direct API access. For HF ids, append ":fastest" /
 # ":cheapest" / ":preferred" / ":<provider>" to override the default
 # routing policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
-    {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
+    {"id": "openai/gpt-5.5", "label": "GPT-5.5 (high)"},
+    {"id": "gemini/gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro"},
     {"id": "openai/gpt-5.4", "label": "GPT-5.4"},
     {"id": "anthropic/claude-opus-4-7", "label": "Claude Opus 4.7"},
     {"id": "anthropic/claude-opus-4-6", "label": "Claude Opus 4.6"},
@@ -63,10 +65,10 @@ def _print_hf_routing_info(model_id: str, console) -> bool:
     proceed with the switch, ``False`` to indicate a hard problem the user
     should notice before we fire the effort probe.
 
-    Anthropic / OpenAI ids return ``True`` without printing anything —
-    the probe below covers "does this model exist".
+    Anthropic / Gemini / OpenAI ids return ``True`` without printing anything
+    — the probe below covers "does this model exist".
     """
-    if model_id.startswith(("anthropic/", "openai/")):
+    if model_id.startswith(("anthropic/", "gemini/", "openai/")):
         return True
 
     from agent.core import hf_router_catalog as cat
@@ -139,7 +141,7 @@ def print_model_listing(config, console) -> None:
     console.print(
         "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M2.7').\n"
         "Add ':fastest', ':cheapest', ':preferred', or ':<provider>' to override routing.\n"
-        "Use 'anthropic/<model>' or 'openai/<model>' for direct API access.[/dim]"
+        "Use 'anthropic/<model>', 'gemini/<model>', or 'openai/<model>' for direct API access.[/dim]"
     )
 
 
@@ -149,6 +151,7 @@ def print_invalid_id(arg: str, console) -> None:
         "[dim]Expected:\n"
         "  • <org>/<model>[:tag]    (HF router — paste from huggingface.co)\n"
         "  • anthropic/<model>\n"
+        "  • gemini/<model>\n"
         "  • openai/<model>[/dim]"
     )
 
@@ -174,7 +177,7 @@ async def probe_and_switch_model(
     Transient errors (5xx, timeout) complete the switch with a yellow
     warning; the next real call re-surfaces the error if it's persistent.
     """
-    preference = config.reasoning_effort
+    preference = preferred_reasoning_effort(model_id, config.reasoning_effort)
     if not _print_hf_routing_info(model_id, console):
         return
 

--- a/agent/core/redact.py
+++ b/agent/core/redact.py
@@ -22,6 +22,8 @@ _PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "[REDACTED_ANTHROPIC_KEY]"),
     # OpenAI: sk-[A-Za-z0-9]{40,}  (legacy + proj keys)
     (re.compile(r"sk-(?!ant-)[A-Za-z0-9_\-]{40,}"), "[REDACTED_OPENAI_KEY]"),
+    # Google AI Studio / Gemini API keys commonly start with AIza.
+    (re.compile(r"AIza[A-Za-z0-9_\-]{30,}"), "[REDACTED_GEMINI_KEY]"),
     # GitHub classic PATs: ghp_, gho_, ghu_, ghs_, ghr_ followed by 36+ chars
     (re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"), "[REDACTED_GITHUB_TOKEN]"),
     # GitHub fine-grained PATs: github_pat_<alphanumeric_underscore>
@@ -37,7 +39,8 @@ _PATTERNS: list[tuple[re.Pattern, str]] = [
 # when the key looks secret-y.
 _SECRETY_NAMES = re.compile(
     r"(?i)\b(HF_TOKEN|HUGGINGFACEHUB_API_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY|"
-    r"GITHUB_TOKEN|AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID|PASSWORD|SECRET|API_KEY)"
+    r"GEMINI_API_KEY|GITHUB_TOKEN|AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID|"
+    r"PASSWORD|SECRET|API_KEY)"
     r"\s*[:=]\s*([^\s\"']+)"
 )
 

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -14,6 +14,7 @@ from agent.config import Config
 from agent.context_manager.manager import ContextManager
 from agent.messaging.gateway import NotificationGateway
 from agent.messaging.models import NotificationRequest
+from agent.core.model_defaults import preferred_reasoning_effort
 
 logger = logging.getLogger(__name__)
 
@@ -321,7 +322,7 @@ class Session:
         """
         if model_name in self.model_effective_effort:
             return self.model_effective_effort[model_name]
-        return self.config.reasoning_effort
+        return preferred_reasoning_effort(model_name, self.config.reasoning_effort)
 
     def increment_turn(self) -> None:
         """Increment turn counter (called after each user interaction)"""

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -57,6 +57,20 @@ AVAILABLE_MODELS = [
         "recommended": True,
     },
     {
+        "id": "openai/gpt-5.5",
+        "label": "GPT-5.5 (high)",
+        "provider": "openai",
+        "tier": "pro",
+        "reasoning_effort": "high",
+    },
+    {
+        "id": "gemini/gemini-3.1-pro-preview",
+        "label": "Gemini 3.1 Pro",
+        "provider": "gemini",
+        "tier": "pro",
+        "reasoning_effort": "high",
+    },
+    {
         "id": "MiniMaxAI/MiniMax-M2.7",
         "label": "MiniMax M2.7",
         "provider": "huggingface",
@@ -78,10 +92,9 @@ def _is_anthropic_model(model_id: str) -> bool:
 async def _require_hf_for_anthropic(request: Request, model_id: str) -> None:
     """403 if a non-``huggingface``-org user tries to select an Anthropic model.
 
-    Anthropic models are billed to the Space's ``ANTHROPIC_API_KEY``; every
-    other model in ``AVAILABLE_MODELS`` is routed through HF Router and
-    billed via ``X-HF-Bill-To``. The gate only fires for Anthropic so
-    non-HF users can still freely switch between the free models.
+    Anthropic models are billed to the Space's ``ANTHROPIC_API_KEY``. The
+    gate only fires for Anthropic so non-HF users can still freely switch
+    between ungated models.
 
     Pattern: https://github.com/huggingface/ml-intern/pull/63
     """

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -43,6 +43,20 @@ const MODEL_OPTIONS: ModelOption[] = [
     recommended: true,
   },
   {
+    id: 'gpt-5.5-high',
+    name: 'GPT-5.5 (high)',
+    description: 'OpenAI',
+    modelPath: 'openai/gpt-5.5',
+    avatarUrl: 'https://huggingface.co/api/avatars/openai',
+  },
+  {
+    id: 'gemini-3.1-pro',
+    name: 'Gemini 3.1 Pro',
+    description: 'Google AI Studio',
+    modelPath: 'gemini/gemini-3.1-pro-preview',
+    avatarUrl: 'https://huggingface.co/api/avatars/google',
+  },
+  {
     id: 'minimax-m2.7',
     name: 'MiniMax M2.7',
     description: 'Novita',

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 import agent.main as main_mod
+from agent.core.model_switcher import SUGGESTED_MODELS
 from agent.tools.research_tool import _get_research_model
 from agent.utils import terminal_display
 
@@ -24,6 +25,13 @@ def test_bedrock_anthropic_research_model_stays_on_bedrock():
 
 def test_non_anthropic_research_model_is_unchanged():
     assert _get_research_model("openai/gpt-5.4") == "openai/gpt-5.4"
+
+
+def test_cli_suggests_new_direct_models():
+    suggested = {m["id"]: m["label"] for m in SUGGESTED_MODELS}
+
+    assert suggested["openai/gpt-5.5"] == "GPT-5.5 (high)"
+    assert suggested["gemini/gemini-3.1-pro-preview"] == "Gemini 3.1 Pro"
 
 
 def test_subagent_display_does_not_spawn_background_redraw(monkeypatch):

--- a/tests/unit/test_llm_error_classification.py
+++ b/tests/unit/test_llm_error_classification.py
@@ -16,6 +16,7 @@ from agent.core.agent_loop import (
     _MAX_LLM_RETRIES,
     _LLM_RATE_LIMIT_RETRY_DELAYS,
     _LLM_RETRY_DELAYS,
+    _friendly_error_message,
     _is_context_overflow_error,
     _is_rate_limit_error,
     _is_transient_error,
@@ -98,3 +99,17 @@ def test_rate_limit_total_budget_covers_bedrock_bucket_recovery():
     exceed the ~60s Bedrock TPM bucket recovery window."""
     assert len(_LLM_RATE_LIMIT_RETRY_DELAYS) == _MAX_LLM_RETRIES - 1
     assert sum(_LLM_RATE_LIMIT_RETRY_DELAYS) > 60
+
+
+def test_quota_error_gets_friendly_message_without_traceback():
+    err = Exception(
+        "litellm.RateLimitError: geminiException - "
+        '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED",'
+        '"message":"Quota exceeded for metric: requests"}}'
+    )
+
+    msg = _friendly_error_message(err)
+
+    assert msg is not None
+    assert "quota" in msg.lower()
+    assert "traceback" not in msg.lower()

--- a/tests/unit/test_llm_params.py
+++ b/tests/unit/test_llm_params.py
@@ -4,6 +4,7 @@ from agent.core.llm_params import (
     _resolve_hf_router_token,
     _resolve_llm_params,
 )
+from agent.core.model_defaults import preferred_reasoning_effort
 
 
 def test_openai_xhigh_effort_is_forwarded():
@@ -28,6 +29,38 @@ def test_openai_max_effort_is_still_rejected():
         assert "OpenAI doesn't accept effort='max'" in str(exc)
     else:
         raise AssertionError("Expected UnsupportedEffortError for max effort")
+
+
+def test_model_default_caps_gpt55_max_to_high():
+    assert preferred_reasoning_effort("openai/gpt-5.5", "max") == "high"
+
+
+def test_model_default_does_not_override_explicit_gpt55_effort():
+    assert preferred_reasoning_effort("openai/gpt-5.5", "xhigh") == "xhigh"
+
+
+def test_gemini_high_effort_is_forwarded():
+    params = _resolve_llm_params(
+        "gemini/gemini-3.1-pro-preview",
+        reasoning_effort="high",
+        strict=True,
+    )
+
+    assert params["model"] == "gemini/gemini-3.1-pro-preview"
+    assert params["reasoning_effort"] == "high"
+
+
+def test_gemini_xhigh_effort_is_rejected():
+    try:
+        _resolve_llm_params(
+            "gemini/gemini-3.1-pro-preview",
+            reasoning_effort="xhigh",
+            strict=True,
+        )
+    except UnsupportedEffortError as exc:
+        assert "Gemini doesn't accept effort='xhigh'" in str(exc)
+    else:
+        raise AssertionError("Expected UnsupportedEffortError for xhigh effort")
 
 
 def test_hf_router_token_prefers_inference_token(monkeypatch):

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -23,6 +23,13 @@ def test_github_token():
     assert out == "[REDACTED_GITHUB_TOKEN]"
 
 
+def test_gemini_key():
+    s = "url?key=AIza" + "A" * 35
+    out = scrub_string(s)
+    assert "AIza" not in out
+    assert "[REDACTED_GEMINI_KEY]" in out
+
+
 def test_github_fine_grained_pat():
     # Fine-grained PATs: github_pat_<alphanumeric + underscore>, 36+ chars
     s = "github_pat_" + "A1B2_" * 10


### PR DESCRIPTION
## Summary
- add GPT-5.5 (high) and Gemini 3.1 Pro to the frontend model selector and backend allowlist
- add Gemini direct-provider LiteLLM routing and effort validation
- add CLI /model suggestions plus shared default-effort handling so GPT-5.5 uses high when the global preference is max
- document the Gemini CLI model id

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/test_llm_params.py tests/unit/test_cli_rendering.py`
- `npm run build`

## Known unrelated failures
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit` fails two existing `test_doom_loop.py` assertion text expectations.
- `npm run lint` fails existing unrelated lint issues in `ActivityStatusBar.tsx`, `agentStore.ts`, `main.tsx`, and `logger.ts`.