### PR TITLE
ci: prepare Claude Code bin directory

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -59,6 +59,9 @@ jobs:
             printf 'PROMPT_EOF\n'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Prepare Claude Code bin directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- create the Claude Code installer target directory before running anthropics/claude-code-action@v1
- temporarily works around upstream installer failures where /home/runner/.local/bin/claude is not created

Related to https://github.com/anthropics/claude-code-action/issues/1290

## Testing
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .