### PR TITLE
Fix onboarding Start button hidden by CSS overflow on small screens

### DIFF
--- a/frontend/src/components/WelcomeScreen/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen/WelcomeScreen.tsx
@@ -307,7 +307,7 @@ export default function WelcomeScreen() {
             bgcolor: 'var(--surface)',
             border: '1px solid var(--border)',
             borderRadius: '12px',
-            overflow: 'hidden',
+            overflowY: 'auto',
             mx: 2,
           }}
         >


### PR DESCRIPTION
Fixes the onboarding checklist container clipping the Start button on 1366×768 viewports.

  `overflow: hidden` on the checklist `Box` prevented scrolling, so users on smaller screens could not reach the Start
  button without opening DevTools.

  **Change:** `overflow: 'hidden'` → `overflowY: 'auto'` in `WelcomeScreen.tsx`

  Fixes: smolagents/ml-intern/discussions/19