### PR TITLE
Security: Environment variable token fallback in request resolution

### DIFF
--- a/agent/core/hf_tokens.py
+++ b/agent/core/hf_tokens.py
@@ -66,7 +66,7 @@ def bearer_token_from_header(auth_header: str | None) -> str | None:
 def resolve_hf_request_token(
     request: Any,
     *,
-    include_env_fallback: bool = True,
+    include_env_fallback: bool = False,
 ) -> str | None:
     """Resolve a user token from a FastAPI request.
 


### PR DESCRIPTION
## Problem

In agent/core/hf_tokens.py, the resolve_hf_request_token function has include_env_fallback=True by default. This means server-side HF_TOKEN environment variable can be used as a fallback when no user token is provided. If HF_TOKEN is set to a production token, it could be inadvertently used in contexts where only user tokens should apply.

**Severity**: `medium`
**File**: `agent/core/hf_tokens.py`

## Solution

Review the include_env_fallback usage and ensure production deployments don't have HF_TOKEN set when user-specific tokens are required. Consider making this opt-in rather than default behavior.

## Changes

- `agent/core/hf_tokens.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
