### PR TITLE
Expose OpenAI models in the UI & make Claude model picker configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Notes
+
+## Local Dev Servers
+
+- Frontend: from `frontend/`, run `npm ci` if dependencies are missing, then `npm run dev`.
+- Backend: from `backend/`, run `uv run uvicorn main:app --host ::1 --port 7860`.
+- Frontend URL: http://localhost:5173/
+- Backend health check: `curl -g http://[::1]:7860/api`
+- Frontend proxy health check: `curl http://localhost:5173/api`
+
+Notes:
+
+- Vite proxies `/api` and `/auth` to `http://localhost:7860`.
+- If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
+- Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,4 @@ Notes:
 - Vite proxies `/api` and `/auth` to `http://localhost:7860`.
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
-- Production defaults to the Bedrock Claude model. For local development with a personal Anthropic key, set `ANTHROPIC_API_KEY` and `ML_INTERN_MODEL_ID=anthropic/claude-opus-4-6` before starting the backend.
+- Production defaults to the Bedrock Claude model. For local development, set `ML_INTERN_MODEL_ID` before starting the backend to test another default model, for example `anthropic/claude-opus-4-6` or `moonshotai/Kimi-K2.6`. Direct Anthropic models also require `ANTHROPIC_API_KEY`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,7 @@ Notes:
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
 - Production defaults to the Bedrock Claude model. For local development with a personal Anthropic key, set `ANTHROPIC_API_KEY` and `ML_INTERN_CLAUDE_MODEL_ID=anthropic/claude-opus-4-6` before starting the backend. Other models are selected through the app's model switcher.
+
+## GitHub CLI
+
+- For multiline PR descriptions, prefer `gh pr edit <number> --body-file <file>` over inline `--body` so shell quoting, `$` env-var names, backticks, and newlines are preserved correctly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,4 @@ Notes:
 - Vite proxies `/api` and `/auth` to `http://localhost:7860`.
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
+- Production defaults to the Bedrock Claude model. For local development with a personal Anthropic key, set `ANTHROPIC_API_KEY` and `ML_INTERN_MODEL_ID=anthropic/claude-opus-4-6` before starting the backend.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,4 @@ Notes:
 - Vite proxies `/api` and `/auth` to `http://localhost:7860`.
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
-- Production defaults to the Bedrock Claude model. For local development, set `ML_INTERN_MODEL_ID` before starting the backend to test another default model, for example `anthropic/claude-opus-4-6` or `moonshotai/Kimi-K2.6`. Direct Anthropic models also require `ANTHROPIC_API_KEY`.
+- Production defaults to the Bedrock Claude model. For local development with a personal Anthropic key, set `ANTHROPIC_API_KEY` and `ML_INTERN_CLAUDE_MODEL_ID=anthropic/claude-opus-4-6` before starting the backend. Other models are selected through the app's model switcher.

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -111,7 +111,7 @@ async def _fetch_user_plan(token: str) -> str:
 
     # OAuth whoami sets `type: "user"` and surfaces Pro via the `isPro` boolean
     # — see Space discussion #21. HF-Jobs eligibility (PR #172) ignores plan
-    # entirely; the Claude daily-cap tier is still a free vs pro/org split.
+    # entirely; the premium-model daily-cap tier is still a free vs pro/org split.
     if whoami.get("isPro") is True or whoami.get("is_pro") is True:
         return "pro"
     plan_str = ""

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -41,8 +41,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["agent"])
 
-BEDROCK_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
-PREMIUM_GATED_MODEL_IDS = {"openai/gpt-5.5"}
+DEFAULT_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
+GATED_MODEL_IDS = {
+    DEFAULT_CLAUDE_MODEL_ID,
+    "openai/gpt-5.5",
+}
 
 
 def _claude_picker_model_id() -> str:
@@ -52,7 +55,7 @@ def _claude_picker_model_id() -> str:
     Claude endpoint between production Bedrock and local Anthropic. Other
     models are selected through the model switcher.
     """
-    return session_manager.config.model_name or BEDROCK_CLAUDE_MODEL_ID
+    return session_manager.config.model_name
 
 
 def _available_models() -> list[dict[str, Any]]:
@@ -96,24 +99,22 @@ def _available_models() -> list[dict[str, Any]]:
 AVAILABLE_MODELS = _available_models()
 
 
-def _is_anthropic_model(model_id: str) -> bool:
-    return "anthropic" in model_id
+def _is_gated_model(model_id: str) -> bool:
+    return model_id in GATED_MODEL_IDS
 
 
-def _is_premium_model(model_id: str) -> bool:
-    return _is_anthropic_model(model_id) or model_id in PREMIUM_GATED_MODEL_IDS
+async def _require_hf_for_gated_model(request: Request, model_id: str) -> None:
+    """403 if a non-``huggingface``-org user tries to select a gated model.
 
-
-async def _require_hf_for_premium_model(request: Request, model_id: str) -> None:
-    """403 if a non-``huggingface``-org user tries to select a premium model.
-
-    Premium models are billed through service-owned provider credentials or
-    otherwise costly endpoints. The gate only fires for those models so
-    non-HF users can still freely switch between the free models.
+    Gated models are deployed paid endpoints backed by service-owned
+    credentials. Direct ``anthropic/...`` is intentionally not covered here:
+    that path is for local development with a developer's own Anthropic key.
+    The gate only fires for deployed paid models so non-HF users can still
+    freely switch between the free models.
 
     Pattern: https://github.com/huggingface/ml-intern/pull/63
     """
-    if not _is_premium_model(model_id):
+    if not _is_gated_model(model_id):
         return
     if not await require_huggingface_org_member(request):
         raise HTTPException(
@@ -128,25 +129,25 @@ async def _require_hf_for_premium_model(request: Request, model_id: str) -> None
         )
 
 
