### PR TITLE
Make sandboxes private

### DIFF
--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -165,25 +165,12 @@ def _bearer_token(header: str) -> str:
 
 def _require_auth(request: Request) -> None:
     sandbox_token = os.environ.get("SANDBOX_API_TOKEN") or ""
-    if sandbox_token:
-        supplied = (
-            _bearer_token(request.headers.get("x-sandbox-authorization", ""))
-            or request.headers.get("x-sandbox-api-token", "")
-            or _bearer_token(request.headers.get("authorization", ""))
-        )
-        if not supplied:
-            raise HTTPException(status_code=401, detail="Missing bearer token")
-        if not hmac.compare_digest(supplied, sandbox_token):
-            raise HTTPException(status_code=401, detail="Invalid bearer token")
-        return
-
-    expected = os.environ.get("HF_TOKEN") or ""
-    if not expected:
+    if not sandbox_token:
         raise HTTPException(status_code=503, detail="Sandbox API token not configured")
-    supplied = _bearer_token(request.headers.get("authorization", ""))
+    supplied = _bearer_token(request.headers.get("x-sandbox-authorization", ""))
     if not supplied:
         raise HTTPException(status_code=401, detail="Missing bearer token")
-    if not hmac.compare_digest(supplied, expected):
+    if not hmac.compare_digest(supplied, sandbox_token):
         raise HTTPException(status_code=401, detail="Invalid bearer token")
 
 _AUTH = [Depends(_require_auth)]
@@ -536,23 +523,18 @@ class Sandbox:
         )
         self._hf_api = HfApi(token=self.token)
 
-    def _auth_headers(self, *, prefer_hub_auth: bool = True) -> dict[str, str]:
+    def _auth_headers(self) -> dict[str, str]:
         """Return headers for private HF Space access plus sandbox API auth.
 
         Private Spaces require the HF token in ``Authorization`` at the Hub
-        edge. The sandbox server therefore accepts its control-plane token via
-        ``X-Sandbox-Authorization`` while retaining the legacy Authorization
-        fallback for already-running public sandboxes.
+        edge. The sandbox server requires its control-plane token in the
+        dedicated ``X-Sandbox-Authorization`` header.
         """
         headers: dict[str, str] = {}
-        if prefer_hub_auth and self.token:
+        if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
-            if self.api_token:
-                headers["X-Sandbox-Authorization"] = f"Bearer {self.api_token}"
-        elif self.api_token:
-            headers["Authorization"] = f"Bearer {self.api_token}"
-        elif self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
+        if self.api_token:
+            headers["X-Sandbox-Authorization"] = f"Bearer {self.api_token}"
         return headers
 
     # ── Lifecycle ─────────────────────────────────────────────────
@@ -813,16 +795,6 @@ class Sandbox:
                     json=payload,
                     timeout=effective_timeout,
                 )
-                if resp.status_code == 401 and self.api_token and self.token:
-                    # Compatibility with sandboxes created before the server
-                    # accepted X-Sandbox-Authorization. Those public Spaces
-                    # expect the sandbox token in Authorization.
-                    resp = self._client.post(
-                        endpoint,
-                        json=payload,
-                        timeout=effective_timeout,
-                        headers=self._auth_headers(prefer_hub_auth=False),
-                    )
                 try:
                     data = resp.json()
                 except (ValueError, UnicodeDecodeError):

--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -13,7 +13,7 @@ Architecture:
   - Optionally deletes the Space when done
 
 Lifecycle:
