### PR TITLE
Harden sandbox token handling

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -1147,6 +1147,12 @@ class Handlers:
 
                     # 4. Record results and send outputs (order preserved)
                     for tc, tool_name, tool_args, output, success in results:
+                        try:
+                            from agent.core.redact import scrub_string
+
+                            output = scrub_string(output)
+                        except Exception:
+                            pass
                         tool_msg = Message(
                             role="tool",
                             content=output,

--- a/agent/core/redact.py
+++ b/agent/core/redact.py
@@ -16,8 +16,8 @@ from typing import Any
 # Patterns are conservative: they only match tokens with the canonical prefix
 # and a minimum body length so we don't paint over normal text.
 _PATTERNS: list[tuple[re.Pattern, str]] = [
-    # Hugging Face tokens: hf_[A-Za-z0-9]{30,}
-    (re.compile(r"hf_[A-Za-z0-9]{30,}"), "[REDACTED_HF_TOKEN]"),
+    # Hugging Face tokens, including OAuth-style hf_oauth_... tokens.
+    (re.compile(r"hf_[A-Za-z0-9_\-]{30,}"), "[REDACTED_HF_TOKEN]"),
     # Anthropic: sk-ant-[A-Za-z0-9_\-]{20,}
     (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "[REDACTED_ANTHROPIC_KEY]"),
     # OpenAI: sk-[A-Za-z0-9]{40,}  (legacy + proj keys)

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -142,6 +142,13 @@ class Session:
 
     async def send_event(self, event: Event) -> None:
         """Send event back to client and log to trajectory"""
+        try:
+            from agent.core.redact import scrub
+
+            event.data = scrub(event.data)
+        except Exception as e:
+            logger.debug("Event redaction failed for %s: %s", event.event_type, e)
+
         # Log event to trajectory
         self.logged_events.append(
             {

--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -67,6 +67,7 @@ WAIT_TIMEOUT = 600
 WAIT_INTERVAL = 5
 API_WAIT_TIMEOUT = 180
 SANDBOX_API_TOKEN_HASH_ENV = "SANDBOX_API_TOKEN_SHA256"
+SANDBOX_API_TOKEN_HEADER = "X-Sandbox-API-Token"
 _ALLOWED_SANDBOX_VARIABLES = {"TRACKIO_SPACE_ID", "TRACKIO_PROJECT"}
 _FORBIDDEN_SANDBOX_VARIABLES = {
     "HF_TOKEN",
@@ -173,10 +174,12 @@ def _require_auth(request: Request) -> None:
     expected = _expected_api_token_hash()
     if not expected:
         raise HTTPException(status_code=503, detail="Sandbox API token not configured")
-    auth_header = request.headers.get("authorization", "")
-    scheme, _, supplied = auth_header.partition(" ")
-    if scheme.lower() != "bearer" or not supplied:
-        raise HTTPException(status_code=401, detail="Missing bearer token")
+    supplied = request.headers.get("x-sandbox-api-token", "")
+    if not supplied:
+        auth_header = request.headers.get("authorization", "")
+        scheme, _, supplied = auth_header.partition(" ")
+        if scheme.lower() != "bearer" or not supplied:
+            raise HTTPException(status_code=401, detail="Missing sandbox API token")
     supplied_hash = hashlib.sha256(supplied.encode("utf-8")).hexdigest()
     if not hmac.compare_digest(supplied_hash, expected):
         raise HTTPException(status_code=401, detail="Invalid bearer token")
@@ -532,8 +535,9 @@ class Sandbox:
     """
 
     space_id: str
-    token: str | None = None
+    token: str | None = field(default=None, repr=False)
     api_token: str | None = field(default=None, repr=False)
+    private: bool = True
     work_dir: str = "/app"
     timeout: int = DEFAULT_TIMEOUT
     _owns_space: bool = field(default=False, repr=False)
@@ -547,9 +551,14 @@ class Sandbox:
         # Trailing slash is critical: httpx resolves relative paths against base_url.
         # Without it, client.get("health") resolves to /health instead of /api/health.
         self._base_url = f"https://{slug}.hf.space/api/"
+        headers = {}
+        if self.private and self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        if self.api_token:
+            headers[SANDBOX_API_TOKEN_HEADER] = self.api_token
         self._client = httpx.Client(
             base_url=self._base_url,
-            headers={"Authorization": f"Bearer {self.api_token}"} if self.api_token else {},
+            headers=headers,
             timeout=httpx.Timeout(MAX_TIMEOUT, connect=30),
             follow_redirects=True,
         )
@@ -568,7 +577,7 @@ class Sandbox:
         name: str | None = None,
         template: str = TEMPLATE_SPACE,
         hardware: str = "cpu-basic",
-        private: bool = False,
+        private: bool = True,
         sleep_time: int | None = None,
         token: str | None = None,
         secrets: dict[str, str] | None = None,
@@ -676,6 +685,7 @@ class Sandbox:
             space_id=space_id,
             token=token,
             api_token=sandbox_api_token,
+            private=private,
             _owns_space=True,
         )
         try:
@@ -714,6 +724,7 @@ class Sandbox:
         *,
         token: str | None = None,
         api_token: str | None = None,
+        private: bool = True,
     ) -> Sandbox:
         """
         Connect to an existing running Space.
@@ -726,6 +737,7 @@ class Sandbox:
             space_id=space_id,
             token=token,
             api_token=api_token,
+            private=private,
             _owns_space=False,
         )
         sb._wait_for_api(timeout=60)

--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -7,13 +7,13 @@
 Sandbox Tools — Agent-native primitives for HF Space dev-mode sandboxes.
 
 Architecture:
-  - Creates a sandbox by duplicating a template Space (runs sandbox_server.py)
+  - Creates a fresh Docker Space with sandbox_server.py
   - Waits for it to come online
   - Communicates via HTTPS to the Space's API
   - Optionally deletes the Space when done
 
 Lifecycle:
-    sb = Sandbox.create(owner="burtenshaw")         # duplicate, wait, connect
+    sb = Sandbox.create(owner="burtenshaw")         # create, wait, connect
     sb = Sandbox.create(owner="burtenshaw",          # with options
                         hardware="t4-small",
                         private=True,
@@ -37,6 +37,7 @@ Tools: bash, read, write, edit, upload
 from __future__ import annotations
 
 import io
+import hashlib
 import secrets as secrets_lib
 import sys
 import time
@@ -65,6 +66,14 @@ MAX_TIMEOUT = 1200
 WAIT_TIMEOUT = 600
 WAIT_INTERVAL = 5
 API_WAIT_TIMEOUT = 180
+SANDBOX_API_TOKEN_HASH_ENV = "SANDBOX_API_TOKEN_SHA256"
+_ALLOWED_SANDBOX_VARIABLES = {"TRACKIO_SPACE_ID", "TRACKIO_PROJECT"}
+_FORBIDDEN_SANDBOX_VARIABLES = {
+    "HF_TOKEN",
+    "HUGGINGFACE_HUB_TOKEN",
+    "HUGGINGFACEHUB_API_TOKEN",
+    "HF_HOME",
+}
 
 _DOCKERFILE = """\
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
@@ -100,7 +109,7 @@ CMD ["python", "sandbox_server.py"]
 
 _SANDBOX_SERVER = '''\
 """Minimal FastAPI server for sandbox operations."""
-import hmac, os, subprocess, pathlib, signal, threading, re, tempfile
+import hashlib, hmac, os, subprocess, pathlib, signal, threading, re, tempfile
 from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional
@@ -157,18 +166,19 @@ def _atomic_write(path: pathlib.Path, content: str):
 
 app = FastAPI()
 
-def _expected_api_token() -> str:
-    return os.environ.get("SANDBOX_API_TOKEN") or os.environ.get("HF_TOKEN") or ""
+def _expected_api_token_hash() -> str:
+    return os.environ.get("SANDBOX_API_TOKEN_SHA256", "")
 
 def _require_auth(request: Request) -> None:
-    expected = _expected_api_token()
+    expected = _expected_api_token_hash()
     if not expected:
         raise HTTPException(status_code=503, detail="Sandbox API token not configured")
     auth_header = request.headers.get("authorization", "")
     scheme, _, supplied = auth_header.partition(" ")
     if scheme.lower() != "bearer" or not supplied:
         raise HTTPException(status_code=401, detail="Missing bearer token")
-    if not hmac.compare_digest(supplied, expected):
+    supplied_hash = hashlib.sha256(supplied.encode("utf-8")).hexdigest()
+    if not hmac.compare_digest(supplied_hash, expected):
         raise HTTPException(status_code=401, detail="Invalid bearer token")
 
 _AUTH = [Depends(_require_auth)]
@@ -473,6 +483,30 @@ if __name__ == "__main__":
 '''
 
 
+def _sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate_sandbox_variables(variables: dict[str, str] | None) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key, value in (variables or {}).items():
+        normalized = key.strip()
+        if normalized in _FORBIDDEN_SANDBOX_VARIABLES:
+            raise ValueError(f"{normalized} cannot be injected into sandbox environments")
+        if normalized not in _ALLOWED_SANDBOX_VARIABLES:
+            raise ValueError(
+                f"{normalized} is not an allowed sandbox variable. "
+                f"Allowed variables: {', '.join(sorted(_ALLOWED_SANDBOX_VARIABLES))}"
+            )
+        if value:
+            result[normalized] = value
+    return result
+
+
+def _space_variables_payload(variables: dict[str, str]) -> list[dict[str, str]]:
+    return [{"key": key, "value": value} for key, value in variables.items()]
+
+
 @dataclass
 class ToolResult:
     success: bool
@@ -513,10 +547,9 @@ class Sandbox:
         # Trailing slash is critical: httpx resolves relative paths against base_url.
         # Without it, client.get("health") resolves to /health instead of /api/health.
         self._base_url = f"https://{slug}.hf.space/api/"
-        api_token = self.api_token or self.token
         self._client = httpx.Client(
             base_url=self._base_url,
-            headers={"Authorization": f"Bearer {api_token}"} if api_token else {},
+            headers={"Authorization": f"Bearer {self.api_token}"} if self.api_token else {},
             timeout=httpx.Timeout(MAX_TIMEOUT, connect=30),
             follow_redirects=True,
         )
@@ -539,25 +572,27 @@ class Sandbox:
         sleep_time: int | None = None,
         token: str | None = None,
         secrets: dict[str, str] | None = None,
+        variables: dict[str, str] | None = None,
         wait_timeout: int = WAIT_TIMEOUT,
         log: "Callable[[str], object] | None" = None,
         cancel_event: "Any | None" = None,
     ) -> Sandbox:
         """
-        Create a new sandbox by duplicating the template Space.
+        Create a new sandbox as a fresh Docker Space.
 
-        Generates a unique space name, duplicates the template, waits for it
+        Generates a unique space name, uploads the server files, waits for it
         to come online, then returns a connected Sandbox.
 
         Args:
             owner: HF username or org (e.g. "burtenshaw").
             name: Base name for the space. Defaults to "sandbox".
                   A unique suffix is always appended.
-            template: Source Space to duplicate (default: burtenshaw/sandbox).
+            template: Deprecated and ignored. Kept for older callers.
             hardware: Hardware tier (cpu-basic, t4-small, etc.).
             private: Whether the Space should be private.
             sleep_time: Auto-sleep after N seconds of inactivity.
             token: HF API token (from user's OAuth session).
+            variables: Non-secret Space variables to expose to the sandbox.
             wait_timeout: Max seconds to wait for Space to start (default: 300).
             cancel_event: A threading.Event (or compatible) checked during
                           polling loops.  When set, the Space is deleted and
@@ -583,30 +618,29 @@ class Sandbox:
         suffix = uuid.uuid4().hex[:8]
         space_id = f"{owner}/{base}-{suffix}"
         sandbox_api_token = secrets_lib.token_urlsafe(32)
+        sandbox_api_token_hash = _sha256_hex(sandbox_api_token)
+        sandbox_variables = _validate_sandbox_variables({**(secrets or {}), **(variables or {})})
 
-        _log(f"Creating sandbox: {space_id} (from {template})...")
+        _log(f"Creating sandbox: {space_id}...")
 
-        kwargs = {
-            "from_id": template,
-            "to_id": space_id,
+        repo_kwargs = {
+            "repo_id": space_id,
+            "repo_type": "space",
+            "space_sdk": "docker",
             "private": private,
-            "hardware": hardware,
+            "space_hardware": hardware,
+            "space_secrets": [
+                {"key": SANDBOX_API_TOKEN_HASH_ENV, "value": sandbox_api_token_hash}
+            ],
+            "space_variables": _space_variables_payload(sandbox_variables),
         }
         if sleep_time is not None:
-            kwargs["sleep_time"] = sleep_time
+            repo_kwargs["space_sleep_time"] = sleep_time
 
-        api.duplicate_space(**kwargs)
+        api.create_repo(**repo_kwargs)
         _log(f"Space created: https://huggingface.co/spaces/{space_id}")
 
         _check_cancel()
-
-        # Inject secrets BEFORE uploading server files (which triggers rebuild).
-        # Secrets added after a Space is running aren't available until restart,
-        # so they must be set before the build/start cycle.
-        sandbox_secrets = {**(secrets or {}), "SANDBOX_API_TOKEN": sandbox_api_token}
-        if sandbox_secrets:
-            for key, val in sandbox_secrets.items():
-                api.add_space_secret(space_id, key, val)
 
         # Upload sandbox server and Dockerfile (triggers rebuild)
         cls._setup_server(space_id, api, log=_log)
@@ -686,6 +720,8 @@ class Sandbox:
 
         Does a health check to verify the Space is reachable.
         """
+        if not api_token:
+            raise ValueError("api_token is required to connect to sandbox APIs")
         sb = cls(
             space_id=space_id,
             token=token,
@@ -766,6 +802,11 @@ class Sandbox:
     def _call(
         self, endpoint: str, payload: dict, timeout: float | None = None
     ) -> ToolResult:
+        if not self.api_token:
+            return ToolResult(
+                success=False,
+                error="Sandbox API token is required for sandbox operations.",
+            )
         # Strip leading slash for correct httpx base_url resolution
         endpoint = endpoint.lstrip("/")
         effective_timeout = timeout or self.timeout

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -314,10 +314,6 @@ SANDBOX_CREATE_TOOL_SPEC = {
                 "enum": [e.value for e in SpaceHardware],
                 "description": "Hardware tier for the sandbox (default: cpu-basic)",
             },
-            "private": {
-                "type": "boolean",
-                "description": "If true, create a private Space",
-            },
             "trackio_space_id": {
                 "type": "string",
                 "description": (
@@ -381,9 +377,7 @@ async def sandbox_create_handler(
             f"Use bash/read/write/edit to interact with it."
         ), True
 
-    create_kwargs: dict[str, Any] = {}
-    if "private" in args:
-        create_kwargs["private"] = args["private"]
+    create_kwargs: dict[str, Any] = {"private": True}
 
     extra_variables: dict[str, str] = {}
     if trackio_space_id:

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -159,7 +159,7 @@ def _cleanup_user_orphan_sandboxes(
 async def _ensure_sandbox(
     session: Any,
     hardware: str = "cpu-basic",
-    extra_secrets: dict[str, str] | None = None,
+    extra_variables: dict[str, str] | None = None,
     **create_kwargs,
 ) -> tuple[Sandbox | None, str | None]:
     """
@@ -231,15 +231,11 @@ async def _ensure_sandbox(
 
     watcher_task = asyncio.create_task(_watch_cancel())
 
-    secrets: dict[str, str] = {"HF_TOKEN": token}
-    if extra_secrets:
-        secrets.update({k: v for k, v in extra_secrets.items() if v})
-
     kwargs = {
         "owner": owner,
         "hardware": hardware,
         "token": token,
-        "secrets": secrets,
+        "variables": {k: v for k, v in (extra_variables or {}).items() if v},
         "log": _log,
         "cancel_event": cancel_flag,
         **create_kwargs,
@@ -263,7 +259,7 @@ async def _ensure_sandbox(
         create_latency_s=int(_t.monotonic() - _t_start),
     )
 
-    # Set a descriptive title (template title is inherited on duplicate)
+    # Set a descriptive title for the freshly created Space.
     from huggingface_hub import metadata_update
 
     await asyncio.to_thread(
@@ -305,7 +301,7 @@ SANDBOX_CREATE_TOOL_SPEC = {
         "If the model won't fit, pick larger hardware upfront — OOM on a sandbox wastes time.\n\n"
         "If you intend to run a training script in this sandbox that uses report_to='trackio', "
         "pass `trackio_space_id` (e.g. '<username>/mlintern-<8char>') and `trackio_project` so they "
-        "are set as TRACKIO_SPACE_ID/TRACKIO_PROJECT secrets in the sandbox and the UI can embed the live dashboard.\n\n"
+        "are set as TRACKIO_SPACE_ID/TRACKIO_PROJECT variables in the sandbox and the UI can embed the live dashboard.\n\n"
         "Hardware: " + ", ".join([e.value for e in SpaceHardware]) + ".\n"
     ),
     "parameters": {
@@ -326,8 +322,8 @@ SANDBOX_CREATE_TOOL_SPEC = {
                 "type": "string",
                 "description": (
                     "Optional. The HF Space hosting the trackio dashboard for runs in this sandbox "
-                    "(e.g. '<username>/mlintern-<8char>', under YOUR HF namespace). Injected as "
-                    "TRACKIO_SPACE_ID secret and surfaced to the UI. The Space is auto-created and "
+                    "(e.g. '<username>/mlintern-<8char>', under YOUR HF namespace). Injected as the "
+                    "TRACKIO_SPACE_ID variable and surfaced to the UI. The Space is auto-created and "
                     "seeded with the trackio dashboard — DO NOT pre-create it via hf_repo_git, "
                     "that produces an empty Space that breaks the embed."
                 ),
@@ -335,7 +331,7 @@ SANDBOX_CREATE_TOOL_SPEC = {
             "trackio_project": {
                 "type": "string",
                 "description": (
-                    "Optional. The trackio project name. Injected as TRACKIO_PROJECT secret and "
+                    "Optional. The trackio project name. Injected as the TRACKIO_PROJECT variable and "
                     "used by the UI to filter the embedded dashboard to this project."
                 ),
             },
@@ -389,18 +385,18 @@ async def sandbox_create_handler(
     if "private" in args:
         create_kwargs["private"] = args["private"]
 
-    extra_secrets: dict[str, str] = {}
+    extra_variables: dict[str, str] = {}
     if trackio_space_id:
-        extra_secrets["TRACKIO_SPACE_ID"] = trackio_space_id
+        extra_variables["TRACKIO_SPACE_ID"] = trackio_space_id
         await _seed_trackio_dashboard_safe(session, trackio_space_id)
     if trackio_project:
-        extra_secrets["TRACKIO_PROJECT"] = trackio_project
+        extra_variables["TRACKIO_PROJECT"] = trackio_project
 
     try:
         sb, error = await _ensure_sandbox(
             session,
             hardware=hardware,
-            extra_secrets=extra_secrets or None,
+            extra_variables=extra_variables or None,
             **create_kwargs,
         )
     except Exception as e:

--- a/tests/integration/test_live_sandbox_auth.py
+++ b/tests/integration/test_live_sandbox_auth.py
@@ -1,7 +1,8 @@
 """Opt-in live sandbox communication test.
 
-This test creates a real Hugging Face Space sandbox, verifies that unauthenticated
-requests are rejected, then exercises the authenticated agent client end-to-end.
+This test creates a real private Hugging Face Space sandbox, verifies that
+unauthenticated requests are rejected, then exercises the authenticated agent
+client end-to-end.
 It is skipped unless ``ML_INTERN_LIVE_SANDBOX_TESTS=1`` and ``HF_TOKEN`` are set.
 """
 
@@ -41,7 +42,6 @@ def test_live_sandbox_authenticated_agent_communication():
             owner=owner,
             name="ml-intern-live-auth",
             hardware="cpu-basic",
-            private=False,
             token=token,
             wait_timeout=900,
         )
@@ -53,7 +53,7 @@ def test_live_sandbox_authenticated_agent_communication():
         )
         try:
             denied = unauthenticated.post("exists", json={"path": "/tmp"})
-            assert denied.status_code == 401
+            assert denied.status_code in {401, 403, 404}
         finally:
             unauthenticated.close()
 

--- a/tests/integration/test_live_sandbox_auth.py
+++ b/tests/integration/test_live_sandbox_auth.py
@@ -43,7 +43,6 @@ def test_live_sandbox_authenticated_agent_communication():
             hardware="cpu-basic",
             private=False,
             token=token,
-            secrets={"HF_TOKEN": token},
             wait_timeout=900,
         )
 
@@ -61,6 +60,21 @@ def test_live_sandbox_authenticated_agent_communication():
         bash = sandbox.bash("printf sandbox-live-ok", timeout=30)
         assert bash.success, bash.error
         assert "sandbox-live-ok" in bash.output
+
+        env_check = sandbox.bash(
+            "python -c \"import os; "
+            "print('HF_TOKEN=' + str('HF_TOKEN' in os.environ)); "
+            "print('HUGGINGFACE_HUB_TOKEN=' + str('HUGGINGFACE_HUB_TOKEN' in os.environ)); "
+            "print('SANDBOX_API_TOKEN=' + str('SANDBOX_API_TOKEN' in os.environ)); "
+            "print('SANDBOX_API_TOKEN_SHA256=' + str('SANDBOX_API_TOKEN_SHA256' in os.environ))\"",
+            timeout=30,
+        )
+        assert env_check.success, env_check.error
+        assert "HF_TOKEN=False" in env_check.output
+        assert "HUGGINGFACE_HUB_TOKEN=False" in env_check.output
+        assert "SANDBOX_API_TOKEN=False" in env_check.output
+        assert "SANDBOX_API_TOKEN_SHA256=True" in env_check.output
+        assert sandbox.api_token not in env_check.output
 
         write = sandbox.write("/tmp/ml_intern_live_auth.txt", "alpha\nbeta\n")
         assert write.success, write.error

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -10,6 +10,13 @@ def test_hf_token():
     assert "[REDACTED_HF_TOKEN]" in out
 
 
+def test_hf_oauth_token():
+    s = "HF_TOKEN=hf_oauth_" + "A" * 40 + "-_suffix"
+    out = scrub_string(s)
+    assert "hf_oauth_" not in out
+    assert "HF_TOKEN=[REDACTED]" in out
+
+
 def test_anthropic_key():
     s = "key=sk-ant-api03_" + "a" * 40
     out = scrub_string(s)

--- a/tests/unit/test_sandbox_api_auth.py
+++ b/tests/unit/test_sandbox_api_auth.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from agent.tools.sandbox_client import (
     _SANDBOX_SERVER,
     _validate_sandbox_variables,
+    SANDBOX_API_TOKEN_HEADER,
     Sandbox,
 )
 
@@ -68,6 +69,34 @@ def test_file_and_command_routes_accept_valid_bearer_token(monkeypatch):
     assert response.json()["success"] is True
 
 
+def test_file_and_command_routes_accept_valid_sandbox_header(monkeypatch):
+    client = TestClient(_sandbox_app(monkeypatch, "sandbox-secret"))
+
+    response = client.post(
+        "/api/exists",
+        json={"path": "/tmp"},
+        headers={SANDBOX_API_TOKEN_HEADER: "sandbox-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_sandbox_header_takes_precedence_over_authorization(monkeypatch):
+    client = TestClient(_sandbox_app(monkeypatch, "sandbox-secret"))
+
+    response = client.post(
+        "/api/exists",
+        json={"path": "/tmp"},
+        headers={
+            SANDBOX_API_TOKEN_HEADER: "wrong-secret",
+            "Authorization": "Bearer sandbox-secret",
+        },
+    )
+
+    assert response.status_code == 401
+
+
 def test_file_and_command_routes_reject_wrong_bearer_token(monkeypatch):
     client = TestClient(_sandbox_app(monkeypatch, "sandbox-secret"))
 
@@ -120,25 +149,40 @@ def test_protected_routes_fail_closed_without_configured_token(monkeypatch):
     assert response.status_code == 503
 
 
-def test_sandbox_prefers_control_plane_token_for_api_headers():
+def test_private_sandbox_uses_hf_auth_and_control_plane_header():
     sandbox = Sandbox("owner/name", token="hf-token", api_token="sandbox-secret")
 
-    assert sandbox._client.headers["authorization"] == "Bearer sandbox-secret"
+    assert sandbox._client.headers["authorization"] == "Bearer hf-token"
+    assert sandbox._client.headers["x-sandbox-api-token"] == "sandbox-secret"
+
+
+def test_public_sandbox_omits_hf_auth_header():
+    sandbox = Sandbox(
+        "owner/name",
+        token="hf-token",
+        api_token="sandbox-secret",
+        private=False,
+    )
+
+    assert "authorization" not in sandbox._client.headers
+    assert sandbox._client.headers["x-sandbox-api-token"] == "sandbox-secret"
 
 
 def test_sandbox_does_not_fallback_to_hf_token_for_api_headers():
     sandbox = Sandbox("owner/name", token="hf-token")
 
-    assert "authorization" not in sandbox._client.headers
+    assert sandbox._client.headers["authorization"] == "Bearer hf-token"
+    assert "x-sandbox-api-token" not in sandbox._client.headers
     result = sandbox._call("exists", {"path": "/tmp"})
     assert result.success is False
     assert "Sandbox API token is required" in result.error
 
 
-def test_sandbox_api_token_is_hidden_from_repr():
+def test_tokens_are_hidden_from_repr():
     sandbox = Sandbox("owner/name", token="hf-token", api_token="sandbox-secret")
 
     assert "sandbox-secret" not in repr(sandbox)
+    assert "hf-token" not in repr(sandbox)
 
 
 def test_sandbox_variables_allow_trackio_only():

--- a/tests/unit/test_sandbox_api_auth.py
+++ b/tests/unit/test_sandbox_api_auth.py
@@ -1,6 +1,16 @@
+import hashlib
+
 from fastapi.testclient import TestClient
 
-from agent.tools.sandbox_client import _SANDBOX_SERVER, Sandbox
+from agent.tools.sandbox_client import (
+    _SANDBOX_SERVER,
+    _validate_sandbox_variables,
+    Sandbox,
+)
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
 def _sandbox_app(
@@ -10,9 +20,10 @@ def _sandbox_app(
     hf_token: str | None = None,
 ):
     monkeypatch.delenv("SANDBOX_API_TOKEN", raising=False)
+    monkeypatch.delenv("SANDBOX_API_TOKEN_SHA256", raising=False)
     monkeypatch.delenv("HF_TOKEN", raising=False)
     if token is not None:
-        monkeypatch.setenv("SANDBOX_API_TOKEN", token)
+        monkeypatch.setenv("SANDBOX_API_TOKEN_SHA256", _hash_token(token))
     if hf_token is not None:
         monkeypatch.setenv("HF_TOKEN", hf_token)
     namespace = {}
@@ -32,9 +43,16 @@ def test_health_is_public(monkeypatch):
 def test_file_and_command_routes_require_bearer_token(monkeypatch):
     client = TestClient(_sandbox_app(monkeypatch, "sandbox-secret"))
 
-    response = client.post("/api/exists", json={"path": "/tmp"})
-
-    assert response.status_code == 401
+    for path, payload in [
+        ("/api/bash", {"command": "true"}),
+        ("/api/kill", {}),
+        ("/api/read", {"path": "/tmp/x"}),
+        ("/api/write", {"path": "/tmp/x", "content": "x"}),
+        ("/api/edit", {"path": "/tmp/x", "old_str": "x", "new_str": "y"}),
+        ("/api/exists", {"path": "/tmp"}),
+    ]:
+        response = client.post(path, json=payload)
+        assert response.status_code == 401
 
 
 def test_file_and_command_routes_accept_valid_bearer_token(monkeypatch):
@@ -50,7 +68,19 @@ def test_file_and_command_routes_accept_valid_bearer_token(monkeypatch):
     assert response.json()["success"] is True
 
 
-def test_legacy_hf_token_fallback_is_accepted(monkeypatch):
+def test_file_and_command_routes_reject_wrong_bearer_token(monkeypatch):
+    client = TestClient(_sandbox_app(monkeypatch, "sandbox-secret"))
+
+    response = client.post(
+        "/api/exists",
+        json={"path": "/tmp"},
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_legacy_hf_token_fallback_is_not_accepted(monkeypatch):
     client = TestClient(_sandbox_app(monkeypatch, token=None, hf_token="hf-secret"))
 
     response = client.post(
@@ -59,8 +89,23 @@ def test_legacy_hf_token_fallback_is_accepted(monkeypatch):
         headers={"Authorization": "Bearer hf-secret"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["success"] is True
+    assert response.status_code == 503
+
+
+def test_legacy_raw_sandbox_token_env_is_not_accepted(monkeypatch):
+    monkeypatch.delenv("SANDBOX_API_TOKEN_SHA256", raising=False)
+    monkeypatch.setenv("SANDBOX_API_TOKEN", "sandbox-secret")
+    namespace = {}
+    exec(_SANDBOX_SERVER, namespace)
+    client = TestClient(namespace["app"])
+
+    response = client.post(
+        "/api/exists",
+        json={"path": "/tmp"},
+        headers={"Authorization": "Bearer sandbox-secret"},
+    )
+
+    assert response.status_code == 503
 
 
 def test_protected_routes_fail_closed_without_configured_token(monkeypatch):
@@ -81,7 +126,40 @@ def test_sandbox_prefers_control_plane_token_for_api_headers():
     assert sandbox._client.headers["authorization"] == "Bearer sandbox-secret"
 
 
+def test_sandbox_does_not_fallback_to_hf_token_for_api_headers():
+    sandbox = Sandbox("owner/name", token="hf-token")
+
+    assert "authorization" not in sandbox._client.headers
+    result = sandbox._call("exists", {"path": "/tmp"})
+    assert result.success is False
+    assert "Sandbox API token is required" in result.error
+
+
 def test_sandbox_api_token_is_hidden_from_repr():
     sandbox = Sandbox("owner/name", token="hf-token", api_token="sandbox-secret")
 
     assert "sandbox-secret" not in repr(sandbox)
+
+
+def test_sandbox_variables_allow_trackio_only():
+    assert _validate_sandbox_variables(
+        {"TRACKIO_SPACE_ID": "user/dashboard", "TRACKIO_PROJECT": "run"}
+    ) == {"TRACKIO_SPACE_ID": "user/dashboard", "TRACKIO_PROJECT": "run"}
+
+
+def test_sandbox_variables_reject_hf_token():
+    try:
+        _validate_sandbox_variables({"HF_TOKEN": "hf_secret"})
+    except ValueError as e:
+        assert "HF_TOKEN cannot be injected" in str(e)
+    else:
+        raise AssertionError("HF_TOKEN was accepted as a sandbox variable")
+
+
+def test_sandbox_variables_reject_arbitrary_names():
+    try:
+        _validate_sandbox_variables({"SAFE_LOOKING": "value"})
+    except ValueError as e:
+        assert "not an allowed sandbox variable" in str(e)
+    else:
+        raise AssertionError("Unexpected sandbox variable was accepted")


### PR DESCRIPTION
## Summary
- Create sandbox Spaces as private Docker Spaces by default while keeping all command/file endpoints authenticated.
- Remove user HF credentials from sandbox environments; only Trackio non-secret variables are allowed.
- Store only a SHA-256 hash of the sandbox control token in the Space and keep the raw token client-side.
- Split private Space routing auth from sandbox app auth: Authorization remains the HF bearer token for hf.space, while X-Sandbox-API-Token authenticates FastAPI control endpoints.
- Redact token-like tool outputs/events before they enter model context, frontend events, or persistence.

## Security posture
- Private Space visibility blocks anonymous platform access before requests reach the sandbox app.
- /api/health stays public for readiness; /api/bash, /api/read, /api/write, /api/edit, /api/exists, and /api/kill require sandbox auth.
- HF_TOKEN and Hugging Face Hub token aliases are rejected from sandbox variable injection and are no longer accepted as sandbox API auth fallbacks.
- The sandbox environment contains SANDBOX_API_TOKEN_SHA256, not the raw control token.

## Tests
- uv run pytest tests/unit/test_sandbox_api_auth.py tests/unit/test_redact.py tests/unit/test_sandbox_already_active_message.py -q
- ML_INTERN_LIVE_SANDBOX_TESTS=1 uv run pytest tests/integration/test_live_sandbox_auth.py -q

## Notes
- Live test created a real private Space, verified unauthenticated access is rejected, exercised authenticated bash/read/write/reconnect, and confirmed no HF_TOKEN, HUGGINGFACE_HUB_TOKEN, or raw SANDBOX_API_TOKEN appears in env output.
- Full unit suite currently has two unrelated pre-existing doom-loop assertion failures: tests expect DOOM LOOP DETECTED while implementation returns [SYSTEM: REPETITION GUARD].
