### PR TITLE
Fix Pro entitlement checks

### DIFF
--- a/agent/tools/jobs_tool.py
+++ b/agent/tools/jobs_tool.py
@@ -631,10 +631,11 @@ class HfJobsTool:
                         "formatted": (
                             f"Hugging Face Jobs rejected this run because the "
                             f"namespace `{self.namespace}` has no available credits. "
-                            "Tell the user to add credits at "
-                            "https://huggingface.co/settings/billing — once topped up, "
-                            "re-run this same job. (Switching namespaces is fine if "
-                            "another wallet has credits.)"
+                            "HF Jobs are billed with namespace credits, which are "
+                            "separate from HF Pro membership. Tell the user to add "
+                            "credits at https://huggingface.co/settings/billing — "
+                            "once topped up, re-run this same job. (Switching "
+                            "namespaces is fine if another wallet has credits.)"
                         ),
                         "totalResults": 0,
                         "resultsShared": 0,

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -56,6 +56,7 @@ REQUIRED_OAUTH_SCOPES: tuple[str, ...] = (
 # Plan field discovery — log the whoami-v2 shape once at DEBUG so we can
 # confirm the actual key in production without hammering the HF API.
 _WHOAMI_SHAPE_LOGGED = False
+_PAID_PLAN_TAGS = ("pro", "enterprise", "team")
 
 
 def normalize_oauth_scopes(scopes: Iterable[str]) -> tuple[str, ...]:
@@ -136,6 +137,38 @@ def _user_from_info(user_info: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _has_paid_plan_tag(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return any(tag in value.lower() for tag in _PAID_PLAN_TAGS)
+
+
+def _normalize_user_plan(whoami: Any) -> str:
+    """Normalize a whoami-v2 payload to the app's quota tiers."""
+    if not isinstance(whoami, dict):
+        return "free"
+
+    # OAuth whoami sets `type: "user"` and surfaces Pro via the `isPro` boolean
+    # — see Space discussion #21.
+    if whoami.get("isPro") is True or whoami.get("is_pro") is True:
+        return "pro"
+
+    for key in ("plan", "accountType", "account_type", "tier", "subscription"):
+        if _has_paid_plan_tag(whoami.get(key)):
+            return "pro"
+
+    orgs = whoami.get("orgs") or []
+    if isinstance(orgs, list):
+        for org in orgs:
+            if not isinstance(org, dict):
+                continue
+            for key in ("plan", "accountType", "account_type", "tier"):
+                if _has_paid_plan_tag(org.get(key)):
+                    return "org"
+
+    return "free"
+
+
 async def _fetch_user_plan(token: str) -> str:
     """Look up the user's HF plan via /api/whoami-v2.
 
@@ -160,26 +193,7 @@ async def _fetch_user_plan(token: str) -> str:
             whoami.get("isPro") if isinstance(whoami, dict) else None,
         )
 
-    if not isinstance(whoami, dict):
-        return "free"
-
-    # OAuth whoami sets `type: "user"` and surfaces Pro via the `isPro` boolean
-    # — see Space discussion #21. HF-Jobs eligibility (PR #172) ignores plan
-    # entirely; the premium-model daily-cap tier is still a free vs pro/org split.
-    if whoami.get("isPro") is True or whoami.get("is_pro") is True:
-        return "pro"
-    plan_str = ""
-    for key in ("plan", "type", "accountType"):
-        value = whoami.get(key)
-        if isinstance(value, str) and value:
-            plan_str = value.lower()
-            break
-    if any(tag in plan_str for tag in ("pro", "enterprise", "team")):
-        return "pro"
-    orgs = whoami.get("orgs") or []
-    if isinstance(orgs, list) and orgs:
-        return "org"
-    return "free"
+    return _normalize_user_plan(whoami)
 
 
 async def _extract_user_from_token(token: str) -> dict[str, Any] | None:

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import re
 import time
 from collections.abc import Iterable
 from hashlib import sha256
@@ -56,7 +57,6 @@ REQUIRED_OAUTH_SCOPES: tuple[str, ...] = (
 # Plan field discovery — log the whoami-v2 shape once at DEBUG so we can
 # confirm the actual key in production without hammering the HF API.
 _WHOAMI_SHAPE_LOGGED = False
-_PAID_PLAN_TAGS = ("pro", "enterprise", "team")
 
 
 def normalize_oauth_scopes(scopes: Iterable[str]) -> tuple[str, ...]:
@@ -137,10 +137,10 @@ def _user_from_info(user_info: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _has_paid_plan_tag(value: Any) -> bool:
+def _has_pro_plan_token(value: Any) -> bool:
     if not isinstance(value, str):
         return False
-    return any(tag in value.lower() for tag in _PAID_PLAN_TAGS)
+    return "pro" in re.split(r"[^a-z0-9]+", value.lower())
 
 
 def _normalize_user_plan(whoami: Any) -> str:
@@ -154,7 +154,7 @@ def _normalize_user_plan(whoami: Any) -> str:
         return "pro"
 
     for key in ("plan", "accountType", "account_type", "tier", "subscription"):
-        if _has_paid_plan_tag(whoami.get(key)):
+        if _has_pro_plan_token(whoami.get(key)):
             return "pro"
 
     return "free"
@@ -175,12 +175,12 @@ async def _fetch_user_plan(token: str) -> str:
     if not _WHOAMI_SHAPE_LOGGED:
         _WHOAMI_SHAPE_LOGGED = True
         logger.debug(
-            "whoami-v2 payload keys: %s (sample values: plan=%r type=%r isPro=%r)",
+            "whoami-v2 payload keys: %s (sample values: plan=%r accountType=%r isPro=%r)",
             sorted(whoami.keys())
             if isinstance(whoami, dict)
             else type(whoami).__name__,
             whoami.get("plan") if isinstance(whoami, dict) else None,
-            whoami.get("type") if isinstance(whoami, dict) else None,
+            whoami.get("accountType") if isinstance(whoami, dict) else None,
             whoami.get("isPro") if isinstance(whoami, dict) else None,
         )
 

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -141,7 +141,7 @@ def _normalize_user_plan(whoami: Any) -> str:
     if not isinstance(whoami, dict):
         return "free"
 
-    if whoami.get("isPro") is True or whoami.get("is_pro") is True:
+    if whoami.get("isPro") is True:
         return "pro"
 
     return "free"
@@ -162,12 +162,11 @@ async def _fetch_user_plan(token: str) -> str:
     if not _WHOAMI_SHAPE_LOGGED:
         _WHOAMI_SHAPE_LOGGED = True
         logger.debug(
-            "whoami-v2 payload keys: %s (sample values: isPro=%r is_pro=%r)",
+            "whoami-v2 payload keys: %s (sample values: isPro=%r)",
             sorted(whoami.keys())
             if isinstance(whoami, dict)
             else type(whoami).__name__,
             whoami.get("isPro") if isinstance(whoami, dict) else None,
-            whoami.get("is_pro") if isinstance(whoami, dict) else None,
         )
 
     return _normalize_user_plan(whoami)

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -35,7 +35,7 @@ DEV_USER: dict[str, Any] = {
     "user_id": "dev",
     "username": "dev",
     "authenticated": True,
-    "plan": "org",  # Dev runs at the Pro/Org quota tier so local testing isn't capped.
+    "plan": "pro",  # Dev runs at the Pro quota tier so local testing isn't capped.
 }
 
 INTERNAL_HF_TOKEN_KEY = "_hf_token"
@@ -144,7 +144,7 @@ def _has_paid_plan_tag(value: Any) -> bool:
 
 
 def _normalize_user_plan(whoami: Any) -> str:
-    """Normalize a whoami-v2 payload to the app's quota tiers."""
+    """Normalize a whoami-v2 payload to the app's personal quota tiers."""
     if not isinstance(whoami, dict):
         return "free"
 
@@ -157,22 +157,13 @@ def _normalize_user_plan(whoami: Any) -> str:
         if _has_paid_plan_tag(whoami.get(key)):
             return "pro"
 
-    orgs = whoami.get("orgs") or []
-    if isinstance(orgs, list):
-        for org in orgs:
-            if not isinstance(org, dict):
-                continue
-            for key in ("plan", "accountType", "account_type", "tier"):
-                if _has_paid_plan_tag(org.get(key)):
-                    return "org"
-
     return "free"
 
 
 async def _fetch_user_plan(token: str) -> str:
     """Look up the user's HF plan via /api/whoami-v2.
 
-    Returns 'free' | 'pro' | 'org'. Non-200, network errors, or an unknown
+    Returns 'free' | 'pro'. Non-200, network errors, or an unknown
     payload shape all collapse to 'free' — safe default; we'd rather under-
     grant the Pro cap than over-grant it on bad data.
     """

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -6,7 +6,6 @@
 
 import logging
 import os
-import re
 import time
 from collections.abc import Iterable
 from hashlib import sha256
@@ -54,8 +53,8 @@ REQUIRED_OAUTH_SCOPES: tuple[str, ...] = (
     "write-discussions",
 )
 
-# Plan field discovery — log the whoami-v2 shape once at DEBUG so we can
-# confirm the actual key in production without hammering the HF API.
+# Log the whoami-v2 shape once at DEBUG so we can confirm the production Pro
+# signal without hammering the HF API.
 _WHOAMI_SHAPE_LOGGED = False
 
 
@@ -137,25 +136,13 @@ def _user_from_info(user_info: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _has_pro_plan_token(value: Any) -> bool:
-    if not isinstance(value, str):
-        return False
-    return "pro" in re.split(r"[^a-z0-9]+", value.lower())
-
-
 def _normalize_user_plan(whoami: Any) -> str:
     """Normalize a whoami-v2 payload to the app's personal quota tiers."""
     if not isinstance(whoami, dict):
         return "free"
 
-    # OAuth whoami sets `type: "user"` and surfaces Pro via the `isPro` boolean
-    # — see Space discussion #21.
     if whoami.get("isPro") is True or whoami.get("is_pro") is True:
         return "pro"
-
-    for key in ("plan", "accountType", "account_type", "tier", "subscription"):
-        if _has_pro_plan_token(whoami.get(key)):
-            return "pro"
 
     return "free"
 
@@ -175,13 +162,12 @@ async def _fetch_user_plan(token: str) -> str:
     if not _WHOAMI_SHAPE_LOGGED:
         _WHOAMI_SHAPE_LOGGED = True
         logger.debug(
-            "whoami-v2 payload keys: %s (sample values: plan=%r accountType=%r isPro=%r)",
+            "whoami-v2 payload keys: %s (sample values: isPro=%r is_pro=%r)",
             sorted(whoami.keys())
             if isinstance(whoami, dict)
             else type(whoami).__name__,
-            whoami.get("plan") if isinstance(whoami, dict) else None,
-            whoami.get("accountType") if isinstance(whoami, dict) else None,
             whoami.get("isPro") if isinstance(whoami, dict) else None,
+            whoami.get("is_pro") if isinstance(whoami, dict) else None,
         )
 
     return _normalize_user_plan(whoami)

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -174,7 +174,7 @@ async def _enforce_premium_model_quota(
     cap = user_quotas.daily_cap_for(plan)
     new_count = await user_quotas.try_increment_claude(user_id, cap)
     if new_count is None:
-        if plan in {"pro", "org"}:
+        if plan == "pro":
             message = (
                 "Daily premium model limit reached. Use a free model and try "
                 "premium models again tomorrow."

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -12,7 +12,6 @@ from typing import Any
 from dependencies import (
     INTERNAL_HF_TOKEN_KEY,
     get_current_user,
-    require_huggingface_org_member,
 )
 from fastapi import (
     APIRouter,
@@ -55,7 +54,7 @@ _background_teardown_tasks: set[asyncio.Task] = set()
 
 DEFAULT_CLAUDE_MODEL_ID = "bedrock/us.anthropic.claude-opus-4-6-v1"
 DEFAULT_FREE_MODEL_ID = "moonshotai/Kimi-K2.6"
-GATED_MODEL_IDS = {
+PREMIUM_MODEL_IDS = {
     DEFAULT_CLAUDE_MODEL_ID,
     "openai/gpt-5.5",
 }
@@ -120,35 +119,8 @@ def _available_models() -> list[dict[str, Any]]:
 AVAILABLE_MODELS = _available_models()
 
 
-def _is_gated_model(model_id: str) -> bool:
-    return model_id in GATED_MODEL_IDS
-
-
-def _premium_model_restricted_error() -> HTTPException:
-    return HTTPException(
-        status_code=403,
-        detail={
-            "error": "premium_model_restricted",
-            "message": (
-                "Premium models are gated to HF staff. Pick a free model — "
-                "Kimi K2.6, MiniMax M2.7, GLM 5.1, or DeepSeek V4 Pro — "
-                "instead."
-            ),
-        },
-    )
-
-
-async def _require_hf_for_gated_model(request: Request, model_id: str) -> None:
-    """403 if a non-``huggingface``-org user tries to select a gated model.
-
-    Gated models are deployed paid endpoints backed by service-owned
-    credentials. The gate only fires for deployed paid models so non-HF users
-    can still freely switch between the free models.
-    """
-    if not _is_gated_model(model_id):
-        return
-    if not await require_huggingface_org_member(request):
-        raise _premium_model_restricted_error()
+def _is_premium_model(model_id: str) -> bool:
+    return model_id in PREMIUM_MODEL_IDS
 
 
 async def _model_override_for_new_session(
@@ -157,21 +129,19 @@ async def _model_override_for_new_session(
 ) -> str | None:
     """Return the model override to use when creating a new session.
 
-    Explicit gated-model requests keep the hard membership gate. Implicit
-    default sessions are more forgiving: when the configured default is gated
-    and the user lacks access, start them on the first free model instead of
-    blocking session creation.
+    Explicit premium model requests are allowed and charged at message-submit
+    time. Implicit default sessions are more forgiving: when the configured
+    default is premium, start them on the first free model instead of spending
+    premium quota accidentally.
     """
     resolved_model = requested_model or session_manager.config.model_name
-    if not _is_gated_model(resolved_model):
-        return requested_model
-    if await require_huggingface_org_member(request):
+    if not _is_premium_model(resolved_model):
         return requested_model
     if requested_model:
-        raise _premium_model_restricted_error()
+        return requested_model
 
     logger.info(
-        "Default gated model %s is unavailable to this user; "
+        "Default premium model %s would spend quota; "
         "creating session with free fallback %s",
         resolved_model,
         DEFAULT_FREE_MODEL_ID,
@@ -179,40 +149,48 @@ async def _model_override_for_new_session(
     return DEFAULT_FREE_MODEL_ID
 
 
-async def _enforce_gated_model_quota(
+async def _enforce_premium_model_quota(
     user: dict[str, Any],
     agent_session: AgentSession,
 ) -> None:
-    """Charge the user's daily gated-model quota on first use in a session.
+    """Charge the user's daily premium-model quota on first use in a session.
 
     Runs at *message-submit* time, not session-create time — so spinning up a
-    gated-model session to look around doesn't burn quota. The
+    premium-model session to look around doesn't burn quota. The
     ``claude_counted`` flag on ``AgentSession`` guards against re-counting the
     same session; the stored field name is kept for persistence compatibility.
 
-    No-ops when the session's current model isn't gated, or when this
+    No-ops when the session's current model isn't premium, or when this
     session has already been charged. Raises 429 when the user has hit
     their daily cap.
     """
     if agent_session.claude_counted:
         return
     model_name = agent_session.session.config.model_name
-    if not _is_gated_model(model_name):
+    if not _is_premium_model(model_name):
         return
     user_id = user["user_id"]
-    cap = user_quotas.daily_cap_for(user.get("plan"))
+    plan = user.get("plan", "free")
+    cap = user_quotas.daily_cap_for(plan)
     new_count = await user_quotas.try_increment_claude(user_id, cap)
     if new_count is None:
+        if plan in {"pro", "org"}:
+            message = (
+                "Daily premium model limit reached. Use a free model and try "
+                "premium models again tomorrow."
+            )
+        else:
+            message = (
+                "Daily premium model limit reached. Upgrade to HF Pro for "
+                f"{user_quotas.CLAUDE_PRO_DAILY}/day or use a free model."
+            )
         raise HTTPException(
             status_code=429,
             detail={
                 "error": "premium_model_daily_cap",
-                "plan": user.get("plan", "free"),
+                "plan": plan,
                 "cap": cap,
-                "message": (
-                    "Daily premium model limit reached. Upgrade to HF Pro for "
-                    f"{user_quotas.CLAUDE_PRO_DAILY}/day or use a free model."
-                ),
+                "message": message,
             },
         )
     agent_session.claude_counted = True
@@ -405,7 +383,7 @@ async def create_session(
     behalf of the user.
 
     Optional body ``{"model"?: <id>}`` selects the session's LLM; unknown
-    ids are rejected (400). The gated-model quota runs at message-submit
+    ids are rejected (400). The premium-model quota runs at message-submit
     time, not here — spinning up a session to look around is free.
 
     Returns 503 if the server or user has reached the session limit.
@@ -426,8 +404,8 @@ async def create_session(
     if model and model not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
 
-    # Explicit premium selections remain gated. If the implicit configured
-    # default is unavailable, start the session on a free model instead.
+    # Explicit premium selections are allowed. If the implicit configured
+    # default is premium, start the session on a free model instead.
     model = await _model_override_for_new_session(request, model)
 
     try:
@@ -458,7 +436,7 @@ async def restore_session_summary(
     session's context as a user-role system note.
 
     Optional ``"model"`` in the body overrides the session's LLM. The
-    gated-model quota runs at message-submit time, not here.
+    premium-model quota runs at message-submit time, not here.
     """
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
@@ -524,10 +502,7 @@ async def set_session_model(
 
     Takes effect on the next LLM call in that session — other sessions
     (including other browser tabs) are unaffected. Model switches don't
-    charge quota — the gated-model quota only fires at message-submit time.
-
-    Switching TO a gated deployed model requires HF org membership; free-model
-    and local-dev direct provider switches are unrestricted.
+    charge quota — the premium-model quota only fires at message-submit time.
     """
     agent_session = await _check_session_access(session_id, user, request)
     model_id = body.get("model")
@@ -536,7 +511,6 @@ async def set_session_model(
     valid_ids = {m["id"] for m in AVAILABLE_MODELS}
     if model_id not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}")
-    await _require_hf_for_gated_model(request, model_id)
     if not agent_session:
         raise HTTPException(status_code=404, detail="Session not found")
     await session_manager.update_session_model(session_id, model_id)
@@ -686,7 +660,7 @@ async def submit_input(
         body = SubmitRequest(**payload)
     except ValidationError as exc:
         raise RequestValidationError(exc.errors()) from exc
-    await _enforce_gated_model_quota(user, agent_session)
+    await _enforce_premium_model_quota(user, agent_session)
     success = await session_manager.submit_user_input(body.session_id, body.text)
     if not success:
         raise HTTPException(status_code=404, detail="Session not found or inactive")
@@ -738,12 +712,12 @@ async def chat_sse(
     text = body.get("text")
     approvals = body.get("approvals")
 
-    # Gate user-message sends against the daily gated-model quota. Approvals are
+    # Gate user-message sends against the daily premium-model quota. Approvals are
     # continuations of an in-progress turn — the session was already charged
     # on its first message, so we skip the gate there.
     if text is not None and not approvals:
         try:
-            await _enforce_gated_model_quota(user, agent_session)
+            await _enforce_premium_model_quota(user, agent_session)
         except HTTPException:
             broadcaster.unsubscribe(sub_id)
             raise

--- a/backend/user_quotas.py
+++ b/backend/user_quotas.py
@@ -13,7 +13,7 @@ back to a premium model doesn't (`AgentSession.claude_counted` guards that).
 
 Cap tiers:
   free user   → CLAUDE_FREE_DAILY (1)
-  pro / org   → CLAUDE_PRO_DAILY  (20)
+  pro user    → CLAUDE_PRO_DAILY  (20)
 """
 
 import asyncio
@@ -40,7 +40,7 @@ def _today() -> str:
 
 def daily_cap_for(plan: str | None) -> int:
     """Return the daily Claude-session cap for the given plan."""
-    return CLAUDE_PRO_DAILY if plan in {"pro", "org"} else CLAUDE_FREE_DAILY
+    return CLAUDE_PRO_DAILY if plan == "pro" else CLAUDE_FREE_DAILY
 
 
 async def get_claude_used_today(user_id: str) -> int:

--- a/backend/user_quotas.py
+++ b/backend/user_quotas.py
@@ -40,7 +40,7 @@ def _today() -> str:
 
 def daily_cap_for(plan: str | None) -> int:
     """Return the daily Claude-session cap for the given plan."""
-    return CLAUDE_FREE_DAILY if (plan or "free") == "free" else CLAUDE_PRO_DAILY
+    return CLAUDE_PRO_DAILY if plan in {"pro", "org"} else CLAUDE_FREE_DAILY
 
 
 async def get_claude_used_today(user_id: str) -> int:

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -87,6 +87,19 @@ const findModelByPath = (path: string, options: ModelOption[]): ModelOption | un
   return options.find(m => m.modelPath === path || path?.includes(m.id));
 };
 
+const readApiErrorMessage = async (res: Response, fallback: string): Promise<string> => {
+  try {
+    const data = await res.json();
+    const detail = data?.detail;
+    if (typeof detail === 'string') return detail;
+    if (detail && typeof detail.message === 'string') return detail.message;
+    if (detail && typeof detail.error === 'string') return detail.error;
+  } catch {
+    /* ignore malformed error bodies */
+  }
+  return fallback;
+};
+
 interface ChatInputProps {
   sessionId?: string;
   initialModelPath?: string | null;
@@ -121,6 +134,7 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
   const setClaudeQuotaExhausted = useAgentStore((s) => s.setClaudeQuotaExhausted);
   const jobsUpgradeRequired = useAgentStore((s) => s.jobsUpgradeRequired);
   const setJobsUpgradeRequired = useAgentStore((s) => s.setJobsUpgradeRequired);
+  const setError = useAgentStore((s) => s.setError);
   const updateSessionModel = useSessionStore((s) => s.updateSessionModel);
   const [awaitingTopUp, setAwaitingTopUp] = useState(false);
   const lastSentRef = useRef<string>('');
@@ -240,8 +254,13 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
       if (res.ok) {
         setSelectedModelId(model.id);
         updateSessionModel(sessionId, model.modelPath);
+        setError(null);
+        return;
       }
-    } catch { /* ignore */ }
+      setError(await readApiErrorMessage(res, 'Could not switch model.'));
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Could not switch model.');
+    }
   };
 
   // Dialog close: just clear the flag. The typed text is already restored.

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -1,5 +1,18 @@
 import { useState, useCallback, useEffect, useRef, KeyboardEvent } from 'react';
-import { Box, TextField, IconButton, CircularProgress, Typography, Menu, MenuItem, ListItemIcon, ListItemText, Chip } from '@mui/material';
+import {
+  Alert,
+  Box,
+  TextField,
+  IconButton,
+  CircularProgress,
+  Typography,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Chip,
+  Snackbar,
+} from '@mui/material';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import StopIcon from '@mui/icons-material/Stop';
@@ -134,9 +147,9 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
   const setClaudeQuotaExhausted = useAgentStore((s) => s.setClaudeQuotaExhausted);
   const jobsUpgradeRequired = useAgentStore((s) => s.jobsUpgradeRequired);
   const setJobsUpgradeRequired = useAgentStore((s) => s.setJobsUpgradeRequired);
-  const setError = useAgentStore((s) => s.setError);
   const updateSessionModel = useSessionStore((s) => s.updateSessionModel);
   const [awaitingTopUp, setAwaitingTopUp] = useState(false);
+  const [modelSwitchError, setModelSwitchError] = useState<string | null>(null);
   const lastSentRef = useRef<string>('');
 
   useEffect(() => {
@@ -254,12 +267,12 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
       if (res.ok) {
         setSelectedModelId(model.id);
         updateSessionModel(sessionId, model.modelPath);
-        setError(null);
+        setModelSwitchError(null);
         return;
       }
-      setError(await readApiErrorMessage(res, 'Could not switch model.'));
+      setModelSwitchError(await readApiErrorMessage(res, 'Could not switch model.'));
     } catch (error) {
-      setError(error instanceof Error ? error.message : 'Could not switch model.');
+      setModelSwitchError(error instanceof Error ? error.message : 'Could not switch model.');
     }
   };
 
@@ -594,6 +607,21 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
           onUpgrade={handleJobsUpgradeClick}
           onRetry={handleJobsRetry}
         />
+        <Snackbar
+          open={!!modelSwitchError}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          onClose={() => setModelSwitchError(null)}
+          autoHideDuration={6000}
+        >
+          <Alert
+            severity="error"
+            variant="filled"
+            onClose={() => setModelSwitchError(null)}
+            sx={{ fontSize: '0.8rem', maxWidth: 480 }}
+          >
+            {modelSwitchError}
+          </Alert>
+        </Snackbar>
       </Box>
     </Box>
   );

--- a/frontend/src/components/ClaudeCapDialog.tsx
+++ b/frontend/src/components/ClaudeCapDialog.tsx
@@ -30,9 +30,7 @@ export default function ClaudeCapDialog({
   onUseFreeModel,
   onUpgrade,
 }: ClaudeCapDialogProps) {
-  // plan not surfaced in copy right now — Pro users see the same dialog and
-  // can upgrade their org if they're also capped.
-  void plan;
+  const isFreePlan = plan === 'free';
 
   return (
     <Dialog
@@ -62,62 +60,68 @@ export default function ClaudeCapDialog({
           sx={{ color: 'var(--muted-text)', fontSize: '0.85rem', lineHeight: 1.6 }}
         >
           Opus and GPT-5.5 are expensive to run, so we cap premium models at {cap}{' '}
-          {cap === 1 ? 'session' : 'sessions'} a day. Give Kimi, MiniMax, GLM,
-          or DeepSeek a spin instead.
+          {cap === 1 ? 'session' : 'sessions'} a day. {isFreePlan
+            ? 'HF Pro raises the daily premium-model limit.'
+            : 'Your plan has used today’s premium-model allowance.'}{' '}
+          Give Kimi, MiniMax, GLM, or DeepSeek a spin instead.
         </DialogContentText>
-        <Box
-          sx={{
-            mt: 2,
-            p: 1.5,
-            borderRadius: '8px',
-            bgcolor: 'var(--accent-yellow-weak)',
-            border: '1px solid var(--border)',
-          }}
-        >
-          <Typography
-            variant="caption"
+        {isFreePlan && (
+          <Box
             sx={{
-              display: 'block',
-              fontWeight: 700,
-              color: 'var(--text)',
-              fontSize: '0.78rem',
-              mb: 0.5,
-              letterSpacing: '0.02em',
+              mt: 2,
+              p: 1.5,
+              borderRadius: '8px',
+              bgcolor: 'var(--accent-yellow-weak)',
+              border: '1px solid var(--border)',
             }}
           >
-            HF Pro ($9/mo) — more premium model sessions
-          </Typography>
-          <Typography
-            variant="caption"
-            sx={{ display: 'block', color: 'var(--muted-text)', fontSize: '0.78rem', lineHeight: 1.55 }}
-          >
-            {PRO_CAP} premium model sessions/day here, 20× HF Inference credits,
-            ZeroGPU access, and priority on Spaces hardware.
-          </Typography>
-        </Box>
+            <Typography
+              variant="caption"
+              sx={{
+                display: 'block',
+                fontWeight: 700,
+                color: 'var(--text)',
+                fontSize: '0.78rem',
+                mb: 0.5,
+                letterSpacing: '0.02em',
+              }}
+            >
+              HF Pro ($9/mo) — more premium model sessions
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{ display: 'block', color: 'var(--muted-text)', fontSize: '0.78rem', lineHeight: 1.55 }}
+            >
+              {PRO_CAP} premium model sessions/day here, 20× HF Inference credits,
+              ZeroGPU access, and priority on Spaces hardware.
+            </Typography>
+          </Box>
+        )}
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2.5, pt: 2, gap: 1 }}>
-        <Button
-          component="a"
-          href={HF_PRICING_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={onUpgrade}
-          variant="contained"
-          size="small"
-          sx={{
-            fontSize: '0.82rem',
-            px: 2.5,
-            bgcolor: 'var(--accent-yellow)',
-            color: '#000',
-            textTransform: 'none',
-            fontWeight: 700,
-            boxShadow: 'none',
-            '&:hover': { bgcolor: '#FFB340', boxShadow: 'none' },
-          }}
-        >
-          Upgrade to Pro
-        </Button>
+        {isFreePlan && (
+          <Button
+            component="a"
+            href={HF_PRICING_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onUpgrade}
+            variant="contained"
+            size="small"
+            sx={{
+              fontSize: '0.82rem',
+              px: 2.5,
+              bgcolor: 'var(--accent-yellow)',
+              color: '#000',
+              textTransform: 'none',
+              fontWeight: 700,
+              boxShadow: 'none',
+              '&:hover': { bgcolor: '#FFB340', boxShadow: 'none' },
+            }}
+          >
+            Upgrade to Pro
+          </Button>
+        )}
         <Button
           onClick={onUseFreeModel}
           size="small"

--- a/frontend/src/components/JobsUpgradeDialog.tsx
+++ b/frontend/src/components/JobsUpgradeDialog.tsx
@@ -148,7 +148,7 @@ export default function JobsUpgradeDialog({
           {awaitingTopUp
             ? 'Once your top-up is through, click below to resume — the agent will pick the run back up where it left off.'
             : message ||
-              'Hugging Face Jobs need credits on the namespace running them. Add some, then resume — the agent waits here in the meantime.'}
+              'Hugging Face Jobs need credits on the namespace running them. Job credits are separate from HF Pro membership. Add some, then resume.'}
         </Typography>
 
         <Box

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -31,7 +31,7 @@ const DRAWER_WIDTH = 260;
 
 export default function AppLayout() {
   const { sessions, activeSessionId, markExpired } = useSessionStore();
-  const { isConnected, llmHealthError, setLlmHealthError, user } = useAgentStore();
+  const { isConnected, error, setError, llmHealthError, setLlmHealthError, user } = useAgentStore();
   const {
     isLeftSidebarOpen,
     isRightPanelOpen,
@@ -466,6 +466,21 @@ export default function AppLayout() {
               {llmHealthError.model} — {llmHealthError.error.slice(0, 150)}
             </Typography>
           )}
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={!!error}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        onClose={() => setError(null)}
+        autoHideDuration={6000}
+      >
+        <Alert
+          severity="error"
+          variant="filled"
+          onClose={() => setError(null)}
+          sx={{ fontSize: '0.8rem', maxWidth: 480 }}
+        >
+          {error}
         </Alert>
       </Snackbar>
     </Box>

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -31,7 +31,7 @@ const DRAWER_WIDTH = 260;
 
 export default function AppLayout() {
   const { sessions, activeSessionId, markExpired } = useSessionStore();
-  const { isConnected, error, setError, llmHealthError, setLlmHealthError, user } = useAgentStore();
+  const { isConnected, llmHealthError, setLlmHealthError, user } = useAgentStore();
   const {
     isLeftSidebarOpen,
     isRightPanelOpen,
@@ -466,21 +466,6 @@ export default function AppLayout() {
               {llmHealthError.model} — {llmHealthError.error.slice(0, 150)}
             </Typography>
           )}
-        </Alert>
-      </Snackbar>
-      <Snackbar
-        open={!!error}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-        onClose={() => setError(null)}
-        autoHideDuration={6000}
-      >
-        <Alert
-          severity="error"
-          variant="filled"
-          onClose={() => setError(null)}
-          sx={{ fontSize: '0.8rem', maxWidth: 480 }}
-        >
-          {error}
         </Alert>
       </Snackbar>
     </Box>

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -60,9 +60,6 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
       },
       onError: (error: string) => {
         updateSession(sessionId, { isProcessing: false });
-        if (isActiveRef.current) {
-          useAgentStore.getState().setError(error);
-        }
         callbacksRef.current.onError?.(error);
       },
       onProcessing: () => {
@@ -369,9 +366,6 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
         return;
       }
       logger.error('useChat error:', error);
-      if (isActiveRef.current) {
-        useAgentStore.getState().setError(error.message);
-      }
     },
   });
 

--- a/frontend/src/hooks/useUserQuota.ts
+++ b/frontend/src/hooks/useUserQuota.ts
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAgentStore } from '@/store/agentStore';
 import { apiFetch } from '@/utils/api';
 
-export type PlanTier = 'free' | 'pro' | 'org';
+export type PlanTier = 'free' | 'pro';
 
 export interface UserQuota {
   plan: PlanTier;

--- a/frontend/src/lib/sse-chat-transport.ts
+++ b/frontend/src/lib/sse-chat-transport.ts
@@ -294,8 +294,8 @@ function createEventToChunkStream(sideChannel: SideChannelCallbacks): TransformS
             useAgentStore.getState().setJobsUpgradeRequired({
               namespace: namespace || null,
               message: namespace
-                ? `Hugging Face Jobs need credits on the "${namespace}" namespace. Add some, then re-run the same job — the agent will pick it back up.`
-                : 'Hugging Face Jobs need credits on this namespace. Add some, then re-run the same job — the agent will pick it back up.',
+                ? `Hugging Face Jobs need credits on the "${namespace}" namespace. Job credits are separate from HF Pro membership; add credits, then re-run the same job.`
+                : 'Hugging Face Jobs need namespace credits, which are separate from HF Pro membership. Add credits, then re-run the same job.',
             });
           }
           break;

--- a/frontend/src/store/agentStore.ts
+++ b/frontend/src/store/agentStore.ts
@@ -6,7 +6,7 @@
  *  - Connection / processing flags
  *  - Panel state (right panel — single-artifact pattern)
  *  - Plan state
- *  - User info / error banners
+ *  - User info / health and quota banners
  *  - Edited scripts (for hf_jobs code editing)
  *
  * Per-session state:
@@ -117,7 +117,6 @@ interface AgentStore {
   isConnected: boolean;
   activityStatus: ActivityStatus;
   user: User | null;
-  error: string | null;
   llmHealthError: LLMHealthError | null;
   /** Set when a premium-model send hits the daily quota; ChatInput opens the cap dialog. */
   claudeQuotaExhausted: boolean;
@@ -173,7 +172,6 @@ interface AgentStore {
   setConnected: (isConnected: boolean) => void;
   setActivityStatus: (status: ActivityStatus) => void;
   setUser: (user: User | null) => void;
-  setError: (error: string | null) => void;
   setLlmHealthError: (error: LLMHealthError | null) => void;
   setClaudeQuotaExhausted: (exhausted: boolean) => void;
   setJobsUpgradeRequired: (state: JobsUpgradeState | null) => void;
@@ -295,7 +293,6 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
   isConnected: false,
   activityStatus: { type: 'idle' },
   user: null,
-  error: null,
   llmHealthError: null,
   claudeQuotaExhausted: false,
   jobsUpgradeRequired: null,
@@ -335,7 +332,7 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
     // (plus activityStatus when the processing→idle side-effect fires).
     // This prevents overwriting flat fields changed by global setters
     // (e.g. setPanelView called from CodePanel) with stale snapshot values.
-    let flatMirror: Record<string, unknown> = {};
+    const flatMirror: Record<string, unknown> = {};
     if (isActive) {
       for (const key of Object.keys(updates)) {
         flatMirror[key] = updated[key as keyof PerSessionState];
@@ -388,14 +385,13 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
       panelView: incoming.panelView,
       panelEditable: incoming.panelEditable,
       plan: incoming.plan,
-      // Clear transient error on switch
-      error: null,
     });
   },
 
   clearSessionState: (sessionId) => {
     set((state) => {
-      const { [sessionId]: _, ...rest } = state.sessionStates;
+      const rest = { ...state.sessionStates };
+      delete rest[sessionId];
       return { sessionStates: rest };
     });
   },
@@ -410,7 +406,6 @@ export const useAgentStore = create<AgentStore>()((set, get) => ({
   setConnected: (isConnected) => set({ isConnected }),
   setActivityStatus: (status) => set({ activityStatus: status }),
   setUser: (user) => set({ user }),
-  setError: (error) => set({ error }),
   setLlmHealthError: (error) => set({ llmHealthError: error }),
   setClaudeQuotaExhausted: (exhausted) => set({ claudeQuotaExhausted: exhausted }),
   setJobsUpgradeRequired: (state) => set({ jobsUpgradeRequired: state }),

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -1,4 +1,4 @@
-"""Tests for gated model handling in backend/routes/agent.py."""
+"""Tests for premium model handling in backend/routes/agent.py."""
 
 import asyncio
 import sys
@@ -22,43 +22,15 @@ def _reset_quota_store():
     agent.user_quotas._reset_for_tests()
 
 
-def test_gated_model_predicate_includes_bedrock_claude_and_gpt55_only():
-    assert agent._is_gated_model("bedrock/us.anthropic.claude-opus-4-6-v1")
-    assert agent._is_gated_model("openai/gpt-5.5")
-    assert not agent._is_gated_model("anthropic/claude-opus-4-6")
-    assert not agent._is_gated_model("moonshotai/Kimi-K2.6")
+def test_premium_model_predicate_includes_bedrock_claude_and_gpt55_only():
+    assert agent._is_premium_model("bedrock/us.anthropic.claude-opus-4-6-v1")
+    assert agent._is_premium_model("openai/gpt-5.5")
+    assert not agent._is_premium_model("anthropic/claude-opus-4-6")
+    assert not agent._is_premium_model("moonshotai/Kimi-K2.6")
 
 
 @pytest.mark.asyncio
-async def test_gated_model_gate_rejects_gpt55_for_non_hf_user(monkeypatch):
-    async def fake_require_hf_org_member(_request):
-        return False
-
-    monkeypatch.setattr(
-        agent,
-        "require_huggingface_org_member",
-        fake_require_hf_org_member,
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        await agent._require_hf_for_gated_model(None, "openai/gpt-5.5")
-
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail["error"] == "premium_model_restricted"
-
-
-@pytest.mark.asyncio
-async def test_default_gated_session_falls_back_to_free_model_for_non_hf_user(
-    monkeypatch,
-):
-    async def fake_require_hf_org_member(_request):
-        return False
-
-    monkeypatch.setattr(
-        agent,
-        "require_huggingface_org_member",
-        fake_require_hf_org_member,
-    )
+async def test_default_premium_session_falls_back_to_free_model(monkeypatch):
     monkeypatch.setattr(
         agent.session_manager.config,
         "model_name",
@@ -71,19 +43,11 @@ async def test_default_gated_session_falls_back_to_free_model_for_non_hf_user(
 
 
 @pytest.mark.asyncio
-async def test_default_gated_session_stays_default_for_hf_user(monkeypatch):
-    async def fake_require_hf_org_member(_request):
-        return True
-
-    monkeypatch.setattr(
-        agent,
-        "require_huggingface_org_member",
-        fake_require_hf_org_member,
-    )
+async def test_default_free_session_keeps_config_default(monkeypatch):
     monkeypatch.setattr(
         agent.session_manager.config,
         "model_name",
-        agent.DEFAULT_CLAUDE_MODEL_ID,
+        agent.DEFAULT_FREE_MODEL_ID,
     )
 
     model = await agent._model_override_for_new_session(None, None)
@@ -92,16 +56,7 @@ async def test_default_gated_session_stays_default_for_hf_user(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_explicit_gated_session_allowed_for_hf_user(monkeypatch):
-    async def fake_require_hf_org_member(_request):
-        return True
-
-    monkeypatch.setattr(
-        agent,
-        "require_huggingface_org_member",
-        fake_require_hf_org_member,
-    )
-
+async def test_explicit_premium_session_allowed_for_authenticated_user():
     model = await agent._model_override_for_new_session(
         None,
         agent.DEFAULT_CLAUDE_MODEL_ID,
@@ -111,34 +66,39 @@ async def test_explicit_gated_session_allowed_for_hf_user(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_explicit_gated_session_request_still_rejects_non_hf_user(monkeypatch):
-    async def fake_require_hf_org_member(_request):
-        return False
+async def test_switching_to_premium_model_is_allowed_for_authenticated_user(
+    monkeypatch,
+):
+    updated = []
 
+    async def fake_check_session_access(session_id, user, request=None):
+        assert session_id == "s1"
+        assert user["user_id"] == "u1"
+        return SimpleNamespace(user_id="u1")
+
+    async def fake_update_session_model(session_id, model_id):
+        updated.append((session_id, model_id))
+
+    monkeypatch.setattr(agent, "_check_session_access", fake_check_session_access)
     monkeypatch.setattr(
-        agent, "require_huggingface_org_member", fake_require_hf_org_member
+        agent.session_manager,
+        "update_session_model",
+        fake_update_session_model,
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await agent._model_override_for_new_session(None, agent.DEFAULT_CLAUDE_MODEL_ID)
+    response = await agent.set_session_model(
+        "s1",
+        {"model": "openai/gpt-5.5"},
+        request=None,
+        user={"user_id": "u1", "plan": "free"},
+    )
 
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail["error"] == "premium_model_restricted"
-
-
-@pytest.mark.asyncio
-async def test_ungated_models_skip_hf_membership_check(monkeypatch):
-    async def fail_if_called(_request):
-        raise AssertionError("ungated models must not require HF org membership")
-
-    monkeypatch.setattr(agent, "require_huggingface_org_member", fail_if_called)
-
-    await agent._require_hf_for_gated_model(None, "moonshotai/Kimi-K2.6")
-    await agent._require_hf_for_gated_model(None, "anthropic/claude-opus-4-6")
+    assert response == {"session_id": "s1", "model": "openai/gpt-5.5"}
+    assert updated == [("s1", "openai/gpt-5.5")]
 
 
 @pytest.mark.asyncio
-async def test_gated_quota_charges_gpt55(monkeypatch):
+async def test_premium_quota_charges_gpt55(monkeypatch):
     persisted = []
 
     async def fake_persist_session_snapshot(agent_session):
@@ -157,7 +117,7 @@ async def test_gated_quota_charges_gpt55(monkeypatch):
         ),
     )
 
-    await agent._enforce_gated_model_quota(
+    await agent._enforce_premium_model_quota(
         {"user_id": "u1", "plan": "free"},
         agent_session,
     )
@@ -168,9 +128,78 @@ async def test_gated_quota_charges_gpt55(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_gated_quota_skips_direct_anthropic(monkeypatch):
+async def test_free_user_premium_quota_rejects_second_session(monkeypatch):
+    async def fake_persist_session_snapshot(_agent_session):
+        return None
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "persist_session_snapshot",
+        fake_persist_session_snapshot,
+    )
+
+    first_session = SimpleNamespace(
+        claude_counted=False,
+        session=SimpleNamespace(
+            config=SimpleNamespace(model_name="openai/gpt-5.5"),
+        ),
+    )
+    second_session = SimpleNamespace(
+        claude_counted=False,
+        session=SimpleNamespace(
+            config=SimpleNamespace(model_name="openai/gpt-5.5"),
+        ),
+    )
+
+    await agent._enforce_premium_model_quota(
+        {"user_id": "free-user", "plan": "free"},
+        first_session,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await agent._enforce_premium_model_quota(
+            {"user_id": "free-user", "plan": "free"},
+            second_session,
+        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail["error"] == "premium_model_daily_cap"
+    assert exc_info.value.detail["plan"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_pro_and_org_users_use_pro_premium_quota(monkeypatch):
+    async def fake_persist_session_snapshot(_agent_session):
+        return None
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "persist_session_snapshot",
+        fake_persist_session_snapshot,
+    )
+
+    for plan in ("pro", "org"):
+        for index in range(2):
+            agent_session = SimpleNamespace(
+                claude_counted=False,
+                session=SimpleNamespace(
+                    config=SimpleNamespace(model_name="openai/gpt-5.5"),
+                ),
+            )
+            await agent._enforce_premium_model_quota(
+                {"user_id": f"{plan}-user", "plan": plan},
+                agent_session,
+            )
+            assert agent_session.claude_counted is True
+            assert (
+                await agent.user_quotas.get_claude_used_today(f"{plan}-user")
+                == index + 1
+            )
+
+
+@pytest.mark.asyncio
+async def test_premium_quota_skips_direct_anthropic(monkeypatch):
     async def fail_if_persisted(_agent_session):
-        raise AssertionError("direct Anthropic should not consume deployed gated quota")
+        raise AssertionError("direct Anthropic should not consume premium quota")
 
     monkeypatch.setattr(
         agent.session_manager,
@@ -185,7 +214,7 @@ async def test_gated_quota_skips_direct_anthropic(monkeypatch):
         ),
     )
 
-    await agent._enforce_gated_model_quota(
+    await agent._enforce_premium_model_quota(
         {"user_id": "u1", "plan": "free"},
         agent_session,
     )

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -167,7 +167,7 @@ async def test_free_user_premium_quota_rejects_second_session(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pro_and_org_users_use_pro_premium_quota(monkeypatch):
+async def test_pro_user_uses_pro_premium_quota(monkeypatch):
     async def fake_persist_session_snapshot(_agent_session):
         return None
 
@@ -177,23 +177,58 @@ async def test_pro_and_org_users_use_pro_premium_quota(monkeypatch):
         fake_persist_session_snapshot,
     )
 
-    for plan in ("pro", "org"):
-        for index in range(2):
-            agent_session = SimpleNamespace(
-                claude_counted=False,
-                session=SimpleNamespace(
-                    config=SimpleNamespace(model_name="openai/gpt-5.5"),
-                ),
-            )
-            await agent._enforce_premium_model_quota(
-                {"user_id": f"{plan}-user", "plan": plan},
-                agent_session,
-            )
-            assert agent_session.claude_counted is True
-            assert (
-                await agent.user_quotas.get_claude_used_today(f"{plan}-user")
-                == index + 1
-            )
+    for index in range(2):
+        agent_session = SimpleNamespace(
+            claude_counted=False,
+            session=SimpleNamespace(
+                config=SimpleNamespace(model_name="openai/gpt-5.5"),
+            ),
+        )
+        await agent._enforce_premium_model_quota(
+            {"user_id": "pro-user", "plan": "pro"},
+            agent_session,
+        )
+        assert agent_session.claude_counted is True
+        assert await agent.user_quotas.get_claude_used_today("pro-user") == index + 1
+
+
+@pytest.mark.asyncio
+async def test_org_plan_uses_free_premium_quota(monkeypatch):
+    async def fake_persist_session_snapshot(_agent_session):
+        return None
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "persist_session_snapshot",
+        fake_persist_session_snapshot,
+    )
+
+    first_session = SimpleNamespace(
+        claude_counted=False,
+        session=SimpleNamespace(
+            config=SimpleNamespace(model_name="openai/gpt-5.5"),
+        ),
+    )
+    second_session = SimpleNamespace(
+        claude_counted=False,
+        session=SimpleNamespace(
+            config=SimpleNamespace(model_name="openai/gpt-5.5"),
+        ),
+    )
+
+    await agent._enforce_premium_model_quota(
+        {"user_id": "org-user", "plan": "org"},
+        first_session,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await agent._enforce_premium_model_quota(
+            {"user_id": "org-user", "plan": "org"},
+            second_session,
+        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail["plan"] == "org"
+    assert "Upgrade to HF Pro" in exc_info.value.detail["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_plan_normalization.py
+++ b/tests/unit/test_plan_normalization.py
@@ -19,17 +19,7 @@ def test_oauth_is_pro_flag_takes_priority_over_user_type():
 @pytest.mark.parametrize(
     "payload",
     [
-        {"type": "user", "isPro": True},
-        {"type": "user", "is_pro": True},
-    ],
-)
-def test_pro_boolean_flags_get_pro_tier(payload):
-    assert dependencies._normalize_user_plan(payload) == "pro"
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [
+        {"is_pro": True},
         {"accountType": "pro"},
         {"plan": "HF Pro"},
         {"subscription": "hf_pro"},
@@ -38,7 +28,7 @@ def test_pro_boolean_flags_get_pro_tier(payload):
         {"tier": "promotional"},
     ],
 )
-def test_string_plan_values_stay_free(payload):
+def test_non_ispro_signals_stay_free(payload):
     assert dependencies._normalize_user_plan(payload) == "free"
 
 

--- a/tests/unit/test_plan_normalization.py
+++ b/tests/unit/test_plan_normalization.py
@@ -30,14 +30,14 @@ def test_free_user_with_free_org_stays_free():
     assert dependencies._normalize_user_plan(whoami) == "free"
 
 
-def test_user_with_paid_org_gets_org_tier():
+def test_user_with_paid_org_without_personal_pro_stays_free():
     whoami = {
         "name": "alice",
         "type": "user",
         "orgs": [{"name": "team-a", "plan": "team"}],
     }
 
-    assert dependencies._normalize_user_plan(whoami) == "org"
+    assert dependencies._normalize_user_plan(whoami) == "free"
 
 
 @pytest.mark.parametrize("payload", [None, [], {"type": "user"}, {"plan": "free"}])

--- a/tests/unit/test_plan_normalization.py
+++ b/tests/unit/test_plan_normalization.py
@@ -1,0 +1,45 @@
+"""Tests for Hugging Face plan normalization."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+import dependencies  # noqa: E402
+
+
+def test_oauth_is_pro_flag_takes_priority_over_user_type():
+    assert dependencies._normalize_user_plan({"type": "user", "isPro": True}) == "pro"
+
+
+def test_paid_personal_plan_gets_pro_tier():
+    assert dependencies._normalize_user_plan({"accountType": "pro"}) == "pro"
+
+
+def test_free_user_with_free_org_stays_free():
+    whoami = {
+        "name": "alice",
+        "type": "user",
+        "orgs": [{"name": "oss-friends", "plan": "free"}],
+    }
+
+    assert dependencies._normalize_user_plan(whoami) == "free"
+
+
+def test_user_with_paid_org_gets_org_tier():
+    whoami = {
+        "name": "alice",
+        "type": "user",
+        "orgs": [{"name": "team-a", "plan": "team"}],
+    }
+
+    assert dependencies._normalize_user_plan(whoami) == "org"
+
+
+@pytest.mark.parametrize("payload", [None, [], {"type": "user"}, {"plan": "free"}])
+def test_unknown_or_malformed_payload_defaults_to_free(payload):
+    assert dependencies._normalize_user_plan(payload) == "free"

--- a/tests/unit/test_plan_normalization.py
+++ b/tests/unit/test_plan_normalization.py
@@ -16,8 +16,28 @@ def test_oauth_is_pro_flag_takes_priority_over_user_type():
     assert dependencies._normalize_user_plan({"type": "user", "isPro": True}) == "pro"
 
 
-def test_paid_personal_plan_gets_pro_tier():
-    assert dependencies._normalize_user_plan({"accountType": "pro"}) == "pro"
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"accountType": "pro"},
+        {"plan": "HF Pro"},
+        {"subscription": "hf_pro"},
+    ],
+)
+def test_personal_pro_plan_gets_pro_tier(payload):
+    assert dependencies._normalize_user_plan(payload) == "pro"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"accountType": "team"},
+        {"plan": "enterprise"},
+        {"tier": "promotional"},
+    ],
+)
+def test_non_pro_plan_values_stay_free(payload):
+    assert dependencies._normalize_user_plan(payload) == "free"
 
 
 def test_free_user_with_free_org_stays_free():

--- a/tests/unit/test_plan_normalization.py
+++ b/tests/unit/test_plan_normalization.py
@@ -19,24 +19,26 @@ def test_oauth_is_pro_flag_takes_priority_over_user_type():
 @pytest.mark.parametrize(
     "payload",
     [
-        {"accountType": "pro"},
-        {"plan": "HF Pro"},
-        {"subscription": "hf_pro"},
+        {"type": "user", "isPro": True},
+        {"type": "user", "is_pro": True},
     ],
 )
-def test_personal_pro_plan_gets_pro_tier(payload):
+def test_pro_boolean_flags_get_pro_tier(payload):
     assert dependencies._normalize_user_plan(payload) == "pro"
 
 
 @pytest.mark.parametrize(
     "payload",
     [
+        {"accountType": "pro"},
+        {"plan": "HF Pro"},
+        {"subscription": "hf_pro"},
         {"accountType": "team"},
         {"plan": "enterprise"},
         {"tier": "promotional"},
     ],
 )
-def test_non_pro_plan_values_stay_free(payload):
+def test_string_plan_values_stay_free(payload):
     assert dependencies._normalize_user_plan(payload) == "free"
 
 

--- a/tests/unit/test_user_quotas.py
+++ b/tests/unit/test_user_quotas.py
@@ -27,7 +27,7 @@ def _reset_store():
 def test_daily_cap_for_known_plans():
     assert user_quotas.daily_cap_for("free") == user_quotas.CLAUDE_FREE_DAILY
     assert user_quotas.daily_cap_for("pro") == user_quotas.CLAUDE_PRO_DAILY
-    assert user_quotas.daily_cap_for("org") == user_quotas.CLAUDE_PRO_DAILY
+    assert user_quotas.daily_cap_for("org") == user_quotas.CLAUDE_FREE_DAILY
 
 
 def test_daily_cap_for_unknown_or_missing_defaults_to_free():

--- a/tests/unit/test_user_quotas.py
+++ b/tests/unit/test_user_quotas.py
@@ -33,10 +33,7 @@ def test_daily_cap_for_known_plans():
 def test_daily_cap_for_unknown_or_missing_defaults_to_free():
     assert user_quotas.daily_cap_for(None) == user_quotas.CLAUDE_FREE_DAILY
     assert user_quotas.daily_cap_for("") == user_quotas.CLAUDE_FREE_DAILY
-    # Anything we don't recognize as the Pro/Org tier gets the Pro cap because
-    # the function's contract is "free" is the only downgraded tier. If that
-    # ever flips, this test will flip too — adjust consciously.
-    assert user_quotas.daily_cap_for("mystery") == user_quotas.CLAUDE_PRO_DAILY
+    assert user_quotas.daily_cap_for("mystery") == user_quotas.CLAUDE_FREE_DAILY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Addresses the Pro entitlement item from https://github.com/huggingface/ml-intern/issues/223 and the user reports in:

- https://huggingface.co/spaces/smolagents/ml-intern/discussions/18
- https://huggingface.co/spaces/smolagents/ml-intern/discussions/25
- https://huggingface.co/spaces/smolagents/ml-intern/discussions/34

Changes:

- Normalize HF `whoami-v2` plan data into personal premium-model quota tiers.
- Detect personal HF Pro users only via the documented `isPro: true` boolean from `whoami-v2`.
- Ignore org membership, org billing state, team plans, enterprise plans, and string plan/account fields for premium-model quota; users need personal HF Pro for the higher premium-model cap.
- Default malformed, missing, or unknown plan data to `free`.
- Stop requiring membership in the `huggingface` org to select Claude Opus 4.6 or GPT-5.5; premium models are now controlled by the daily quota gate.
- Keep implicit sessions on the free fallback model when the backend default is premium, so users do not spend premium quota accidentally.
- Make unknown quota tiers use the free cap.
- Clarify HF Jobs billing copy: Jobs require namespace credits, which are separate from HF Pro membership.
- Surface model-switch API failures through a model-switch-only toast instead of silently ignoring them.
- Remove the now-unused global `agentStore.error` plumbing so transport errors are not written to dead state.

cc @jagwar for viz: this PR is needed to enable Pro users to be able to launch HF jobs by adding credits to their account. I'm pretty confident we're not regressing with abuse on the Bedrock endpoint, but let me know if you see something fishy

## Test Plan

- [x] `uv run --extra dev pytest tests/unit/test_agent_model_gating.py tests/unit/test_hf_access.py tests/unit/test_user_quotas.py tests/unit/test_plan_normalization.py`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npx eslint src/components/Chat/ChatInput.tsx src/components/ClaudeCapDialog.tsx src/components/JobsUpgradeDialog.tsx src/components/Layout/AppLayout.tsx src/lib/sse-chat-transport.ts`
- [x] `cd frontend && npx eslint src/hooks/useUserQuota.ts`

Note: full `cd frontend && npm run lint` still fails on pre-existing unrelated lint issues in untouched files (`ActivityStatusBar.tsx`, `agentStore.ts`, and `logger.ts`).