-    sb = Sandbox.create(owner="burtenshaw")         # duplicate, wait, connect
+    sb = Sandbox.create(owner="burtenshaw")         # duplicate private Space, wait, connect
     sb = Sandbox.create(owner="burtenshaw",          # with options
                         hardware="t4-small",
                         private=True,
@@ -157,16 +157,31 @@ def _atomic_write(path: pathlib.Path, content: str):
 
 app = FastAPI()
 
-def _expected_api_token() -> str:
-    return os.environ.get("SANDBOX_API_TOKEN") or os.environ.get("HF_TOKEN") or ""
+def _bearer_token(header: str) -> str:
+    scheme, _, supplied = header.partition(" ")
+    if scheme.lower() != "bearer" or not supplied:
+        return ""
+    return supplied
 
 def _require_auth(request: Request) -> None:
-    expected = _expected_api_token()
+    sandbox_token = os.environ.get("SANDBOX_API_TOKEN") or ""
+    if sandbox_token:
+        supplied = (
+            _bearer_token(request.headers.get("x-sandbox-authorization", ""))
+            or request.headers.get("x-sandbox-api-token", "")
+            or _bearer_token(request.headers.get("authorization", ""))
+        )
+        if not supplied:
+            raise HTTPException(status_code=401, detail="Missing bearer token")
+        if not hmac.compare_digest(supplied, sandbox_token):
+            raise HTTPException(status_code=401, detail="Invalid bearer token")
+        return
+
+    expected = os.environ.get("HF_TOKEN") or ""
     if not expected:
         raise HTTPException(status_code=503, detail="Sandbox API token not configured")
-    auth_header = request.headers.get("authorization", "")
-    scheme, _, supplied = auth_header.partition(" ")
-    if scheme.lower() != "bearer" or not supplied:
+    supplied = _bearer_token(request.headers.get("authorization", ""))
+    if not supplied:
         raise HTTPException(status_code=401, detail="Missing bearer token")
     if not hmac.compare_digest(supplied, expected):
         raise HTTPException(status_code=401, detail="Invalid bearer token")
@@ -513,14 +528,32 @@ class Sandbox:
         # Trailing slash is critical: httpx resolves relative paths against base_url.
         # Without it, client.get("health") resolves to /health instead of /api/health.
         self._base_url = f"https://{slug}.hf.space/api/"
-        api_token = self.api_token or self.token
         self._client = httpx.Client(
             base_url=self._base_url,
-            headers={"Authorization": f"Bearer {api_token}"} if api_token else {},
+            headers=self._auth_headers(),
             timeout=httpx.Timeout(MAX_TIMEOUT, connect=30),
             follow_redirects=True,
         )
         self._hf_api = HfApi(token=self.token)
+
+    def _auth_headers(self, *, prefer_hub_auth: bool = True) -> dict[str, str]:
+        """Return headers for private HF Space access plus sandbox API auth.
+
+        Private Spaces require the HF token in ``Authorization`` at the Hub
+        edge. The sandbox server therefore accepts its control-plane token via
+        ``X-Sandbox-Authorization`` while retaining the legacy Authorization
+        fallback for already-running public sandboxes.
+        """
+        headers: dict[str, str] = {}
+        if prefer_hub_auth and self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+            if self.api_token:
+                headers["X-Sandbox-Authorization"] = f"Bearer {self.api_token}"
+        elif self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+        elif self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     # ── Lifecycle ─────────────────────────────────────────────────
 
@@ -535,7 +568,7 @@ class Sandbox:
         name: str | None = None,
         template: str = TEMPLATE_SPACE,
         hardware: str = "cpu-basic",
-        private: bool = False,
+        private: bool = True,
         sleep_time: int | None = None,
         token: str | None = None,
         secrets: dict[str, str] | None = None,
@@ -555,7 +588,7 @@ class Sandbox:
                   A unique suffix is always appended.
             template: Source Space to duplicate (default: burtenshaw/sandbox).
             hardware: Hardware tier (cpu-basic, t4-small, etc.).
-            private: Whether the Space should be private.
+            private: Whether the Space should be private. Defaults to True.
             sleep_time: Auto-sleep after N seconds of inactivity.
             token: HF API token (from user's OAuth session).
             wait_timeout: Max seconds to wait for Space to start (default: 300).
@@ -780,6 +813,16 @@ class Sandbox:
                     json=payload,
                     timeout=effective_timeout,
                 )
+                if resp.status_code == 401 and self.api_token and self.token:
+                    # Compatibility with sandboxes created before the server
+                    # accepted X-Sandbox-Authorization. Those public Spaces
+                    # expect the sandbox token in Authorization.
+                    resp = self._client.post(
+                        endpoint,
+                        json=payload,
+                        timeout=effective_timeout,
+                        headers=self._auth_headers(prefer_hub_auth=False),
+                    )
                 try:
                     data = resp.json()
                 except (ValueError, UnicodeDecodeError):

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -235,7 +235,7 @@ async def _ensure_sandbox(
     if extra_secrets:
         secrets.update({k: v for k, v in extra_secrets.items() if v})
 
-    create_kwargs["private"] = True
+    create_kwargs["private"] = True  # enforce: overrides any caller-supplied value
     kwargs = {
         "owner": owner,
         "hardware": hardware,
@@ -383,7 +383,7 @@ async def sandbox_create_handler(
             f"Use bash/read/write/edit to interact with it."
         ), True
 
-    create_kwargs: dict[str, Any] = {"private": True}
+    create_kwargs: dict[str, Any] = {}
 
     extra_secrets: dict[str, str] = {}
     if trackio_space_id:

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -235,6 +235,7 @@ async def _ensure_sandbox(
     if extra_secrets:
         secrets.update({k: v for k, v in extra_secrets.items() if v})
 
+    create_kwargs["private"] = True
     kwargs = {
         "owner": owner,
         "hardware": hardware,
@@ -292,7 +293,8 @@ SANDBOX_CREATE_TOOL_SPEC = {
     "description": (
         "Create a persistent remote Linux environment for developing and testing scripts.\n\n"
         "Workflow: sandbox_create → write script → pip install → test with small run → fix errors → hf_jobs at scale.\n"
-        "The sandbox persists across tool calls within the session. pip install works out of the box.\n\n"
+        "The sandbox persists across tool calls within the session. pip install works out of the box. "
+        "Sandboxes are always created as private HF Spaces.\n\n"
         "Use this when: you need to develop, test, and iterate on scripts before launching via hf_jobs. "
         "Especially for training scripts where you need to verify imports, test on a small subset, and fix errors interactively.\n\n"
         "Skip this when: the task is a simple one-shot operation (status check, resource search, quick data query), "
@@ -317,10 +319,6 @@ SANDBOX_CREATE_TOOL_SPEC = {
                 "type": "string",
                 "enum": [e.value for e in SpaceHardware],
                 "description": "Hardware tier for the sandbox (default: cpu-basic)",
-            },
-            "private": {
-                "type": "boolean",
-                "description": "If true, create a private Space",
             },
             "trackio_space_id": {
                 "type": "string",
@@ -385,9 +383,7 @@ async def sandbox_create_handler(
             f"Use bash/read/write/edit to interact with it."
         ), True
 
-    create_kwargs: dict[str, Any] = {}
-    if "private" in args:
-        create_kwargs["private"] = args["private"]
+    create_kwargs: dict[str, Any] = {"private": True}
 
     extra_secrets: dict[str, str] = {}
     if trackio_space_id:
@@ -415,6 +411,7 @@ async def sandbox_create_handler(
         f"Sandbox created: {sb.space_id}\n"
         f"URL: {sb.url}\n"
         f"Hardware: {hardware}\n"
+        "Visibility: private\n"
         f"Use bash/read/write/edit to interact with it."
     ), True
 

--- a/frontend/src/components/Chat/ToolCallGroup.tsx
+++ b/frontend/src/components/Chat/ToolCallGroup.tsx
@@ -536,9 +536,7 @@ function InlineApproval({
                   {' '}({cost})
                 </Box>
               )}
-              {!!args.private && (
-                <Box component="span" sx={{ color: 'var(--muted-text)' }}>{' (private)'}</Box>
-              )}
+              <Box component="span" sx={{ color: 'var(--muted-text)' }}>{' (private)'}</Box>
             </Typography>
             <Typography variant="body2" sx={{ color: 'var(--muted-text)', fontSize: '0.7rem', opacity: 0.7 }}>
               Creates a temporary HF Space to develop and test scripts before running jobs. Takes 1-2 min to start.

--- a/tests/integration/test_live_sandbox_auth.py
+++ b/tests/integration/test_live_sandbox_auth.py
@@ -55,7 +55,7 @@ def test_live_sandbox_authenticated_agent_communication():
         )
         try:
             denied = unauthenticated.post("exists", json={"path": "/tmp"})
-            assert denied.status_code in {401, 403, 404}
+            assert denied.status_code in {401, 403, 404}  # HF private-Space edge may 404 to avoid leaking existence
         finally:
             unauthenticated.close()
 

--- a/tests/integration/test_live_sandbox_auth.py
+++ b/tests/integration/test_live_sandbox_auth.py
@@ -1,7 +1,8 @@
 """Opt-in live sandbox communication test.
 
-This test creates a real Hugging Face Space sandbox, verifies that unauthenticated
-requests are rejected, then exercises the authenticated agent client end-to-end.
+This test creates a real private Hugging Face Space sandbox, verifies that
+unauthenticated requests are rejected, then exercises the authenticated agent
+client end-to-end.
 It is skipped unless ``ML_INTERN_LIVE_SANDBOX_TESTS=1`` and ``HF_TOKEN`` are set.
 """
 
@@ -41,7 +42,7 @@ def test_live_sandbox_authenticated_agent_communication():
             owner=owner,
             name="ml-intern-live-auth",
             hardware="cpu-basic",
-            private=False,
+            private=True,
             token=token,
             secrets={"HF_TOKEN": token},
             wait_timeout=900,
@@ -54,7 +55,7 @@ def test_live_sandbox_authenticated_agent_communication():
         )
         try:
             denied = unauthenticated.post("exists", json={"path": "/tmp"})
-            assert denied.status_code == 401
+            assert denied.status_code in {401, 403, 404}
         finally:
             unauthenticated.close()
 

--- a/tests/unit/test_sandbox_api_auth.py
+++ b/tests/unit/test_sandbox_api_auth.py
@@ -37,7 +37,7 @@ def test_file_and_command_routes_require_bearer_token(monkeypatch):
     assert response.status_code == 401
 
 
-def test_file_and_command_routes_accept_valid_bearer_token(monkeypatch):
+def test_file_and_command_routes_reject_authorization_bearer_token(monkeypatch):
     client = TestClient(_sandbox_app(monkeypatch, "sandbox-secret"))
 
     response = client.post(
@@ -46,8 +46,7 @@ def test_file_and_command_routes_accept_valid_bearer_token(monkeypatch):
         headers={"Authorization": "Bearer sandbox-secret"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["success"] is True
+    assert response.status_code == 401
 
 
 def test_file_and_command_routes_accept_sandbox_header_with_hf_bearer(monkeypatch):
@@ -82,7 +81,7 @@ def test_hf_bearer_alone_is_rejected_when_sandbox_token_is_configured(monkeypatc
     assert response.status_code == 401
 
 
-def test_legacy_hf_token_fallback_is_accepted(monkeypatch):
+def test_legacy_hf_token_fallback_is_rejected(monkeypatch):
     client = TestClient(_sandbox_app(monkeypatch, token=None, hf_token="hf-secret"))
 
     response = client.post(
@@ -91,8 +90,7 @@ def test_legacy_hf_token_fallback_is_accepted(monkeypatch):
         headers={"Authorization": "Bearer hf-secret"},
     )
 
-    assert response.status_code == 200
-    assert response.json()["success"] is True
+    assert response.status_code == 503
 
 
 def test_protected_routes_fail_closed_without_configured_token(monkeypatch):

--- a/tests/unit/test_sandbox_api_auth.py
+++ b/tests/unit/test_sandbox_api_auth.py
@@ -50,6 +50,38 @@ def test_file_and_command_routes_accept_valid_bearer_token(monkeypatch):
     assert response.json()["success"] is True
 
 
+def test_file_and_command_routes_accept_sandbox_header_with_hf_bearer(monkeypatch):
+    client = TestClient(
+        _sandbox_app(monkeypatch, "sandbox-secret", hf_token="hf-secret")
+    )
+
+    response = client.post(
+        "/api/exists",
+        json={"path": "/tmp"},
+        headers={
+            "Authorization": "Bearer hf-secret",
+            "X-Sandbox-Authorization": "Bearer sandbox-secret",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+def test_hf_bearer_alone_is_rejected_when_sandbox_token_is_configured(monkeypatch):
+    client = TestClient(
+        _sandbox_app(monkeypatch, "sandbox-secret", hf_token="hf-secret")
+    )
+
+    response = client.post(
+        "/api/exists",
+        json={"path": "/tmp"},
+        headers={"Authorization": "Bearer hf-secret"},
+    )
+
+    assert response.status_code == 401
+
+
 def test_legacy_hf_token_fallback_is_accepted(monkeypatch):
     client = TestClient(_sandbox_app(monkeypatch, token=None, hf_token="hf-secret"))
 
@@ -75,10 +107,11 @@ def test_protected_routes_fail_closed_without_configured_token(monkeypatch):
     assert response.status_code == 503
 
 
-def test_sandbox_prefers_control_plane_token_for_api_headers():
+def test_sandbox_sends_hub_auth_and_control_plane_header():
     sandbox = Sandbox("owner/name", token="hf-token", api_token="sandbox-secret")
 
-    assert sandbox._client.headers["authorization"] == "Bearer sandbox-secret"
+    assert sandbox._client.headers["authorization"] == "Bearer hf-token"
+    assert sandbox._client.headers["x-sandbox-authorization"] == "Bearer sandbox-secret"
 
 
 def test_sandbox_api_token_is_hidden_from_repr():

--- a/tests/unit/test_sandbox_private_spaces.py
+++ b/tests/unit/test_sandbox_private_spaces.py
@@ -1,6 +1,7 @@
 import asyncio
 from types import SimpleNamespace
 
+from agent.core import telemetry
 from agent.tools import sandbox_client, sandbox_tool
 from agent.tools.sandbox_client import Sandbox
 from agent.tools.sandbox_tool import sandbox_create_handler
@@ -63,5 +64,53 @@ def test_sandbox_tool_forces_private_spaces(monkeypatch):
     )
 
     assert ok is True
-    assert captured_kwargs["private"] is True
+    assert "private" not in captured_kwargs
     assert "Visibility: private" in out
+
+
+def test_ensure_sandbox_overrides_private_argument(monkeypatch):
+    captured_kwargs = {}
+
+    class FakeApi:
+        def __init__(self, token=None):
+            self.token = token
+
+        def whoami(self):
+            return {"name": "alice"}
+
+    class FakeSession:
+        def __init__(self):
+            self.hf_token = "hf-token"
+            self.sandbox = None
+            self.event_queue = SimpleNamespace(put_nowait=lambda event: None)
+            self._cancelled = asyncio.Event()
+
+        async def send_event(self, event):
+            pass
+
+    def fake_create(**kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(
+            space_id="alice/sandbox-12345678",
+            url="https://huggingface.co/spaces/alice/sandbox-12345678",
+        )
+
+    async def fake_record_sandbox_create(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(sandbox_tool, "HfApi", FakeApi)
+    monkeypatch.setattr(sandbox_tool, "_cleanup_user_orphan_sandboxes", lambda *args: 0)
+    monkeypatch.setattr(Sandbox, "create", staticmethod(fake_create))
+    monkeypatch.setattr(telemetry, "record_sandbox_create", fake_record_sandbox_create)
+    monkeypatch.setattr("huggingface_hub.metadata_update", lambda *args, **kwargs: None)
+
+    async def run():
+        session = FakeSession()
+        sb, error = await sandbox_tool._ensure_sandbox(session, private=False)
+        return sb, error
+
+    sb, error = asyncio.run(run())
+
+    assert error is None
+    assert sb is not None
+    assert captured_kwargs["private"] is True

--- a/tests/unit/test_sandbox_private_spaces.py
+++ b/tests/unit/test_sandbox_private_spaces.py
@@ -1,0 +1,67 @@
+import asyncio
+from types import SimpleNamespace
+
+from agent.tools import sandbox_client, sandbox_tool
+from agent.tools.sandbox_client import Sandbox
+from agent.tools.sandbox_tool import sandbox_create_handler
+
+
+def test_sandbox_client_defaults_to_private_spaces(monkeypatch):
+    duplicate_kwargs = {}
+
+    class FakeApi:
+        def __init__(self, token=None):
+            self.token = token
+
+        def duplicate_space(self, **kwargs):
+            duplicate_kwargs.update(kwargs)
+
+        def add_space_secret(self, *args, **kwargs):
+            pass
+
+        def get_space_runtime(self, space_id):
+            return SimpleNamespace(stage="RUNNING", hardware="cpu-basic")
+
+    monkeypatch.setattr(sandbox_client, "HfApi", FakeApi)
+    monkeypatch.setattr(
+        Sandbox,
+        "_setup_server",
+        staticmethod(lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(Sandbox, "_wait_for_api", lambda self, *args, **kwargs: None)
+
+    Sandbox.create(owner="alice", token="hf-token", log=lambda msg: None)
+
+    assert duplicate_kwargs["private"] is True
+
+
+def test_sandbox_tool_forces_private_spaces(monkeypatch):
+    captured_kwargs = {}
+
+    async def fake_ensure_sandbox(
+        session,
+        hardware="cpu-basic",
+        extra_secrets=None,
+        **create_kwargs,
+    ):
+        captured_kwargs.update(create_kwargs)
+        return (
+            SimpleNamespace(
+                space_id="alice/sandbox-12345678",
+                url="https://huggingface.co/spaces/alice/sandbox-12345678",
+            ),
+            None,
+        )
+
+    monkeypatch.setattr(sandbox_tool, "_ensure_sandbox", fake_ensure_sandbox)
+
+    out, ok = asyncio.run(
+        sandbox_create_handler(
+            {"private": False},
+            session=SimpleNamespace(sandbox=None),
+        )
+    )
+
+    assert ok is True
+    assert captured_kwargs["private"] is True
+    assert "Visibility: private" in out


### PR DESCRIPTION
## Summary

- Make sandbox HF Spaces private by default and enforce private creation in `_ensure_sandbox`.
- Split HF private-Space auth from sandbox API auth with `Authorization` plus `X-Sandbox-Authorization`.
- Remove legacy sandbox auth fallback and update tests/UI copy for private sandboxes.

## Testing

- `uv run pytest tests/unit/test_sandbox_private_spaces.py tests/unit/test_sandbox_api_auth.py tests/unit/test_sandbox_already_active_message.py`
- `npm run build`
