### PR TITLE
fix(research): inherit main model's Bedrock region prefix in sub-agent

### DIFF
--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -224,7 +224,12 @@ def _get_research_model(main_model: str) -> str:
     if main_model.startswith("anthropic/"):
         return "anthropic/claude-sonnet-4-6"
     if main_model.startswith("bedrock/") and "anthropic" in main_model:
-        return "bedrock/us.anthropic.claude-sonnet-4-6"
+        # Mirror the main model's Bedrock inference-profile prefix so the
+        # user's explicit profile choice carries through to the sub-agent
+        # instead of being silently overridden by a hard-coded one.
+        head = main_model.split("/", 1)[1]
+        region_prefix = head.split(".", 1)[0]
+        return f"bedrock/{region_prefix}.anthropic.claude-sonnet-4-6"
     # For non-Anthropic models (HF router etc.), use the same model
     return main_model
 

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -22,6 +22,17 @@ def test_bedrock_anthropic_research_model_stays_on_bedrock():
     )
 
 
+def test_bedrock_research_model_inherits_main_region_prefix():
+    assert (
+        _get_research_model("bedrock/global.anthropic.claude-opus-4-7")
+        == "bedrock/global.anthropic.claude-sonnet-4-6"
+    )
+    assert (
+        _get_research_model("bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0")
+        == "bedrock/apac.anthropic.claude-sonnet-4-6"
+    )
+
+
 def test_non_anthropic_research_model_is_unchanged():
     assert _get_research_model("openai/gpt-5.4") == "openai/gpt-5.4"
 


### PR DESCRIPTION
Fixes #184.

## Problem

The research sub-agent hard-codes `bedrock/us.anthropic.claude-sonnet-4-6`, which AWS Bedrock rejects with `"The provided model identifier is invalid."` whenever the caller's region/account cannot reach the `us.*` cross-region inference profile (e.g. `ap-northeast-1`). The main agent itself is unaffected because the user-chosen profile id is passed straight through to LiteLLM — only the sub-agent overrides it.

## Fix

Inherit the inference-profile prefix from the main model. If the user is running `bedrock/jp.anthropic.claude-opus-4-7`, the sub-agent now picks `bedrock/jp.anthropic.claude-sonnet-4-6`; same for `global.`, `apac.`, etc. The sub-agent stays on the cheaper Sonnet model — only the prefix follows the main agent's choice, matching the project's existing convention of letting the user's explicit profile selection drive Bedrock routing.

```python
if main_model.startswith("bedrock/") and "anthropic" in main_model:
    head = main_model.split("/", 1)[1]
    region_prefix = head.split(".", 1)[0]
    return f"bedrock/{region_prefix}.anthropic.claude-sonnet-4-6"
```

The existing `us.` test case is preserved (the new logic still produces `us.` for a `us.` main model), and a new test covers `global.` / `apac.` prefixes.

## Verification

Direct LiteLLM call from `ap-northeast-1` before/after, against the same model the function returns:

```
bedrock/us.anthropic.claude-sonnet-4-6  -> BedrockException "The provided model identifier is invalid."  (the reported bug)
bedrock/jp.anthropic.claude-sonnet-4-6  -> OK   (what the patched function emits for the user's main model)
```

Unit tests pass:

```
$ pytest tests/unit/test_cli_rendering.py
======================== 7 passed, 5 warnings in 6.51s =========================
```

## Caveats

This makes the sub-agent work for every prefix under which `claude-sonnet-4-6` is published on Bedrock (currently `us.`, `jp.`, `global.`). If a user is on an exotic prefix that has no `sonnet-4-6` variant, the sub-agent will still fail on that environment — but that's also true of the main agent on that prefix today, and addressing it would expand the scope beyond this fix.