### PR TITLE
Azure foundry support added

### DIFF
--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -160,6 +160,23 @@ def _resolve_llm_params(
                 params["output_config"] = {"effort": level}
         return params
 
+    if model_name.startswith("azure/"):
+        # LiteLLM routes ``azure/<deployment-name>`` through the Azure OpenAI
+        # adapter. Credentials are read from standard env vars:
+        #   AZURE_API_KEY      — your Azure AI Foundry API key
+        #   AZURE_API_BASE     — your endpoint URL, e.g.
+        #                        https://<resource>.openai.azure.com/
+        #   AZURE_API_VERSION  — API version, e.g. 2024-02-01
+        import os
+        params: dict = {"model": model_name}
+        if api_base := os.environ.get("AZURE_API_BASE"):
+            params["api_base"] = api_base
+        if api_key := os.environ.get("AZURE_API_KEY"):
+            params["api_key"] = api_key
+        if api_version := os.environ.get("AZURE_API_VERSION"):
+            params["api_version"] = api_version
+        return params
+
     if model_name.startswith("bedrock/"):
         # LiteLLM routes ``bedrock/...`` through the Converse adapter, which
         # picks up AWS credentials from the standard env vars


### PR DESCRIPTION
## Summary
Adds support for models deployed on Azure AI Foundry via LiteLLM's `azure/` prefix.

## Changes
- `agent/core/llm_params.py`: Handle `azure/<deployment>` model names, reading credentials from `AZURE_API_KEY`, `AZURE_API_BASE`, and `AZURE_API_VERSION` env vars
- `README.md`: Document Azure AI Foundry setup with required env vars and usage examples

## Usage
Set the following in your `.env`:
AZURE_API_KEY=<<API KEY>>
AZURE_API_BASE=https://<resource>.openai.azure.com/
AZURE_API_VERSION=<<Version>>
## Run 
ml-intern --model azure/<your-deployment-name> "your prompt"