### PR TITLE
Skip sandbox spaces for artifact metadata

### DIFF
--- a/agent/core/hub_artifacts.py
+++ b/agent/core/hub_artifacts.py
@@ -36,7 +36,6 @@ _USAGE_HEADING_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _FRONT_MATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n?", re.DOTALL)
-_SANDBOX_SPACE_NAME_RE = re.compile(r"^sandbox-[0-9a-f]{8}$")
 
 
 def _safe_session_id(session: Any) -> str:
@@ -80,12 +79,18 @@ def _artifact_key(repo_id: str, repo_type: str | None) -> str:
     return f"{repo_type or 'model'}:{repo_id}"
 
 
+def _sandbox_space_name_pattern() -> str:
+    from agent.tools.sandbox_tool import SANDBOX_SPACE_NAME_RE
+
+    return SANDBOX_SPACE_NAME_RE.pattern
+
+
 def is_sandbox_hub_repo(repo_id: str | None, repo_type: str | None) -> bool:
     """Return True for ML Intern's ephemeral sandbox Space repos."""
     if (repo_type or "model") != "space" or not repo_id:
         return False
     repo_name = str(repo_id).rsplit("/", 1)[-1]
-    return bool(_SANDBOX_SPACE_NAME_RE.fullmatch(repo_name))
+    return bool(re.fullmatch(_sandbox_space_name_pattern(), repo_name))
 
 
 def _session_artifact_set(session: Any, attr: str) -> set[str]:
@@ -476,7 +481,7 @@ def build_hub_artifact_sitecustomize(session: Any) -> str:
             tag = {ML_INTERN_TAG!r}
             marker = {PROVENANCE_MARKER!r}
             supported = {sorted(SUPPORTED_REPO_TYPES)!r}
-            sandbox_space_re = re.compile({_SANDBOX_SPACE_NAME_RE.pattern!r})
+            sandbox_space_re = re.compile({_sandbox_space_name_pattern()!r})
             registering = False
             collection_slug = {collection_slug!r}
             registered = set()

--- a/agent/core/hub_artifacts.py
+++ b/agent/core/hub_artifacts.py
@@ -36,6 +36,7 @@ _USAGE_HEADING_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _FRONT_MATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n?", re.DOTALL)
+_SANDBOX_SPACE_NAME_RE = re.compile(r"^sandbox-[0-9a-f]{8}$")
 
 
 def _safe_session_id(session: Any) -> str:
@@ -77,6 +78,14 @@ def artifact_collection_title(session: Any) -> str:
 
 def _artifact_key(repo_id: str, repo_type: str | None) -> str:
     return f"{repo_type or 'model'}:{repo_id}"
+
+
+def is_sandbox_hub_repo(repo_id: str | None, repo_type: str | None) -> bool:
+    """Return True for ML Intern's ephemeral sandbox Space repos."""
+    if (repo_type or "model") != "space" or not repo_id:
+        return False
+    repo_name = str(repo_id).rsplit("/", 1)[-1]
+    return bool(_SANDBOX_SPACE_NAME_RE.fullmatch(repo_name))
 
 
 def _session_artifact_set(session: Any, attr: str) -> set[str]:
@@ -397,6 +406,8 @@ def register_hub_artifact(
     repo_type = repo_type or "model"
     if repo_type not in SUPPORTED_REPO_TYPES:
         return False
+    if is_sandbox_hub_repo(repo_id, repo_type):
+        return False
 
     key = _artifact_key(repo_id, repo_type)
     remember_hub_artifact(session, repo_id, repo_type)
@@ -465,6 +476,7 @@ def build_hub_artifact_sitecustomize(session: Any) -> str:
             tag = {ML_INTERN_TAG!r}
             marker = {PROVENANCE_MARKER!r}
             supported = {sorted(SUPPORTED_REPO_TYPES)!r}
+            sandbox_space_re = re.compile({_SANDBOX_SPACE_NAME_RE.pattern!r})
             registering = False
             collection_slug = {collection_slug!r}
             registered = set()
@@ -611,6 +623,8 @@ def build_hub_artifact_sitecustomize(session: Any) -> str:
                 repo_type = repo_type or "model"
                 if repo_type not in supported:
                     return
+                if _is_sandbox_repo(repo_id, repo_type):
+                    return
                 key = f"{{repo_type}}:{{repo_id}}"
                 if key in registered and not force:
                     return
@@ -665,6 +679,12 @@ def build_hub_artifact_sitecustomize(session: Any) -> str:
 
             def _repo_type(kwargs):
                 return kwargs.get("repo_type") or "model"
+
+            def _is_sandbox_repo(repo_id, repo_type):
+                if (repo_type or "model") != "space" or not repo_id:
+                    return False
+                repo_name = str(repo_id).rsplit("/", 1)[-1]
+                return bool(sandbox_space_re.fullmatch(repo_name))
 
             def _patched_create_repo(self, *args, **kwargs):
                 result = _original_create_repo(self, *args, **kwargs)

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -374,18 +374,6 @@ async def _create_sandbox_locked(
         create_latency_s=int(_t.monotonic() - _t_start),
     )
 
-    # Set a descriptive title (template title is inherited on duplicate)
-    from huggingface_hub import metadata_update
-
-    await asyncio.to_thread(
-        metadata_update,
-        sb.space_id,
-        {"title": "ml-intern sandbox"},
-        repo_type="space",
-        overwrite=True,
-        token=token,
-    )
-
     await session.send_event(
         Event(
             event_type="tool_log",

--- a/agent/tools/sandbox_tool.py
+++ b/agent/tools/sandbox_tool.py
@@ -33,7 +33,7 @@ DEFAULT_CPU_SANDBOX_HARDWARE = "cpu-basic"
 # Match the exact suffix pattern Sandbox.create produces: "sandbox-<8 hex>".
 # Used to identify orphan sandboxes from prior sessions safely (won't match
 # user-renamed lookalikes).
-_SANDBOX_NAME_RE = re.compile(r"^sandbox-[a-f0-9]{8}$")
+SANDBOX_SPACE_NAME_RE = re.compile(r"^sandbox-[a-f0-9]{8}$")
 
 # How stale a sandbox must be before we treat it as definitely orphan.
 # Anything more recent could be tied to a still-live session in another tab,
@@ -195,7 +195,7 @@ def _cleanup_user_orphan_sandboxes(
 
     for space in spaces:
         space_name = space.id.rsplit("/", 1)[-1]
-        if not _SANDBOX_NAME_RE.match(space_name):
+        if not SANDBOX_SPACE_NAME_RE.match(space_name):
             continue
 
         last_mod = getattr(space, "lastModified", None) or getattr(

--- a/tests/unit/test_hub_artifacts.py
+++ b/tests/unit/test_hub_artifacts.py
@@ -13,6 +13,7 @@ from agent.core.hub_artifacts import (
     build_hub_artifact_sitecustomize,
     ensure_session_artifact_collection,
     is_known_hub_artifact,
+    is_sandbox_hub_repo,
     register_hub_artifact,
     remember_hub_artifact,
     start_session_artifact_collection_task,
@@ -160,6 +161,35 @@ def test_register_hub_artifact_creates_private_collection_and_adds_item_once(
     assert api.collection_items[0]["exists_ok"] is True
     assert len(api.uploads) == 1
     assert b"ml-intern" in api.uploads[0]["path_or_fileobj"]
+
+
+def test_register_hub_artifact_skips_sandbox_spaces(monkeypatch):
+    session = _session()
+    api = SimpleNamespace(token="hf-token")
+    calls = []
+
+    monkeypatch.setattr(
+        hub_artifacts,
+        "_update_repo_card",
+        lambda *args, **kwargs: calls.append(("card", args, kwargs)),
+    )
+    monkeypatch.setattr(
+        hub_artifacts,
+        "_add_to_collection",
+        lambda *args, **kwargs: calls.append(("collection", args, kwargs)),
+    )
+
+    assert is_sandbox_hub_repo("alice/sandbox-1234abcd", "space")
+    assert not is_sandbox_hub_repo("alice/sandbox-1234abcd", "model")
+    assert not is_sandbox_hub_repo("alice/demo-space", "space")
+    assert not register_hub_artifact(
+        api,
+        "alice/sandbox-1234abcd",
+        "space",
+        session=session,
+    )
+    assert not is_known_hub_artifact(session, "alice/sandbox-1234abcd", "space")
+    assert calls == []
 
 
 def test_register_hub_artifact_retries_after_partial_failure(monkeypatch):
@@ -503,3 +533,55 @@ def test_sitecustomize_bootstrap_reuses_existing_collection_slug():
     assert (
         "collection_slug = 'alice/ml-intern-artifacts-2026-05-05-session-123'" in code
     )
+
+
+def test_sitecustomize_skips_sandbox_space_registration(monkeypatch):
+    import huggingface_hub as hub
+    from huggingface_hub import HfApi
+
+    uploads = []
+    downloads = []
+    collection_creates = []
+    collection_items = []
+
+    for name in ("create_repo", "upload_folder", "create_commit"):
+        if hasattr(HfApi, name):
+            monkeypatch.setattr(HfApi, name, getattr(HfApi, name))
+        if hasattr(hub, name):
+            monkeypatch.setattr(hub, name, getattr(hub, name))
+
+    def fake_upload_file(self, **kwargs):
+        uploads.append(kwargs)
+        return SimpleNamespace()
+
+    def fake_hf_hub_download(*args, **kwargs):
+        downloads.append((args, kwargs))
+        raise RuntimeError("sandbox metadata update should be skipped")
+
+    def fake_create_collection(self, **kwargs):
+        collection_creates.append(kwargs)
+        return SimpleNamespace(slug="alice/ml-intern-artifacts")
+
+    def fake_add_collection_item(self, **kwargs):
+        collection_items.append(kwargs)
+
+    monkeypatch.setattr(HfApi, "upload_file", fake_upload_file)
+    monkeypatch.setattr(HfApi, "create_collection", fake_create_collection)
+    monkeypatch.setattr(HfApi, "add_collection_item", fake_add_collection_item)
+    monkeypatch.setattr(hub, "upload_file", getattr(hub, "upload_file"))
+    monkeypatch.setattr(hub, "hf_hub_download", fake_hf_hub_download)
+
+    exec(build_hub_artifact_sitecustomize(_session()), {})
+
+    HfApi(token="hf-token").upload_file(
+        path_or_fileobj=b"app",
+        path_in_repo="app.py",
+        repo_id="alice/sandbox-1234abcd",
+        repo_type="space",
+        token="hf-token",
+    )
+
+    assert [upload["repo_id"] for upload in uploads] == ["alice/sandbox-1234abcd"]
+    assert downloads == []
+    assert collection_creates == []
+    assert collection_items == []

--- a/tests/unit/test_hub_artifacts.py
+++ b/tests/unit/test_hub_artifacts.py
@@ -572,6 +572,24 @@ def test_sitecustomize_skips_sandbox_space_registration(monkeypatch):
     monkeypatch.setattr(hub, "hf_hub_download", fake_hf_hub_download)
 
     exec(build_hub_artifact_sitecustomize(_session()), {})
+    assert HfApi.upload_file is not fake_upload_file
+
+    HfApi(token="hf-token").upload_file(
+        path_or_fileobj=b"app",
+        path_in_repo="app.py",
+        repo_id="alice/normal-space",
+        repo_type="space",
+        token="hf-token",
+    )
+
+    assert downloads[0][1]["repo_id"] == "alice/normal-space"
+    assert len(collection_creates) == 1
+    assert collection_items[0]["item_id"] == "alice/normal-space"
+
+    uploads.clear()
+    downloads.clear()
+    collection_creates.clear()
+    collection_items.clear()
 
     HfApi(token="hf-token").upload_file(
         path_or_fileobj=b"app",

--- a/tests/unit/test_sandbox_private_spaces.py
+++ b/tests/unit/test_sandbox_private_spaces.py
@@ -11,6 +11,10 @@ from agent.tools.sandbox_client import Sandbox
 from agent.tools.sandbox_tool import sandbox_create_handler
 
 
+def _fail_metadata_update(*args, **kwargs):
+    raise AssertionError("sandbox creation should not update Space metadata")
+
+
 def test_sandbox_client_defaults_to_private_spaces(monkeypatch):
     duplicate_kwargs = {}
     requested_hardware = []
@@ -295,7 +299,7 @@ def test_ensure_sandbox_overrides_private_argument(monkeypatch):
     monkeypatch.setattr(sandbox_tool, "_cleanup_user_orphan_sandboxes", lambda *args: 0)
     monkeypatch.setattr(Sandbox, "create", staticmethod(fake_create))
     monkeypatch.setattr(telemetry, "record_sandbox_create", fake_record_sandbox_create)
-    monkeypatch.setattr("huggingface_hub.metadata_update", lambda *args, **kwargs: None)
+    monkeypatch.setattr("huggingface_hub.metadata_update", _fail_metadata_update)
 
     async def run():
         session = FakeSession()
@@ -356,7 +360,7 @@ def test_sandbox_creation_is_serialized_per_owner(monkeypatch):
     monkeypatch.setattr(sandbox_tool, "_cleanup_user_orphan_sandboxes", lambda *args: 0)
     monkeypatch.setattr(Sandbox, "create", staticmethod(fake_create))
     monkeypatch.setattr(telemetry, "record_sandbox_create", fake_record_sandbox_create)
-    monkeypatch.setattr("huggingface_hub.metadata_update", lambda *args, **kwargs: None)
+    monkeypatch.setattr("huggingface_hub.metadata_update", _fail_metadata_update)
 
     async def run():
         await asyncio.gather(


### PR DESCRIPTION
## Summary

- Skip ML Intern sandbox Spaces (`sandbox-<8 hex>`) before artifact registration attempts any repo-card upload or collection update.
- Apply the same guard inside the generated `sitecustomize` hook used by sandbox and HF Jobs Python processes.
- Add regression coverage for both the direct registration path and generated hook path.

## Why

Adding the `ml-intern` tag updates a Space README, which restarts the Space. Sandbox Spaces are ephemeral execution environments, so tagging them can interrupt the running sandbox. These repos should not be treated as generated user-facing artifacts.

## Testing

- `uv run --extra dev pytest tests/unit/test_hub_artifacts.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