-async def _enforce_premium_model_quota(
+async def _enforce_gated_model_quota(
     user: dict[str, Any],
     agent_session: AgentSession,
 ) -> None:
-    """Charge the user's daily premium-model quota on first use in a session.
+    """Charge the user's daily gated-model quota on first use in a session.
 
     Runs at *message-submit* time, not session-create time — so spinning up a
-    premium-model session to look around doesn't burn quota. The
+    gated-model session to look around doesn't burn quota. The
     ``claude_counted`` flag on ``AgentSession`` guards against re-counting the
     same session; the stored field name is kept for persistence compatibility.
 
-    No-ops when the session's current model isn't premium, or when this
+    No-ops when the session's current model isn't gated, or when this
     session has already been charged. Raises 429 when the user has hit
     their daily cap.
     """
     if agent_session.claude_counted:
         return
     model_name = agent_session.session.config.model_name
-    if not _is_premium_model(model_name):
+    if not _is_gated_model(model_name):
         return
     user_id = user["user_id"]
     cap = user_quotas.daily_cap_for(user.get("plan"))
@@ -335,7 +336,7 @@ async def create_session(
     behalf of the user.
 
     Optional body ``{"model"?: <id>}`` selects the session's LLM; unknown
-    ids are rejected (400). The premium-model quota gate runs at message-submit
+    ids are rejected (400). The gated-model quota runs at message-submit
     time, not here — spinning up a session to look around is free.
 
     Returns 503 if the server or user has reached the session limit.
@@ -356,9 +357,9 @@ async def create_session(
     if model and model not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
 
-    # Premium models are gated to HF staff; free models pass through.
+    # Deployed paid models are gated to HF staff; free and local-dev models pass through.
     resolved_model = model or session_manager.config.model_name
-    await _require_hf_for_premium_model(request, resolved_model)
+    await _require_hf_for_gated_model(request, resolved_model)
 
     try:
         session_id = await session_manager.create_session(
@@ -383,7 +384,7 @@ async def restore_session_summary(
     session's context as a user-role system note.
 
     Optional ``"model"`` in the body overrides the session's LLM. The
-    premium-model quota gate runs at message-submit time, not here.
+    gated-model quota runs at message-submit time, not here.
     """
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
@@ -397,7 +398,7 @@ async def restore_session_summary(
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
 
     resolved_model = model or session_manager.config.model_name
-    await _require_hf_for_premium_model(request, resolved_model)
+    await _require_hf_for_gated_model(request, resolved_model)
 
     try:
         session_id = await session_manager.create_session(
@@ -445,10 +446,10 @@ async def set_session_model(
 
     Takes effect on the next LLM call in that session — other sessions
     (including other browser tabs) are unaffected. Model switches don't
-    charge quota — the premium-model quota gate only fires at message-submit time.
+    charge quota — the gated-model quota only fires at message-submit time.
 
-    Switching TO a premium model requires HF org membership; free-model
-    switches are unrestricted.
+    Switching TO a gated deployed model requires HF org membership; free-model
+    and local-dev direct provider switches are unrestricted.
     """
     agent_session = await _check_session_access(session_id, user, request)
     model_id = body.get("model")
@@ -457,7 +458,7 @@ async def set_session_model(
     valid_ids = {m["id"] for m in AVAILABLE_MODELS}
     if model_id not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}")
-    await _require_hf_for_premium_model(request, model_id)
+    await _require_hf_for_gated_model(request, model_id)
     if not agent_session:
         raise HTTPException(status_code=404, detail="Session not found")
     await session_manager.update_session_model(session_id, model_id)
@@ -547,7 +548,7 @@ async def submit_input(
 ) -> dict:
     """Submit user input to a session. Only accessible by the session owner."""
     agent_session = await _check_session_access(request.session_id, user)
-    await _enforce_premium_model_quota(user, agent_session)
+    await _enforce_gated_model_quota(user, agent_session)
     success = await session_manager.submit_user_input(request.session_id, request.text)
     if not success:
         raise HTTPException(status_code=404, detail="Session not found or inactive")
@@ -599,12 +600,12 @@ async def chat_sse(
     text = body.get("text")
     approvals = body.get("approvals")
 
-    # Gate user-message sends against the daily premium-model quota. Approvals are
+    # Gate user-message sends against the daily gated-model quota. Approvals are
     # continuations of an in-progress turn — the session was already charged
     # on its first message, so we skip the gate there.
     if text is not None and not approvals:
         try:
-            await _enforce_premium_model_quota(user, agent_session)
+            await _enforce_gated_model_quota(user, agent_session)
         except HTTPException:
             broadcaster.unsubscribe(sub_id)
             raise

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -44,43 +44,66 @@ router = APIRouter(prefix="/api", tags=["agent"])
 BEDROCK_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
 
 
-def _default_claude_model_id() -> str:
+def _claude_picker_model_id() -> str:
+    """Resolve the model sent by the Claude menu entry.
+
+    ``ML_INTERN_MODEL_ID`` controls the default session model and may point to
+    non-Claude HF Router models for local testing. Only reuse it for the Claude
+    picker when it is actually an Anthropic/Bedrock Claude model.
+    """
     default_model = session_manager.config.model_name
     if "anthropic" in default_model:
         return default_model
     return BEDROCK_CLAUDE_MODEL_ID
 
 
-DEFAULT_CLAUDE_MODEL_ID = _default_claude_model_id()
+def _default_model_option(model_id: str) -> dict[str, Any]:
+    provider = "anthropic" if "anthropic" in model_id else "huggingface"
+    return {
+        "id": model_id,
+        "label": model_id.split("/")[-1],
+        "provider": provider,
+        "tier": "pro" if provider == "anthropic" else "free",
+        "recommended": True,
+    }
 
-AVAILABLE_MODELS = [
-    {
-        "id": "moonshotai/Kimi-K2.6",
-        "label": "Kimi K2.6",
-        "provider": "huggingface",
-        "tier": "free",
-        "recommended": True,
-    },
-    {
-        "id": DEFAULT_CLAUDE_MODEL_ID,
-        "label": "Claude Opus 4.6",
-        "provider": "anthropic",
-        "tier": "pro",
-        "recommended": True,
-    },
-    {
-        "id": "MiniMaxAI/MiniMax-M2.7",
-        "label": "MiniMax M2.7",
-        "provider": "huggingface",
-        "tier": "free",
-    },
-    {
-        "id": "zai-org/GLM-5.1",
-        "label": "GLM 5.1",
-        "provider": "huggingface",
-        "tier": "free",
-    },
-]
+
+def _available_models() -> list[dict[str, Any]]:
+    models = [
+        {
+            "id": "moonshotai/Kimi-K2.6",
+            "label": "Kimi K2.6",
+            "provider": "huggingface",
+            "tier": "free",
+            "recommended": True,
+        },
+        {
+            "id": _claude_picker_model_id(),
+            "label": "Claude Opus 4.6",
+            "provider": "anthropic",
+            "tier": "pro",
+            "recommended": True,
+        },
+        {
+            "id": "MiniMaxAI/MiniMax-M2.7",
+            "label": "MiniMax M2.7",
+            "provider": "huggingface",
+            "tier": "free",
+        },
+        {
+            "id": "zai-org/GLM-5.1",
+            "label": "GLM 5.1",
+            "provider": "huggingface",
+            "tier": "free",
+        },
+    ]
+    default_model = session_manager.config.model_name
+    if default_model not in {model["id"] for model in models}:
+        models.insert(0, _default_model_option(default_model))
+    return models
+
+
+AVAILABLE_MODELS = _available_models()
 
 
 def _is_anthropic_model(model_id: str) -> bool:

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -71,6 +71,12 @@ def _available_models() -> list[dict[str, Any]]:
             "recommended": True,
         },
         {
+            "id": "openai/gpt-5.5",
+            "label": "GPT-5.5",
+            "provider": "openai",
+            "tier": "pro",
+        },
+        {
             "id": "MiniMaxAI/MiniMax-M2.7",
             "label": "MiniMax M2.7",
             "provider": "huggingface",

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -501,10 +501,6 @@ async def get_user_quota(user: dict = Depends(get_current_user)) -> dict:
         "premium_used_today": used,
         "premium_daily_cap": cap,
         "premium_remaining": remaining,
-        # Backward-compatible aliases for the existing frontend and clients.
-        "claude_used_today": used,
-        "claude_daily_cap": cap,
-        "claude_remaining": remaining,
     }
 
 

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["agent"])
 
 BEDROCK_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
+PREMIUM_GATED_MODEL_IDS = {"openai/gpt-5.5"}
 
 
 def _claude_picker_model_id() -> str:
@@ -99,49 +100,53 @@ def _is_anthropic_model(model_id: str) -> bool:
     return "anthropic" in model_id
 
 
-async def _require_hf_for_anthropic(request: Request, model_id: str) -> None:
-    """403 if a non-``huggingface``-org user tries to select an Anthropic model.
+def _is_premium_model(model_id: str) -> bool:
+    return _is_anthropic_model(model_id) or model_id in PREMIUM_GATED_MODEL_IDS
 
-    Anthropic models are billed to the Space's ``ANTHROPIC_API_KEY``; every
-    other model in ``AVAILABLE_MODELS`` is routed through HF Router and
-    billed via ``X-HF-Bill-To``. The gate only fires for Anthropic so
+
+async def _require_hf_for_premium_model(request: Request, model_id: str) -> None:
+    """403 if a non-``huggingface``-org user tries to select a premium model.
+
+    Premium models are billed through service-owned provider credentials or
+    otherwise costly endpoints. The gate only fires for those models so
     non-HF users can still freely switch between the free models.
 
     Pattern: https://github.com/huggingface/ml-intern/pull/63
     """
-    if not _is_anthropic_model(model_id):
+    if not _is_premium_model(model_id):
         return
     if not await require_huggingface_org_member(request):
         raise HTTPException(
             status_code=403,
             detail={
-                "error": "anthropic_restricted",
+                "error": "premium_model_restricted",
                 "message": (
-                    "Opus is gated to HF staff. Pick a free model — "
+                    "Premium models are gated to HF staff. Pick a free model — "
                     "Kimi K2.6, MiniMax M2.7, or GLM 5.1 — instead."
                 ),
             },
         )
 
 
-async def _enforce_claude_quota(
+async def _enforce_premium_model_quota(
     user: dict[str, Any],
     agent_session: AgentSession,
 ) -> None:
-    """Charge the user's daily Claude quota on first use of Anthropic in a session.
+    """Charge the user's daily premium-model quota on first use in a session.
 
     Runs at *message-submit* time, not session-create time — so spinning up a
-    Claude session to look around doesn't burn quota. The ``claude_counted``
-    flag on ``AgentSession`` guards against re-counting the same session.
+    premium-model session to look around doesn't burn quota. The
+    ``claude_counted`` flag on ``AgentSession`` guards against re-counting the
+    same session; the stored field name is kept for persistence compatibility.
 
-    No-ops when the session's current model isn't Anthropic, or when this
+    No-ops when the session's current model isn't premium, or when this
     session has already been charged. Raises 429 when the user has hit
     their daily cap.
     """
     if agent_session.claude_counted:
         return
     model_name = agent_session.session.config.model_name
-    if not _is_anthropic_model(model_name):
+    if not _is_premium_model(model_name):
         return
     user_id = user["user_id"]
     cap = user_quotas.daily_cap_for(user.get("plan"))
@@ -150,11 +155,11 @@ async def _enforce_claude_quota(
         raise HTTPException(
             status_code=429,
             detail={
-                "error": "claude_daily_cap",
+                "error": "premium_model_daily_cap",
                 "plan": user.get("plan", "free"),
                 "cap": cap,
                 "message": (
-                    "Daily Claude limit reached. Upgrade to HF Pro for "
+                    "Daily premium model limit reached. Upgrade to HF Pro for "
                     f"{user_quotas.CLAUDE_PRO_DAILY}/day or use a free model."
                 ),
             },
@@ -330,8 +335,8 @@ async def create_session(
     behalf of the user.
 
     Optional body ``{"model"?: <id>}`` selects the session's LLM; unknown
-    ids are rejected (400). The Claude-quota gate runs at message-submit
-    time, not here — spinning up an Opus session to look around is free.
+    ids are rejected (400). The premium-model quota gate runs at message-submit
+    time, not here — spinning up a session to look around is free.
 
     Returns 503 if the server or user has reached the session limit.
     """
@@ -351,10 +356,9 @@ async def create_session(
     if model and model not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
 
-    # Opus is gated to HF staff (PR #63). Only fires when the resolved model
-    # is Anthropic; free models pass through.
+    # Premium models are gated to HF staff; free models pass through.
     resolved_model = model or session_manager.config.model_name
-    await _require_hf_for_anthropic(request, resolved_model)
+    await _require_hf_for_premium_model(request, resolved_model)
 
     try:
         session_id = await session_manager.create_session(
@@ -379,7 +383,7 @@ async def restore_session_summary(
     session's context as a user-role system note.
 
     Optional ``"model"`` in the body overrides the session's LLM. The
-    Claude-quota gate runs at message-submit time, not here.
+    premium-model quota gate runs at message-submit time, not here.
     """
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
@@ -393,7 +397,7 @@ async def restore_session_summary(
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
 
     resolved_model = model or session_manager.config.model_name
-    await _require_hf_for_anthropic(request, resolved_model)
+    await _require_hf_for_premium_model(request, resolved_model)
 
     try:
         session_id = await session_manager.create_session(
@@ -441,10 +445,10 @@ async def set_session_model(
 
     Takes effect on the next LLM call in that session — other sessions
     (including other browser tabs) are unaffected. Model switches don't
-    charge quota — the Claude-quota gate only fires at message-submit time.
+    charge quota — the premium-model quota gate only fires at message-submit time.
 
-    Switching TO an Anthropic model requires HF org membership (PR #63);
-    free-model switches are unrestricted.
+    Switching TO a premium model requires HF org membership; free-model
+    switches are unrestricted.
     """
     agent_session = await _check_session_access(session_id, user, request)
     model_id = body.get("model")
@@ -453,7 +457,7 @@ async def set_session_model(
     valid_ids = {m["id"] for m in AVAILABLE_MODELS}
     if model_id not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}")
-    await _require_hf_for_anthropic(request, model_id)
+    await _require_hf_for_premium_model(request, model_id)
     if not agent_session:
         raise HTTPException(status_code=404, detail="Session not found")
     await session_manager.update_session_model(session_id, model_id)
@@ -487,15 +491,20 @@ async def set_session_notifications(
 
 @router.get("/user/quota")
 async def get_user_quota(user: dict = Depends(get_current_user)) -> dict:
-    """Return the user's plan tier and today's Claude-session quota state."""
+    """Return the user's plan tier and today's premium-model quota state."""
     plan = user.get("plan", "free")
     used = await user_quotas.get_claude_used_today(user["user_id"])
     cap = user_quotas.daily_cap_for(plan)
+    remaining = max(0, cap - used)
     return {
         "plan": plan,
+        "premium_used_today": used,
+        "premium_daily_cap": cap,
+        "premium_remaining": remaining,
+        # Backward-compatible aliases for the existing frontend and clients.
         "claude_used_today": used,
         "claude_daily_cap": cap,
-        "claude_remaining": max(0, cap - used),
+        "claude_remaining": remaining,
     }
 
 
@@ -542,7 +551,7 @@ async def submit_input(
 ) -> dict:
     """Submit user input to a session. Only accessible by the session owner."""
     agent_session = await _check_session_access(request.session_id, user)
-    await _enforce_claude_quota(user, agent_session)
+    await _enforce_premium_model_quota(user, agent_session)
     success = await session_manager.submit_user_input(request.session_id, request.text)
     if not success:
         raise HTTPException(status_code=404, detail="Session not found or inactive")
@@ -594,12 +603,12 @@ async def chat_sse(
     text = body.get("text")
     approvals = body.get("approvals")
 
-    # Gate user-message sends against the daily Claude quota. Approvals are
+    # Gate user-message sends against the daily premium-model quota. Approvals are
     # continuations of an in-progress turn — the session was already charged
     # on its first message, so we skip the gate there.
     if text is not None and not approvals:
         try:
-            await _enforce_claude_quota(user, agent_session)
+            await _enforce_premium_model_quota(user, agent_session)
         except HTTPException:
             broadcaster.unsubscribe(sub_id)
             raise

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -47,25 +47,11 @@ BEDROCK_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
 def _claude_picker_model_id() -> str:
     """Resolve the model sent by the Claude menu entry.
 
-    ``ML_INTERN_MODEL_ID`` controls the default session model and may point to
-    non-Claude HF Router models for local testing. Only reuse it for the Claude
-    picker when it is actually an Anthropic/Bedrock Claude model.
+    ``ML_INTERN_CLAUDE_MODEL_ID`` is intentionally scoped to switching the
+    Claude endpoint between production Bedrock and local Anthropic. Other
+    models are selected through the model switcher.
     """
-    default_model = session_manager.config.model_name
-    if "anthropic" in default_model:
-        return default_model
-    return BEDROCK_CLAUDE_MODEL_ID
-
-
-def _default_model_option(model_id: str) -> dict[str, Any]:
-    provider = "anthropic" if "anthropic" in model_id else "huggingface"
-    return {
-        "id": model_id,
-        "label": model_id.split("/")[-1],
-        "provider": provider,
-        "tier": "pro" if provider == "anthropic" else "free",
-        "recommended": True,
-    }
+    return session_manager.config.model_name or BEDROCK_CLAUDE_MODEL_ID
 
 
 def _available_models() -> list[dict[str, Any]]:
@@ -97,9 +83,6 @@ def _available_models() -> list[dict[str, Any]]:
             "tier": "free",
         },
     ]
-    default_model = session_manager.config.model_name
-    if default_model not in {model["id"] for model in models}:
-        models.insert(0, _default_model_option(default_model))
     return models
 
 

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -49,11 +49,13 @@ GATED_MODEL_IDS = {
 
 
 def _claude_picker_model_id() -> str:
-    """Resolve the model sent by the Claude menu entry.
+    """Return the model ID used by the Claude option in the UI.
 
-    ``ML_INTERN_CLAUDE_MODEL_ID`` is intentionally scoped to switching the
-    Claude endpoint between production Bedrock and local Anthropic. Other
-    models are selected through the model switcher.
+    The frontend config sets ``session_manager.config.model_name`` from
+    ``ML_INTERN_CLAUDE_MODEL_ID`` when that env var is present, otherwise it
+    falls back to the production Bedrock Claude model. This function only
+    exposes that resolved config value for the Claude picker; non-Claude models
+    are listed separately in the model switcher.
     """
     return session_manager.config.model_name
 
@@ -107,12 +109,8 @@ async def _require_hf_for_gated_model(request: Request, model_id: str) -> None:
     """403 if a non-``huggingface``-org user tries to select a gated model.
 
     Gated models are deployed paid endpoints backed by service-owned
-    credentials. Direct ``anthropic/...`` is intentionally not covered here:
-    that path is for local development with a developer's own Anthropic key.
-    The gate only fires for deployed paid models so non-HF users can still
-    freely switch between the free models.
-
-    Pattern: https://github.com/huggingface/ml-intern/pull/63
+    credentials. The gate only fires for deployed paid models so non-HF users 
+    can still freely switch between the free models.
     """
     if not _is_gated_model(model_id):
         return

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -41,6 +41,18 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["agent"])
 
+BEDROCK_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
+
+
+def _default_claude_model_id() -> str:
+    default_model = session_manager.config.model_name
+    if "anthropic" in default_model:
+        return default_model
+    return BEDROCK_CLAUDE_MODEL_ID
+
+
+DEFAULT_CLAUDE_MODEL_ID = _default_claude_model_id()
+
 AVAILABLE_MODELS = [
     {
         "id": "moonshotai/Kimi-K2.6",
@@ -50,7 +62,7 @@ AVAILABLE_MODELS = [
         "recommended": True,
     },
     {
-        "id": "bedrock/us.anthropic.claude-opus-4-6-v1",
+        "id": DEFAULT_CLAUDE_MODEL_ID,
         "label": "Claude Opus 4.6",
         "provider": "anthropic",
         "tier": "pro",

--- a/backend/user_quotas.py
+++ b/backend/user_quotas.py
@@ -1,12 +1,15 @@
-"""Daily quota for Claude session creations.
+"""Daily quota for premium model session creations.
 
-Tracks per-user Claude session starts against a daily cap derived from the
-user's HF plan. MongoDB is the source of truth when configured; the
+Tracks per-user premium model session starts against a daily cap derived from
+the user's HF plan. MongoDB is the source of truth when configured; the
 in-process dict remains the fallback for local/dev/test runs.
 
-Unit: session *creations*, not messages. A user who selects Claude in a new
-session consumes one quota point; switching an existing Claude session to
-Claude again doesn't (`AgentSession.claude_counted` guards that).
+The public names still say ``claude`` because this quota bucket originally
+only covered Claude and the persisted session field uses that name.
+
+Unit: session *creations*, not messages. A user who sends with a premium model
+in a new session consumes one quota point; switching an already-counted session
+back to a premium model doesn't (`AgentSession.claude_counted` guards that).
 
 Cap tiers:
   free user   → CLAUDE_FREE_DAILY (1)

--- a/configs/frontend_agent_config.json
+++ b/configs/frontend_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "bedrock/us.anthropic.claude-opus-4-6-v1",
+  "model_name": "${ML_INTERN_MODEL_ID:-bedrock/us.anthropic.claude-opus-4-6-v1}",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "yolo_mode": false,

--- a/configs/frontend_agent_config.json
+++ b/configs/frontend_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "${ML_INTERN_MODEL_ID:-bedrock/us.anthropic.claude-opus-4-6-v1}",
+  "model_name": "${ML_INTERN_CLAUDE_MODEL_ID:-bedrock/us.anthropic.claude-opus-4-6-v1}",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "yolo_mode": false,

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -309,11 +309,11 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   // Hide the chip until the user has actually burned quota; opening a
   // premium-model session without sending should not populate a counter.
   const premiumChip = (() => {
-    if (!quota || quota.claudeUsedToday === 0) return null;
+    if (!quota || quota.premiumUsedToday === 0) return null;
     if (quota.plan === 'free') {
-      return quota.claudeRemaining > 0 ? 'Free today' : 'Pro only';
+      return quota.premiumRemaining > 0 ? 'Free today' : 'Pro only';
     }
-    return `${quota.claudeUsedToday}/${quota.claudeDailyCap} today`;
+    return `${quota.premiumUsedToday}/${quota.premiumDailyCap} today`;
   })();
 
   return (
@@ -541,7 +541,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
         <ClaudeCapDialog
           open={claudeQuotaExhausted}
           plan={quota?.plan ?? 'free'}
-          cap={quota?.claudeDailyCap ?? 1}
+          cap={quota?.premiumDailyCap ?? 1}
           onClose={handleCapDialogClose}
           onUseFreeModel={handleUseFreeModel}
           onUpgrade={handlePremiumUpgradeClick}

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -43,6 +43,13 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
     recommended: true,
   },
   {
+    id: 'gpt-5.5',
+    name: 'GPT-5.5',
+    description: 'OpenAI',
+    modelPath: 'openai/gpt-5.5',
+    avatarUrl: 'https://huggingface.co/api/avatars/openai',
+  },
+  {
     id: 'minimax-m2.7',
     name: 'MiniMax M2.7',
     description: 'Novita',

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -8,7 +8,13 @@ import { useUserQuota } from '@/hooks/useUserQuota';
 import ClaudeCapDialog from '@/components/ClaudeCapDialog';
 import JobsUpgradeDialog from '@/components/JobsUpgradeDialog';
 import { useAgentStore } from '@/store/agentStore';
-import { CLAUDE_MODEL_PATH, FIRST_FREE_MODEL_PATH, isClaudePath } from '@/utils/model';
+import {
+  CLAUDE_MODEL_PATH,
+  FIRST_FREE_MODEL_PATH,
+  GPT_55_MODEL_PATH,
+  isClaudePath,
+  isPremiumPath,
+} from '@/utils/model';
 
 // Model configuration
 interface ModelOption {
@@ -46,7 +52,7 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
     id: 'gpt-5.5',
     name: 'GPT-5.5',
     description: 'OpenAI',
-    modelPath: 'openai/gpt-5.5',
+    modelPath: GPT_55_MODEL_PATH,
     avatarUrl: 'https://huggingface.co/api/avatars/openai',
   },
   {
@@ -79,7 +85,8 @@ interface ChatInputProps {
 }
 
 const isClaudeModel = (m: ModelOption) => isClaudePath(m.modelPath);
-const firstFreeModel = (options: ModelOption[]) => options.find(m => !isClaudeModel(m)) ?? options[0];
+const isPremiumModel = (m: ModelOption) => isPremiumPath(m.modelPath);
+const firstFreeModel = (options: ModelOption[]) => options.find(m => !isPremiumModel(m)) ?? options[0];
 
 export default function ChatInput({ sessionId, onSend, onStop, isProcessing = false, disabled = false, placeholder = 'Ask anything...' }: ChatInputProps) {
   const [input, setInput] = useState('');
@@ -89,7 +96,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   const [modelAnchorEl, setModelAnchorEl] = useState<null | HTMLElement>(null);
   const { quota, refresh: refreshQuota } = useUserQuota();
   // The daily-cap dialog is triggered from two places: (a) a 429 returned
-  // from the chat transport when the user tries to send on Opus over cap —
+  // from the chat transport when the user tries to send on a premium model over cap —
   // surfaced via the agent-store flag — and (b) nothing else right now
   // (switching models is free). Keeping the open state in the store means
   // the hook layer can flip it without threading props through.
@@ -159,7 +166,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
     }
   }, [input, disabled, onSend]);
 
-  // When the chat transport reports a Claude-quota 429, restore the typed
+  // When the chat transport reports a premium-model quota 429, restore the typed
   // text so the user doesn't lose their message.
   useEffect(() => {
     if (claudeQuotaExhausted && lastSentRef.current) {
@@ -210,7 +217,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   }, [setClaudeQuotaExhausted]);
 
   // "Use a free model" — switch the current session to Kimi (or the first
-  // non-Anthropic option) and auto-retry the send that tripped the cap.
+  // non-premium option) and auto-retry the send that tripped the cap.
   const handleUseFreeModel = useCallback(async () => {
     setClaudeQuotaExhausted(false);
     if (!sessionId) return;
@@ -233,12 +240,12 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
     } catch { /* ignore */ }
   }, [sessionId, onSend, setClaudeQuotaExhausted, modelOptions]);
 
-  const handleClaudeUpgradeClick = useCallback(async () => {
+  const handlePremiumUpgradeClick = useCallback(async () => {
     if (!sessionId) return;
     try {
       await apiFetch(`/api/pro-click/${sessionId}`, {
         method: 'POST',
-        body: JSON.stringify({ source: 'claude_cap_dialog', target: 'pro_pricing' }),
+        body: JSON.stringify({ source: 'premium_cap_dialog', target: 'pro_pricing' }),
       });
     } catch {
       /* tracking is best-effort */
@@ -286,9 +293,9 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, [awaitingTopUp, jobsUpgradeRequired, handleJobsRetry]);
 
-  // Hide the chip until the user has actually burned quota — an unused
-  // Opus session shouldn't populate a counter.
-  const claudeChip = (() => {
+  // Hide the chip until the user has actually burned quota; opening a
+  // premium-model session without sending should not populate a counter.
+  const premiumChip = (() => {
     if (!quota || quota.claudeUsedToday === 0) return null;
     if (quota.plan === 'free') {
       return quota.claudeRemaining > 0 ? 'Free today' : 'Pro only';
@@ -494,9 +501,9 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
                         }}
                       />
                     )}
-                    {isClaudeModel(model) && claudeChip && (
+                    {isPremiumModel(model) && premiumChip && (
                       <Chip
-                        label={claudeChip}
+                        label={premiumChip}
                         size="small"
                         sx={{
                           height: '18px',
@@ -524,7 +531,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
           cap={quota?.claudeDailyCap ?? 1}
           onClose={handleCapDialogClose}
           onUseFreeModel={handleUseFreeModel}
-          onUpgrade={handleClaudeUpgradeClick}
+          onUpgrade={handlePremiumUpgradeClick}
         />
         <JobsUpgradeDialog
           open={!!jobsUpgradeRequired}

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -20,6 +20,13 @@ interface ModelOption {
   recommended?: boolean;
 }
 
+interface BackendModelOption {
+  id: string;
+  label?: string;
+  provider?: string;
+  recommended?: boolean;
+}
+
 const getHfAvatarUrl = (modelId: string) => {
   const org = modelId.split('/')[0];
   return `https://huggingface.co/api/avatars/${org}`;
@@ -62,6 +69,37 @@ const findModelByPath = (path: string, options: ModelOption[]): ModelOption | un
   return options.find(m => m.modelPath === path || path?.includes(m.id));
 };
 
+const optionFromBackend = (model: BackendModelOption, existing?: ModelOption): ModelOption => {
+  const isClaude = model.provider === 'anthropic' || isClaudePath(model.id);
+  return {
+    id: existing?.id ?? model.id,
+    name: model.label ?? existing?.name ?? model.id.split('/').pop() ?? model.id,
+    description: existing?.description ?? (isClaude ? 'Anthropic' : 'Hugging Face'),
+    modelPath: model.id,
+    avatarUrl: existing?.avatarUrl ?? (isClaude
+      ? 'https://huggingface.co/api/avatars/Anthropic'
+      : getHfAvatarUrl(model.id)),
+    recommended: model.recommended ?? existing?.recommended,
+  };
+};
+
+const mergeBackendModels = (models: BackendModelOption[], fallback: ModelOption[]): ModelOption[] => {
+  const next = models
+    .filter((model) => !!model.id)
+    .map((model) => {
+      const existing = model.provider === 'anthropic'
+        ? fallback.find((option) => isClaudePath(option.modelPath))
+        : findModelByPath(model.id, fallback);
+      return optionFromBackend(model, existing);
+    });
+  for (const option of fallback) {
+    if (!next.some((model) => model.modelPath === option.modelPath)) {
+      next.push(option);
+    }
+  }
+  return next;
+};
+
 interface ChatInputProps {
   sessionId?: string;
   onSend: (text: string) => void;
@@ -99,23 +137,12 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (cancelled || !data?.available) return;
-        const claude = data.available.find((m: { provider?: string; id?: string }) => (
-          m.provider === 'anthropic' && m.id
-        ));
-        if (!claude?.id) return;
-
-        setModelOptions((options) => {
-          const next = options.map((option) => (
-            isClaudeModel(option)
-              ? { ...option, modelPath: claude.id, name: claude.label ?? option.name }
-              : option
-          ));
-          if (data.current) {
-            const current = findModelByPath(data.current, next);
-            if (current) setSelectedModelId(current.id);
-          }
-          return next;
-        });
+        const next = mergeBackendModels(data.available, DEFAULT_MODEL_OPTIONS);
+        setModelOptions(next);
+        if (data.current) {
+          const current = findModelByPath(data.current, next);
+          if (current) setSelectedModelId(current.id);
+        }
       })
       .catch(() => { /* ignore */ });
     return () => { cancelled = true; };

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -25,7 +25,7 @@ const getHfAvatarUrl = (modelId: string) => {
   return `https://huggingface.co/api/avatars/${org}`;
 };
 
-const MODEL_OPTIONS: ModelOption[] = [
+const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   {
     id: 'kimi-k2.6',
     name: 'Kimi K2.6',
@@ -58,8 +58,8 @@ const MODEL_OPTIONS: ModelOption[] = [
   },
 ];
 
-const findModelByPath = (path: string): ModelOption | undefined => {
-  return MODEL_OPTIONS.find(m => m.modelPath === path || path?.includes(m.id));
+const findModelByPath = (path: string, options: ModelOption[]): ModelOption | undefined => {
+  return options.find(m => m.modelPath === path || path?.includes(m.id));
 };
 
 interface ChatInputProps {
@@ -72,12 +72,13 @@ interface ChatInputProps {
 }
 
 const isClaudeModel = (m: ModelOption) => isClaudePath(m.modelPath);
-const firstFreeModel = () => MODEL_OPTIONS.find(m => !isClaudeModel(m)) ?? MODEL_OPTIONS[0];
+const firstFreeModel = (options: ModelOption[]) => options.find(m => !isClaudeModel(m)) ?? options[0];
 
 export default function ChatInput({ sessionId, onSend, onStop, isProcessing = false, disabled = false, placeholder = 'Ask anything...' }: ChatInputProps) {
   const [input, setInput] = useState('');
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const [selectedModelId, setSelectedModelId] = useState<string>(MODEL_OPTIONS[0].id);
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>(DEFAULT_MODEL_OPTIONS);
+  const [selectedModelId, setSelectedModelId] = useState<string>(DEFAULT_MODEL_OPTIONS[0].id);
   const [modelAnchorEl, setModelAnchorEl] = useState<null | HTMLElement>(null);
   const { quota, refresh: refreshQuota } = useUserQuota();
   // The daily-cap dialog is triggered from two places: (a) a 429 returned
@@ -92,6 +93,34 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   const [awaitingTopUp, setAwaitingTopUp] = useState(false);
   const lastSentRef = useRef<string>('');
 
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch('/api/config/model')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data?.available) return;
+        const claude = data.available.find((m: { provider?: string; id?: string }) => (
+          m.provider === 'anthropic' && m.id
+        ));
+        if (!claude?.id) return;
+
+        setModelOptions((options) => {
+          const next = options.map((option) => (
+            isClaudeModel(option)
+              ? { ...option, modelPath: claude.id, name: claude.label ?? option.name }
+              : option
+          ));
+          if (data.current) {
+            const current = findModelByPath(data.current, next);
+            if (current) setSelectedModelId(current.id);
+          }
+          return next;
+        });
+      })
+      .catch(() => { /* ignore */ });
+    return () => { cancelled = true; };
+  }, []);
+
   // Model is per-session: fetch this tab's current model every time the
   // session changes. Other tabs keep their own selections independently.
   useEffect(() => {
@@ -102,15 +131,15 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
       .then((data) => {
         if (cancelled) return;
         if (data?.model) {
-          const model = findModelByPath(data.model);
+          const model = findModelByPath(data.model, modelOptions);
           if (model) setSelectedModelId(model.id);
         }
       })
       .catch(() => { /* ignore */ });
     return () => { cancelled = true; };
-  }, [sessionId]);
+  }, [sessionId, modelOptions]);
 
-  const selectedModel = MODEL_OPTIONS.find(m => m.id === selectedModelId) || MODEL_OPTIONS[0];
+  const selectedModel = modelOptions.find(m => m.id === selectedModelId) || modelOptions[0];
 
   // Auto-focus the textarea when the session becomes ready
   useEffect(() => {
@@ -182,8 +211,8 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   const handleUseFreeModel = useCallback(async () => {
     setClaudeQuotaExhausted(false);
     if (!sessionId) return;
-    const free = MODEL_OPTIONS.find(m => m.modelPath === FIRST_FREE_MODEL_PATH)
-      ?? firstFreeModel();
+    const free = modelOptions.find(m => m.modelPath === FIRST_FREE_MODEL_PATH)
+      ?? firstFreeModel(modelOptions);
     try {
       const res = await apiFetch(`/api/session/${sessionId}/model`, {
         method: 'POST',
@@ -199,7 +228,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
         }
       }
     } catch { /* ignore */ }
-  }, [sessionId, onSend, setClaudeQuotaExhausted]);
+  }, [sessionId, onSend, setClaudeQuotaExhausted, modelOptions]);
 
   const handleClaudeUpgradeClick = useCallback(async () => {
     if (!sessionId) return;
@@ -426,7 +455,7 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
             }
           }}
         >
-          {MODEL_OPTIONS.map((model) => (
+          {modelOptions.map((model) => (
             <MenuItem
               key={model.id}
               onClick={() => handleSelectModel(model)}

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -92,6 +92,8 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   const [input, setInput] = useState('');
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [modelOptions, setModelOptions] = useState<ModelOption[]>(DEFAULT_MODEL_OPTIONS);
+  const modelOptionsRef = useRef<ModelOption[]>(DEFAULT_MODEL_OPTIONS);
+  const sessionIdRef = useRef<string | undefined>(sessionId);
   const [selectedModelId, setSelectedModelId] = useState<string>(DEFAULT_MODEL_OPTIONS[0].id);
   const [modelAnchorEl, setModelAnchorEl] = useState<null | HTMLElement>(null);
   const { quota, refresh: refreshQuota } = useUserQuota();
@@ -106,6 +108,14 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
   const setJobsUpgradeRequired = useAgentStore((s) => s.setJobsUpgradeRequired);
   const [awaitingTopUp, setAwaitingTopUp] = useState(false);
   const lastSentRef = useRef<string>('');
+
+  useEffect(() => {
+    modelOptionsRef.current = modelOptions;
+  }, [modelOptions]);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -123,9 +133,12 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
             ? { ...option, modelPath: claude.id, name: claude.label ?? option.name }
             : option
         ));
+        modelOptionsRef.current = next;
         setModelOptions(next);
-        const current = data.current ? findModelByPath(data.current, next) : null;
-        if (current) setSelectedModelId(current.id);
+        if (!sessionIdRef.current) {
+          const current = data.current ? findModelByPath(data.current, next) : null;
+          if (current) setSelectedModelId(current.id);
+        }
       })
       .catch(() => { /* ignore */ });
     return () => { cancelled = true; };
@@ -141,13 +154,13 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
       .then((data) => {
         if (cancelled) return;
         if (data?.model) {
-          const model = findModelByPath(data.model, modelOptions);
+          const model = findModelByPath(data.model, modelOptionsRef.current);
           if (model) setSelectedModelId(model.id);
         }
       })
       .catch(() => { /* ignore */ });
     return () => { cancelled = true; };
-  }, [sessionId, modelOptions]);
+  }, [sessionId]);
 
   const selectedModel = modelOptions.find(m => m.id === selectedModelId) || modelOptions[0];
 

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -20,13 +20,6 @@ interface ModelOption {
   recommended?: boolean;
 }
 
-interface BackendModelOption {
-  id: string;
-  label?: string;
-  provider?: string;
-  recommended?: boolean;
-}
-
 const getHfAvatarUrl = (modelId: string) => {
   const org = modelId.split('/')[0];
   return `https://huggingface.co/api/avatars/${org}`;
@@ -69,37 +62,6 @@ const findModelByPath = (path: string, options: ModelOption[]): ModelOption | un
   return options.find(m => m.modelPath === path || path?.includes(m.id));
 };
 
-const optionFromBackend = (model: BackendModelOption, existing?: ModelOption): ModelOption => {
-  const isClaude = model.provider === 'anthropic' || isClaudePath(model.id);
-  return {
-    id: existing?.id ?? model.id,
-    name: model.label ?? existing?.name ?? model.id.split('/').pop() ?? model.id,
-    description: existing?.description ?? (isClaude ? 'Anthropic' : 'Hugging Face'),
-    modelPath: model.id,
-    avatarUrl: existing?.avatarUrl ?? (isClaude
-      ? 'https://huggingface.co/api/avatars/Anthropic'
-      : getHfAvatarUrl(model.id)),
-    recommended: model.recommended ?? existing?.recommended,
-  };
-};
-
-const mergeBackendModels = (models: BackendModelOption[], fallback: ModelOption[]): ModelOption[] => {
-  const next = models
-    .filter((model) => !!model.id)
-    .map((model) => {
-      const existing = model.provider === 'anthropic'
-        ? fallback.find((option) => isClaudePath(option.modelPath))
-        : findModelByPath(model.id, fallback);
-      return optionFromBackend(model, existing);
-    });
-  for (const option of fallback) {
-    if (!next.some((model) => model.modelPath === option.modelPath)) {
-      next.push(option);
-    }
-  }
-  return next;
-};
-
 interface ChatInputProps {
   sessionId?: string;
   onSend: (text: string) => void;
@@ -137,12 +99,19 @@ export default function ChatInput({ sessionId, onSend, onStop, isProcessing = fa
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (cancelled || !data?.available) return;
-        const next = mergeBackendModels(data.available, DEFAULT_MODEL_OPTIONS);
+        const claude = data.available.find((m: { provider?: string; id?: string }) => (
+          m.provider === 'anthropic' && m.id
+        ));
+        if (!claude?.id) return;
+
+        const next = DEFAULT_MODEL_OPTIONS.map((option) => (
+          isClaudeModel(option)
+            ? { ...option, modelPath: claude.id, name: claude.label ?? option.name }
+            : option
+        ));
         setModelOptions(next);
-        if (data.current) {
-          const current = findModelByPath(data.current, next);
-          if (current) setSelectedModelId(current.id);
-        }
+        const current = data.current ? findModelByPath(data.current, next) : null;
+        if (current) setSelectedModelId(current.id);
       })
       .catch(() => { /* ignore */ });
     return () => { cancelled = true; };

--- a/frontend/src/components/ClaudeCapDialog.tsx
+++ b/frontend/src/components/ClaudeCapDialog.tsx
@@ -55,15 +55,15 @@ export default function ClaudeCapDialog({
       <DialogTitle
         sx={{ color: 'var(--text)', fontWeight: 700, fontSize: '1rem', pt: 2.5, pb: 0, px: 3 }}
       >
-        You've hit your Opus limit
+        You've hit your premium model limit
       </DialogTitle>
       <DialogContent sx={{ px: 3, pt: 1.25, pb: 0 }}>
         <DialogContentText
           sx={{ color: 'var(--muted-text)', fontSize: '0.85rem', lineHeight: 1.6 }}
         >
-          Opus costs an arm and a leg, so we unfortunately have to cap you at {cap}{' '}
-          {cap === 1 ? 'session' : 'sessions'} a day. Give Kimi, MiniMax, or GLM a spin —
-          they are genuinely good and we use them all the time.
+          Opus and GPT-5.5 are expensive to run, so we cap premium models at {cap}{' '}
+          {cap === 1 ? 'session' : 'sessions'} a day. Give Kimi, MiniMax, or GLM a spin
+          instead.
         </DialogContentText>
         <Box
           sx={{
@@ -85,14 +85,14 @@ export default function ClaudeCapDialog({
               letterSpacing: '0.02em',
             }}
           >
-            HF Pro ($9/mo) — more Opus, more everything
+            HF Pro ($9/mo) — more premium model sessions
           </Typography>
           <Typography
             variant="caption"
             sx={{ display: 'block', color: 'var(--muted-text)', fontSize: '0.78rem', lineHeight: 1.55 }}
           >
-            {PRO_CAP} Opus sessions/day here, 20× HF Inference credits, ZeroGPU access,
-            and priority on Spaces hardware.
+            {PRO_CAP} premium model sessions/day here, 20× HF Inference credits,
+            ZeroGPU access, and priority on Spaces hardware.
           </Typography>
         </Box>
       </DialogContent>

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -346,7 +346,7 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (error) => {
       updateSession(sessionId, { isProcessing: false });
-      // Claude daily-cap: open the cap dialog instead of the generic error
+      // Premium-model daily cap: open the cap dialog instead of the generic error
       // banner. Transport marks the error with this sentinel.
       if (error.message === 'CLAUDE_QUOTA_EXHAUSTED') {
         if (isActiveRef.current) {

--- a/frontend/src/hooks/useUserQuota.ts
+++ b/frontend/src/hooks/useUserQuota.ts
@@ -1,5 +1,5 @@
 /**
- * Reads the current user's Claude daily quota + plan tier from the backend.
+ * Reads the current user's premium-model daily quota + plan tier from the backend.
  *
  * Fetches once when the user becomes authenticated, and exposes a `refresh()`
  * that callers invoke after a successful session-create / model-switch so the
@@ -32,9 +32,9 @@ export function useUserQuota() {
       const data = await res.json();
       setQuota({
         plan: (data.plan ?? 'free') as PlanTier,
-        claudeUsedToday: data.claude_used_today ?? 0,
-        claudeDailyCap: data.claude_daily_cap ?? 1,
-        claudeRemaining: data.claude_remaining ?? 0,
+        claudeUsedToday: data.premium_used_today ?? data.claude_used_today ?? 0,
+        claudeDailyCap: data.premium_daily_cap ?? data.claude_daily_cap ?? 1,
+        claudeRemaining: data.premium_remaining ?? data.claude_remaining ?? 0,
       });
     } catch {
       /* backend unreachable — leave previous value */

--- a/frontend/src/hooks/useUserQuota.ts
+++ b/frontend/src/hooks/useUserQuota.ts
@@ -13,9 +13,9 @@ export type PlanTier = 'free' | 'pro' | 'org';
 
 export interface UserQuota {
   plan: PlanTier;
-  claudeUsedToday: number;
-  claudeDailyCap: number;
-  claudeRemaining: number;
+  premiumUsedToday: number;
+  premiumDailyCap: number;
+  premiumRemaining: number;
 }
 
 export function useUserQuota() {
@@ -32,9 +32,9 @@ export function useUserQuota() {
       const data = await res.json();
       setQuota({
         plan: (data.plan ?? 'free') as PlanTier,
-        claudeUsedToday: data.premium_used_today ?? data.claude_used_today ?? 0,
-        claudeDailyCap: data.premium_daily_cap ?? data.claude_daily_cap ?? 1,
-        claudeRemaining: data.premium_remaining ?? data.claude_remaining ?? 0,
+        premiumUsedToday: data.premium_used_today ?? 0,
+        premiumDailyCap: data.premium_daily_cap ?? 1,
+        premiumRemaining: data.premium_remaining ?? 0,
       });
     } catch {
       /* backend unreachable — leave previous value */

--- a/frontend/src/lib/sse-chat-transport.ts
+++ b/frontend/src/lib/sse-chat-transport.ts
@@ -402,7 +402,7 @@ export class SSEChatTransport implements ChatTransport<UIMessage> {
       this.sideChannel.onSessionDead(sessionId);
     }
     if (response.status === 429) {
-      // Claude daily-quota gate tripped. The prefix is the detection marker
+      // Premium-model daily quota gate tripped. The prefix is the detection marker
       // for useAgentChat's onError handler, which surfaces the cap dialog
       // instead of a generic error banner.
       throw new Error('CLAUDE_QUOTA_EXHAUSTED');

--- a/frontend/src/store/agentStore.ts
+++ b/frontend/src/store/agentStore.ts
@@ -113,7 +113,7 @@ interface AgentStore {
   user: User | null;
   error: string | null;
   llmHealthError: LLMHealthError | null;
-  /** Set when a Claude-send hits the daily quota — ChatInput opens the cap dialog in response. */
+  /** Set when a premium-model send hits the daily quota; ChatInput opens the cap dialog. */
   claudeQuotaExhausted: boolean;
   jobsUpgradeRequired: JobsUpgradeState | null;
 

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -1,14 +1,19 @@
 /**
  * Shared model-id constants used by session-create call sites and the
- * ClaudeCapDialog "Use a free model" escape hatch.
+ * premium-model cap dialog "Use a free model" escape hatch.
  *
  * Keep in sync with MODEL_OPTIONS in components/Chat/ChatInput.tsx and
  * AVAILABLE_MODELS in backend/routes/agent.py.
  */
 
 export const CLAUDE_MODEL_PATH = 'bedrock/us.anthropic.claude-opus-4-6-v1';
+export const GPT_55_MODEL_PATH = 'openai/gpt-5.5';
 export const FIRST_FREE_MODEL_PATH = 'moonshotai/Kimi-K2.6';
 
 export function isClaudePath(modelPath: string | undefined): boolean {
   return !!modelPath && modelPath.includes('anthropic');
+}
+
+export function isPremiumPath(modelPath: string | undefined): boolean {
+  return isClaudePath(modelPath) || modelPath === GPT_55_MODEL_PATH;
 }

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -15,5 +15,5 @@ export function isClaudePath(modelPath: string | undefined): boolean {
 }
 
 export function isPremiumPath(modelPath: string | undefined): boolean {
-  return isClaudePath(modelPath) || modelPath === GPT_55_MODEL_PATH;
+  return modelPath === CLAUDE_MODEL_PATH || modelPath === GPT_55_MODEL_PATH;
 }

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -1,0 +1,82 @@
+"""Tests for premium model gating in backend/routes/agent.py."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from routes import agent  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_quota_store():
+    agent.user_quotas._reset_for_tests()
+    yield
+    agent.user_quotas._reset_for_tests()
+
+
+def test_premium_model_predicate_includes_bedrock_claude_and_gpt55():
+    assert agent._is_premium_model("bedrock/us.anthropic.claude-opus-4-6-v1")
+    assert agent._is_premium_model("anthropic/claude-opus-4-6")
+    assert agent._is_premium_model("openai/gpt-5.5")
+    assert not agent._is_premium_model("moonshotai/Kimi-K2.6")
+
+
+@pytest.mark.asyncio
+async def test_premium_model_gate_rejects_gpt55_for_non_hf_user(monkeypatch):
+    async def fake_require_hf_org_member(_request):
+        return False
+
+    monkeypatch.setattr(agent, "require_huggingface_org_member", fake_require_hf_org_member)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await agent._require_hf_for_premium_model(None, "openai/gpt-5.5")
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["error"] == "premium_model_restricted"
+
+
+@pytest.mark.asyncio
+async def test_free_model_gate_skips_hf_membership_check(monkeypatch):
+    async def fail_if_called(_request):
+        raise AssertionError("free models must not require HF org membership")
+
+    monkeypatch.setattr(agent, "require_huggingface_org_member", fail_if_called)
+
+    await agent._require_hf_for_premium_model(None, "moonshotai/Kimi-K2.6")
+
+
+@pytest.mark.asyncio
+async def test_premium_quota_charges_gpt55(monkeypatch):
+    persisted = []
+
+    async def fake_persist_session_snapshot(agent_session):
+        persisted.append(agent_session)
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "persist_session_snapshot",
+        fake_persist_session_snapshot,
+    )
+
+    agent_session = SimpleNamespace(
+        claude_counted=False,
+        session=SimpleNamespace(
+            config=SimpleNamespace(model_name="openai/gpt-5.5"),
+        ),
+    )
+
+    await agent._enforce_premium_model_quota(
+        {"user_id": "u1", "plan": "free"},
+        agent_session,
+    )
+
+    assert agent_session.claude_counted is True
+    assert persisted == [agent_session]
+    assert await agent.user_quotas.get_claude_used_today("u1") == 1

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -80,3 +80,22 @@ async def test_premium_quota_charges_gpt55(monkeypatch):
     assert agent_session.claude_counted is True
     assert persisted == [agent_session]
     assert await agent.user_quotas.get_claude_used_today("u1") == 1
+
+
+@pytest.mark.asyncio
+async def test_user_quota_response_uses_premium_fields_only(monkeypatch):
+    async def fake_get_used_today(user_id):
+        assert user_id == "u1"
+        return 2
+
+    monkeypatch.setattr(agent.user_quotas, "get_claude_used_today", fake_get_used_today)
+    monkeypatch.setattr(agent.user_quotas, "daily_cap_for", lambda plan: 5)
+
+    response = await agent.get_user_quota({"user_id": "u1", "plan": "pro"})
+
+    assert response == {
+        "plan": "pro",
+        "premium_used_today": 2,
+        "premium_daily_cap": 5,
+        "premium_remaining": 3,
+    }

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -1,4 +1,4 @@
-"""Tests for premium model gating in backend/routes/agent.py."""
+"""Tests for gated model handling in backend/routes/agent.py."""
 
 import sys
 from pathlib import Path
@@ -21,39 +21,40 @@ def _reset_quota_store():
     agent.user_quotas._reset_for_tests()
 
 
-def test_premium_model_predicate_includes_bedrock_claude_and_gpt55():
-    assert agent._is_premium_model("bedrock/us.anthropic.claude-opus-4-6-v1")
-    assert agent._is_premium_model("anthropic/claude-opus-4-6")
-    assert agent._is_premium_model("openai/gpt-5.5")
-    assert not agent._is_premium_model("moonshotai/Kimi-K2.6")
+def test_gated_model_predicate_includes_bedrock_claude_and_gpt55_only():
+    assert agent._is_gated_model("bedrock/us.anthropic.claude-opus-4-6-v1")
+    assert agent._is_gated_model("openai/gpt-5.5")
+    assert not agent._is_gated_model("anthropic/claude-opus-4-6")
+    assert not agent._is_gated_model("moonshotai/Kimi-K2.6")
 
 
 @pytest.mark.asyncio
-async def test_premium_model_gate_rejects_gpt55_for_non_hf_user(monkeypatch):
+async def test_gated_model_gate_rejects_gpt55_for_non_hf_user(monkeypatch):
     async def fake_require_hf_org_member(_request):
         return False
 
     monkeypatch.setattr(agent, "require_huggingface_org_member", fake_require_hf_org_member)
 
     with pytest.raises(HTTPException) as exc_info:
-        await agent._require_hf_for_premium_model(None, "openai/gpt-5.5")
+        await agent._require_hf_for_gated_model(None, "openai/gpt-5.5")
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail["error"] == "premium_model_restricted"
 
 
 @pytest.mark.asyncio
-async def test_free_model_gate_skips_hf_membership_check(monkeypatch):
+async def test_ungated_models_skip_hf_membership_check(monkeypatch):
     async def fail_if_called(_request):
-        raise AssertionError("free models must not require HF org membership")
+        raise AssertionError("ungated models must not require HF org membership")
 
     monkeypatch.setattr(agent, "require_huggingface_org_member", fail_if_called)
 
-    await agent._require_hf_for_premium_model(None, "moonshotai/Kimi-K2.6")
+    await agent._require_hf_for_gated_model(None, "moonshotai/Kimi-K2.6")
+    await agent._require_hf_for_gated_model(None, "anthropic/claude-opus-4-6")
 
 
 @pytest.mark.asyncio
-async def test_premium_quota_charges_gpt55(monkeypatch):
+async def test_gated_quota_charges_gpt55(monkeypatch):
     persisted = []
 
     async def fake_persist_session_snapshot(agent_session):
@@ -72,7 +73,7 @@ async def test_premium_quota_charges_gpt55(monkeypatch):
         ),
     )
 
-    await agent._enforce_premium_model_quota(
+    await agent._enforce_gated_model_quota(
         {"user_id": "u1", "plan": "free"},
         agent_session,
     )
@@ -80,6 +81,33 @@ async def test_premium_quota_charges_gpt55(monkeypatch):
     assert agent_session.claude_counted is True
     assert persisted == [agent_session]
     assert await agent.user_quotas.get_claude_used_today("u1") == 1
+
+
+@pytest.mark.asyncio
+async def test_gated_quota_skips_direct_anthropic(monkeypatch):
+    async def fail_if_persisted(_agent_session):
+        raise AssertionError("direct Anthropic should not consume deployed gated quota")
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "persist_session_snapshot",
+        fail_if_persisted,
+    )
+
+    agent_session = SimpleNamespace(
+        claude_counted=False,
+        session=SimpleNamespace(
+            config=SimpleNamespace(model_name="anthropic/claude-opus-4-6"),
+        ),
+    )
+
+    await agent._enforce_gated_model_quota(
+        {"user_id": "u1", "plan": "free"},
+        agent_session,
+    )
+
+    assert agent_session.claude_counted is False
+    assert await agent.user_quotas.get_claude_used_today("u1") == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add GPT-5.5 to the web model picker.
- Gate GPT-5.5 the same way as Bedrock/Anthropic Claude: HF org-member access plus the shared daily premium-model quota.
- Avoid the duplicate per-session model fetch in the chat input after model options load.
- Make the Claude UI option configurable with ML_INTERN_CLAUDE_MODEL_ID.
- Keep Bedrock as the production Claude default while allowing direct Anthropic for local development.
- Sync the frontend Claude option with the backend-resolved model ID.
- Add local dev server notes in AGENTS.md.

## Deployment Notes
- To enable GPT-5.5 on the deployed Space, add OPENAI_API_KEY as a private Space secret and restart/rebuild the Space.
- ML_INTERN_CLAUDE_MODEL_ID is not required for GPT-5.5; it only controls the Claude picker entry between Bedrock and direct Anthropic.
- GPT-5.5 access is limited by HF org membership via HF_EMPLOYEE_ORG and the shared premium-model daily quota.

## Validation
- npm run build
- uv run python -m py_compile backend/routes/agent.py backend/user_quotas.py backend/dependencies.py tests/unit/test_agent_model_gating.py
- uv run --extra dev pytest tests/unit/test_agent_model_gating.py tests/unit/test_user_quotas.py
- git diff --check
- Verified /api/config/model for default Bedrock and local Anthropic Claude overrides.
- Verified /api/config/model includes openai/gpt-5.5.

Closes #192 