### PR TITLE
fix: async plan isolation, blocking API call, and CORS for production

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -347,8 +347,8 @@ async def event_listener(
                 shimmer.stop()
                 stream_buf.discard()
                 print_turn_complete()
-                print_plan()
                 session = session_holder[0] if session_holder else None
+                print_plan(session=session)
                 if session is not None:
                     await session.send_deferred_turn_complete_notification(event)
                 turn_complete_event.set()

--- a/agent/tools/hf_repo_git_tool.py
+++ b/agent/tools/hf_repo_git_tool.py
@@ -285,11 +285,14 @@ class HfRepoGitTool:
         repo_type = args.get("repo_type", "model")
         status = args.get("status", "all")  # open, closed, all
 
-        discussions = list(self.api.get_repo_discussions(
-            repo_id=repo_id,
-            repo_type=repo_type,
-            discussion_status=status if status != "all" else None,
-        ))
+        def _fetch():
+            return list(self.api.get_repo_discussions(
+                repo_id=repo_id,
+                repo_type=repo_type,
+                discussion_status=status if status != "all" else None,
+            ))
+
+        discussions = await _async_call(_fetch)
 
         if not discussions:
             return {"formatted": f"No discussions in {repo_id}", "totalResults": 0, "resultsShared": 0}

--- a/agent/tools/plan_tool.py
+++ b/agent/tools/plan_tool.py
@@ -5,8 +5,9 @@ from agent.utils.terminal_display import format_plan_tool_output
 
 from .types import ToolResult
 
-# In-memory storage for the current plan (raw structure from agent)
-_current_plan: List[Dict[str, str]] = []
+# Per-session plan storage to avoid cross-session corruption
+_session_plans: Dict[str, List[Dict[str, str]]] = {}
+_last_plan_session_id: str | None = None
 
 
 class PlanTool:
@@ -26,7 +27,7 @@ class PlanTool:
         Returns:
             ToolResult with formatted output
         """
-        global _current_plan
+        global _session_plans, _last_plan_session_id
 
         todos = params.get("todos", [])
 
@@ -54,8 +55,10 @@ class PlanTool:
                     "isError": True,
                 }
 
-        # Store the raw todos structure in memory
-        _current_plan = todos
+        # Store per-session to prevent cross-session plan corruption
+        session_id = self.session.session_id if self.session else "__no_session__"
+        _session_plans[session_id] = todos
+        _last_plan_session_id = session_id
 
         # Emit plan update event if session is available
         if self.session:
@@ -76,9 +79,13 @@ class PlanTool:
         }
 
 
-def get_current_plan() -> List[Dict[str, str]]:
-    """Get the current plan (raw structure)."""
-    return _current_plan
+def get_current_plan(session_id: str | None = None) -> List[Dict[str, str]]:
+    """Get the current plan for a session (raw structure)."""
+    if session_id:
+        return _session_plans.get(session_id, [])
+    if _last_plan_session_id:
+        return _session_plans.get(_last_plan_session_id, [])
+    return []
 
 
 # Tool specification

--- a/agent/utils/terminal_display.py
+++ b/agent/utils/terminal_display.py
@@ -437,11 +437,12 @@ def print_help() -> None:
 
 # ── Plan display ───────────────────────────────────────────────────────
 
-def format_plan_display() -> str:
+def format_plan_display(session=None) -> str:
     """Format the current plan for display."""
     from agent.tools.plan_tool import get_current_plan
 
-    plan = get_current_plan()
+    session_id = session.session_id if session else None
+    plan = get_current_plan(session_id=session_id)
     if not plan:
         return ""
 
@@ -462,8 +463,8 @@ def format_plan_display() -> str:
     return "\n".join(lines)
 
 
-def print_plan() -> None:
-    plan_str = format_plan_display()
+def print_plan(session=None) -> None:
+    plan_str = format_plan_display(session=session)
     if plan_str:
         _console.print(plan_str)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -70,15 +70,22 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# CORS middleware for development
+# CORS middleware
+allow_origins = [
+    "http://localhost:5173",  # Vite dev server
+    "http://localhost:3000",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:3000",
+]
+
+# Add production HF Spaces URL when deployed
+space_host = os.environ.get("SPACE_HOST")
+if space_host:
+    allow_origins.append(f"https://{space_host}")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",  # Vite dev server
-        "http://localhost:3000",
-        "http://127.0.0.1:5173",
-        "http://127.0.0.1:3000",
-    ],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

Three targeted fixes:

- **plan_tool.py: Per-session plan isolation** — The module-level `_current_plan` list was shared across all sessions, causing concurrent sessions to overwrite each other's plans. Replaced with a per-session dict keyed by `session_id`. Updated `get_current_plan()`, `format_plan_display()`, and `print_plan()` to be session-aware.

- **hf_repo_git_tool.py: Async wrapper for `get_repo_discussions`** — Every other `HfApi` call in this file uses `_async_call()` to run in a thread pool, but `get_repo_discussions` was called synchronously, blocking the event loop during the HTTP request. Wrapped it in `_async_call()` with the list materialized inside the thread.

- **backend/main.py: CORS origins for production** — `allow_origins` was hardcoded to localhost-only, causing CORS middleware to reject browser requests when deployed to HF Spaces. Added `SPACE_HOST` env var to the allow list dynamically.

## Test plan
- [x] Code review of diff
- [ ] Verify plan isolation: two concurrent sessions should have independent plans
- [ ] Verify `get_repo_discussions` no longer blocks the event loop
- [ ] Verify CORS allows production HF Spaces URL when `SPACE_HOST` is set