### PR TITLE
fix: add MCP tool timeout + running state to prevent silent stall after hub_repo_details (#127)

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -1108,6 +1108,14 @@ class Handlers:
                     ) -> tuple[ToolCall, str, dict, str, bool]:
                         if not valid:
                             return (tc, name, args, err, False)
+                        # Emit "running" immediately so the CLI/frontend shows
+                        # progress instead of going silent (fixes issue #127).
+                        await session.send_event(
+                            Event(
+                                event_type="tool_state_change",
+                                data={"tool_call_id": tc.id, "tool": name, "state": "running"},
+                            )
+                        )
                         out, ok = await session.tool_router.call_tool(
                             name, args, session=session, tool_call_id=tc.id
                         )

--- a/agent/core/tools.py
+++ b/agent/core/tools.py
@@ -3,10 +3,17 @@ Tool system for the agent
 Provides ToolSpec and ToolRouter for managing both built-in and MCP tools
 """
 
+import asyncio
 import logging
 import warnings
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
+
+# Timeout (seconds) for a single MCP tool call.
+# hub_repo_details fetches model-card + siblings list from huggingface.co/api
+# which can stall indefinitely on slow Hub responses.  30 s is generous but
+# prevents the agent from silently hanging for 5+ minutes.
+MCP_TOOL_TIMEOUT = 30
 
 logger = logging.getLogger(__name__)
 
@@ -265,9 +272,21 @@ class ToolRouter:
         # Otherwise, use MCP client
         if self._mcp_initialized:
             try:
-                result = await self.mcp_client.call_tool(tool_name, arguments)
+                result = await asyncio.wait_for(
+                    self.mcp_client.call_tool(tool_name, arguments),
+                    timeout=MCP_TOOL_TIMEOUT,
+                )
                 output = convert_mcp_content_to_string(result.content)
                 return output, not result.is_error
+            except asyncio.TimeoutError:
+                timeout_msg = (
+                    f"Tool '{tool_name}' timed out after {MCP_TOOL_TIMEOUT}s "
+                    "with no response from the HF MCP server. "
+                    "The Hub API may be slow or rate-limiting. "
+                    "You can retry, or proceed with the information already available."
+                )
+                logger.warning("MCP tool %s timed out after %ds", tool_name, MCP_TOOL_TIMEOUT)
+                return timeout_msg, False
             except ToolError as e:
                 # Catch MCP tool errors and return them to the agent
                 error_msg = f"Tool error: {str(e)}"


### PR DESCRIPTION
## Problem

When running `ml-intern` headless from CLI, the agent silently stalls 
for 5+ minutes after a `hub_repo_details` tool call with zero progress 
output. The user has no way to know if the agent is working or frozen.

Fixes #127

## Root Cause

Two overlapping bugs:

**1. No timeout on MCP tool calls (`agent/core/tools.py`)**  
`hub_repo_details` is an MCP tool served by `huggingface.co/mcp`. The 
call `await self.mcp_client.call_tool(tool_name, arguments)` had zero 
timeout — if the HF Hub API is slow or rate-limiting, this await hangs 
indefinitely, blocking the entire agent loop.

**2. No progress event emitted during tool execution (`agent/core/agent_loop.py`)**  
After `tool_call` fires (showing `▸ hub_repo_details` in terminal), 
`_exec_tool` went silent until results arrived. No `tool_state_change: 
running` event was emitted for non-approval tools, so the CLI showed 
nothing for the entire duration of the stall.

## Changes

**`agent/core/tools.py`**
- Added `import asyncio`
- Added `MCP_TOOL_TIMEOUT = 30` constant (easy to tune)
- Wrapped `mcp_client.call_tool()` with `asyncio.wait_for(timeout=MCP_TOOL_TIMEOUT)`
- Added `except asyncio.TimeoutError` handler that returns a clear error 
  message to the agent so it can retry or continue instead of hanging

**`agent/core/agent_loop.py`**
- Emit `tool_state_change: running` event inside `_exec_tool` immediately 
  before `call_tool()` so the CLI/frontend shows the tool is actively 
  executing

## Before / After

**Before:**
▸ hub_repo_details  {"repo_ids": ["openai/whisper-small"]}
[5 minutes of silence → user hits Ctrl+C]

**After:**
▸ hub_repo_details  {"repo_ids": ["openai/whisper-small"]}  [running]
[if slow]: Tool 'hub_repo_details' timed out after 30s — agent continues

## Testing
Reproduced locally with the command from the issue:
ml-intern "Fine-tune a small Whisper model for Arabic speech recognition
on a GPU under 5 dollars and compare the fine-tuned model's metrics to
the original model."
Agent no longer stalls silently after `hub_repo_details`.