### PR TITLE
Skip redundant CPU sandbox hardware request

### DIFF
--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -613,7 +613,7 @@ class Sandbox:
         *,
         name: str | None = None,
         template: str = TEMPLATE_SPACE,
-        hardware: str = "cpu-basic",
+        hardware: str = CPU_BASIC_HARDWARE,
         private: bool = True,
         sleep_time: int | None = None,
         token: str | None = None,
@@ -682,7 +682,9 @@ class Sandbox:
         # ``duplicate_space`` already receives the target hardware. The extra
         # /hardware call is useful for paid tiers, but hosted OAuth tokens can
         # 401 on that endpoint for a fresh private Space even after duplication
-        # succeeds. Avoid the redundant call for default CPU sandboxes.
+        # succeeds. Avoid the redundant call for default CPU sandboxes when no
+        # auto-sleep timer is requested; with sleep_time set, the hardware
+        # endpoint is still needed to configure auto-sleep.
         if hardware == CPU_BASIC_HARDWARE and sleep_time is None:
             _log(f"Using duplicated Space hardware: {hardware}")
         else:

--- a/agent/tools/sandbox_client.py
+++ b/agent/tools/sandbox_client.py
@@ -66,6 +66,7 @@ WAIT_TIMEOUT = 600
 WAIT_INTERVAL = 5
 API_WAIT_TIMEOUT = 180
 HARDWARE_REQUEST_TIMEOUT = 60
+CPU_BASIC_HARDWARE = "cpu-basic"
 
 
 def _is_transient_space_visibility_error(error: Exception) -> bool:
@@ -678,18 +679,22 @@ class Sandbox:
 
         _check_cancel()
 
-        # Some template duplicates can initially inherit the template hardware.
-        # Explicitly request the target tier so automatic CPU sandboxes never
-        # silently come up on GPU hardware.
-        _request_space_hardware_with_retry(
-            api,
-            space_id,
-            hardware=hardware,
-            sleep_time=sleep_time,
-            log=_log,
-            check_cancel=_check_cancel,
-        )
-        _log(f"Requested hardware: {hardware}")
+        # ``duplicate_space`` already receives the target hardware. The extra
+        # /hardware call is useful for paid tiers, but hosted OAuth tokens can
+        # 401 on that endpoint for a fresh private Space even after duplication
+        # succeeds. Avoid the redundant call for default CPU sandboxes.
+        if hardware == CPU_BASIC_HARDWARE and sleep_time is None:
+            _log(f"Using duplicated Space hardware: {hardware}")
+        else:
+            _request_space_hardware_with_retry(
+                api,
+                space_id,
+                hardware=hardware,
+                sleep_time=sleep_time,
+                log=_log,
+                check_cancel=_check_cancel,
+            )
+            _log(f"Requested hardware: {hardware}")
 
         # Inject secrets BEFORE uploading server files (which triggers rebuild).
         # Secrets added after a Space is running aren't available until restart,

--- a/tests/unit/test_sandbox_private_spaces.py
+++ b/tests/unit/test_sandbox_private_spaces.py
@@ -43,7 +43,8 @@ def test_sandbox_client_defaults_to_private_spaces(monkeypatch):
     Sandbox.create(owner="alice", token="hf-token", log=lambda msg: None)
 
     assert duplicate_kwargs["private"] is True
-    assert requested_hardware == [(duplicate_kwargs["to_id"], "cpu-basic", None)]
+    assert duplicate_kwargs["hardware"] == "cpu-basic"
+    assert requested_hardware == []
 
 
 def test_sandbox_client_retries_transient_runtime_404(monkeypatch):
@@ -124,7 +125,7 @@ def test_sandbox_client_retries_transient_hardware_401(monkeypatch):
             pass
 
         def get_space_runtime(self, space_id):
-            return SimpleNamespace(stage="RUNNING", hardware="cpu-basic")
+            return SimpleNamespace(stage="RUNNING", hardware="t4-small")
 
     monkeypatch.setattr(sandbox_client, "HfApi", FakeApi)
     monkeypatch.setattr(sandbox_client.time, "sleep", lambda seconds: None)
@@ -135,7 +136,12 @@ def test_sandbox_client_retries_transient_hardware_401(monkeypatch):
     )
     monkeypatch.setattr(Sandbox, "_wait_for_api", lambda self, *args, **kwargs: None)
 
-    sandbox = Sandbox.create(owner="alice", token="hf-token", log=logs.append)
+    sandbox = Sandbox.create(
+        owner="alice",
+        token="hf-token",
+        hardware="t4-small",
+        log=logs.append,
+    )
 
     assert sandbox.space_id.startswith("alice/sandbox-")
     assert hardware_calls == 2


### PR DESCRIPTION
## Summary

- Skip the follow-up `/hardware` request for default `cpu-basic` sandbox creation.
- Keep the hardware retry path for non-default hardware tiers.
- Update unit coverage so CPU sandboxes rely on the hardware value passed to `duplicate_space`, while upgraded hardware still exercises retry behavior.

## Context

The deployed Space can create the private sandbox Space successfully, but hosted credentials may receive a 401 from the immediate follow-up `/hardware` endpoint. For `cpu-basic`, that endpoint call is redundant because `duplicate_space` already receives `hardware="cpu-basic"`.

## Testing

- `uv run --extra dev pytest tests/unit/test_sandbox_private_spaces.py tests/unit/test_sandbox_api_auth.py tests/unit/test_session_manager_persistence.py`
