### PR TITLE
Security: Default API key in local model configuration

### DIFF
--- a/agent/core/local_models.py
+++ b/agent/core/local_models.py
@@ -27,7 +27,7 @@ LOCAL_MODEL_PREFIXES = tuple(LOCAL_MODEL_PROVIDERS)
 RESERVED_LOCAL_MODEL_PREFIXES = ("openai-compat/",)
 LOCAL_MODEL_BASE_URL_ENV = "LOCAL_LLM_BASE_URL"
 LOCAL_MODEL_API_KEY_ENV = "LOCAL_LLM_API_KEY"
-LOCAL_MODEL_API_KEY_DEFAULT = "sk-local-no-key-required"
+LOCAL_MODEL_API_KEY_DEFAULT = None
 
 
 def local_model_provider(model_id: str) -> dict[str, str] | None:


### PR DESCRIPTION
## Problem

In agent/core/local_models.py, the default API key is set to 'sk-local-no-key-required' which provides a non-empty fallback rather than requiring explicit configuration. This could lead to unintended connections to local LLM servers without proper authentication.

**Severity**: `medium`
**File**: `agent/core/local_models.py`

## Solution

Consider using None as default and requiring explicit configuration, or at minimum document this behavior clearly and ensure it's only used in development contexts.

## Changes

- `agent/core/local_models.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
