### PR TITLE
Reclaim idle sessions to fix session-capacity overshoot

### DIFF
--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -233,8 +233,11 @@ class MongoSessionStore(NoopSessionStore):
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
         auto_approval_estimated_spend_usd: float = 0.0,
+        raise_on_error: bool = False,
     ) -> None:
         if not self._ready():
+            if raise_on_error:
+                raise RuntimeError("session store not ready")
             return
         now = _now()
         await self.upsert_session(
@@ -278,6 +281,11 @@ class MongoSessionStore(NoopSessionStore):
             if ops:
                 await self.db.session_messages.bulk_write(ops, ordered=False)
         except PyMongoError as e:
+            # Best-effort by default, but the reaper passes raise_on_error so a
+            # silent message-write failure doesn't let it evict a session whose
+            # latest messages never made it to Mongo.
+            if raise_on_error:
+                raise
             logger.warning("Failed to persist session %s snapshot: %s", session_id, e)
 
     async def load_session(

--- a/agent/prompts/system_prompt_v3.yaml
+++ b/agent/prompts/system_prompt_v3.yaml
@@ -136,6 +136,8 @@ system_prompt: |
 
   Do NOT call sandbox_create before normal CPU work. Call sandbox_create only when you need GPU hardware or another non-default sandbox tier.
 
+  The sandbox filesystem does not survive session resumption. If a session is resumed, any files, installed packages, or running processes from earlier are gone — recreate what you need before relying on the sandbox.
+
   Use a GPU sandbox (t4-small minimum) when testing code that uses CUDA, bf16/fp16, quantization, flash attention, torch.compile, or model loading. CPU sandboxes cannot test GPU code paths. If the available sandbox tiers cannot fit the full model path, test the largest useful smoke path, state what was not covered, and submit one HF job first.
 
 

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -659,6 +659,7 @@ async def upload_session_dataset(
         agent_session.session.context_manager.add_message(
             Message(role="user", content=dataset_context_note(uploaded))
         )
+        session_manager._touch(agent_session)
         await session_manager.persist_session_snapshot(agent_session)
         logger.info(
             "Uploaded dataset file %s to %s for session %s",

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -6,7 +6,7 @@ import logging
 import os
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -96,8 +96,15 @@ class AgentSession:
     hf_token: str | None = None  # User's HF OAuth token for tool execution
     task: asyncio.Task | None = None
     created_at: datetime = field(default_factory=datetime.utcnow)
+    # Last genuine activity (submit/turn-start/turn-finish/direct user write).
+    # Drives the idle reaper. Defaults to load time so a freshly-restored but
+    # untouched session isn't reaped for a full idle window.
+    last_active_at: datetime = field(default_factory=datetime.utcnow)
     is_active: bool = True
     is_processing: bool = False  # True while a submission is being executed
+    # Set under the lock by the reaper while tearing this session down. Blocks
+    # submit() from enqueueing onto a session that's being evicted.
+    is_reaping: bool = False
     broadcaster: Any = None
     title: str | None = None
     # True once this session has been counted against the user's daily
@@ -125,6 +132,16 @@ DEFAULT_YOLO_COST_CAP_USD: float = 5.0
 SANDBOX_SHUTDOWN_CLEANUP_CONCURRENCY: int = 10
 SANDBOX_SHUTDOWN_CLEANUP_TIMEOUT_S: float = 60.0
 
+# ── Idle-session reaper ─────────────────────────────────────────────
+# A live session idle ≥ REAPER_IDLE_HOURS with no in-flight work has its
+# sandbox + RAM released and is evicted from the live pool, while staying
+# fully resumable from Mongo (it reappears as a normal chat, never "ended").
+# This frees both the global pool and the user's concurrent slots.
+REAPER_IDLE_HOURS: float = float(os.environ.get("REAPER_IDLE_HOURS", "2"))
+REAPER_INTERVAL_S: float = float(os.environ.get("REAPER_INTERVAL_S", "300"))
+REAP_TEARDOWN_TIMEOUT_S: float = float(os.environ.get("REAP_TEARDOWN_TIMEOUT_S", "30"))
+REAPER_IDLE = timedelta(hours=REAPER_IDLE_HOURS)
+
 
 class SessionManager:
     """Manages multiple concurrent agent sessions."""
@@ -135,15 +152,29 @@ class SessionManager:
         self.sessions: dict[str, AgentSession] = {}
         self._lock = asyncio.Lock()
         self.persistence_store = None
+        # In-flight create_session calls that have passed the capacity check
+        # but not yet inserted their session. Counted alongside
+        # active_session_count to hard-cap the global pool against the
+        # check-then-create race (see create_session).
+        self._pending_creates: int = 0
+        self._reaper_task: asyncio.Task | None = None
 
     async def start(self) -> None:
         """Start shared background resources."""
         self.persistence_store = get_session_store()
         await self.persistence_store.init()
         await self.messaging_gateway.start()
+        self._reaper_task = asyncio.create_task(self._reaper_loop())
 
     async def close(self) -> None:
         """Flush and close shared background resources."""
+        if self._reaper_task is not None:
+            self._reaper_task.cancel()
+            try:
+                await self._reaper_task
+            except asyncio.CancelledError:
+                pass
+            self._reaper_task = None
         await self._cleanup_all_sandboxes_on_close()
         await self.messaging_gateway.close()
         if self.persistence_store is not None:
@@ -159,6 +190,16 @@ class SessionManager:
         return sum(
             1 for s in self.sessions.values() if s.user_id == user_id and s.is_active
         )
+
+    @staticmethod
+    def _touch(agent_session: "AgentSession") -> None:
+        """Stamp genuine activity so the idle reaper's clock resets.
+
+        Call on real user/agent activity (submit, turn start/finish, direct
+        user-initiated writes) — never on passive reads or hydration, which
+        would keep an otherwise-idle session alive forever.
+        """
+        agent_session.last_active_at = datetime.utcnow()
 
     def _create_session_sync(
         self,
@@ -500,10 +541,20 @@ class SessionManager:
         *,
         runtime_state: str | None = None,
         status: str = "active",
+        raise_on_error: bool = False,
     ) -> None:
-        """Persist the current runtime context snapshot."""
+        """Persist the current runtime context snapshot.
+
+        Best-effort by default: a disabled store is a no-op and write failures
+        are swallowed. Pass ``raise_on_error=True`` when the caller must know
+        the snapshot was durably written (e.g. the reaper, which only evicts a
+        session after confirming it stayed resumable) — then a disabled store
+        or a write failure raises instead of silently dropping the snapshot.
+        """
         store = self._store()
         if not getattr(store, "enabled", False):
+            if raise_on_error:
+                raise RuntimeError("persistence store is disabled")
             return
         try:
             await store.save_snapshot(
@@ -537,8 +588,11 @@ class SessionManager:
                     )
                     or 0.0
                 ),
+                raise_on_error=raise_on_error,
             )
         except Exception as e:
+            if raise_on_error:
+                raise
             logger.warning(
                 "Failed to persist snapshot for %s: %s",
                 agent_session.session_id,
@@ -634,6 +688,32 @@ class SessionManager:
                 *restored_messages,
             ]
 
+        # If this session ever had a sandbox, its container did not survive the
+        # resume (a fresh, empty one is lazily recreated). Tell the agent so it
+        # recreates files/packages instead of assuming /app/train.py et al. still
+        # exist. Gated on sandbox_status so pure Q&A chats get no note. Mirrors
+        # the seed_from_summary note convention.
+        #
+        # Skip it when an approval is pending: the restored context ends with an
+        # assistant tool-call message awaiting results, so injecting a user
+        # message here would sit between the tool_calls and their results. On
+        # approval the real results get appended after the note, leaving them
+        # orphaned (the context manager stubs the "missing" result right after
+        # the assistant message) — which the provider rejects. The agent still
+        # learns the sandbox is empty when the approved tool runs against it.
+        if meta.get("sandbox_status") and not meta.get("pending_approval"):
+            session.context_manager.items.append(
+                Message(
+                    role="user",
+                    content=(
+                        "[SYSTEM: This session was resumed and its sandbox was "
+                        "reset. Any files, installed packages, or running "
+                        "processes from earlier are gone — recreate what you "
+                        "need before using the sandbox.]"
+                    ),
+                )
+            )
+
         self._restore_pending_approval(session, meta.get("pending_approval") or [])
         session.turn_count = int(meta.get("turn_count") or 0)
         session.auto_approval_enabled = bool(meta.get("auto_approval_enabled", False))
@@ -707,11 +787,17 @@ class SessionManager:
                 maximum number of concurrent sessions.
         """
         # ── Capacity checks ──────────────────────────────────────────
+        # Reserve a global slot under the lock so concurrent creates can't all
+        # pass the check then over-admit past MAX_SESSIONS (the build + insert
+        # happen later, outside the lock). active_session_count won't reflect
+        # this session until _start_agent_session inserts it, so we count
+        # _pending_creates alongside it to close that gap.
         async with self._lock:
             active_count = self.active_session_count
-            if active_count >= MAX_SESSIONS:
+            projected = active_count + self._pending_creates
+            if projected >= MAX_SESSIONS:
                 raise SessionCapacityError(
-                    f"Server is at capacity ({active_count}/{MAX_SESSIONS} sessions). "
+                    f"Server is at capacity ({projected}/{MAX_SESSIONS} sessions). "
                     "Please try again later.",
                     error_type="global",
                 )
@@ -723,6 +809,7 @@ class SessionManager:
                         "concurrent sessions. Please close an existing session first.",
                         error_type="per_user",
                     )
+            self._pending_creates += 1
 
         session_id = str(uuid.uuid4())
 
@@ -730,41 +817,57 @@ class SessionManager:
         submission_queue: asyncio.Queue = asyncio.Queue()
         event_queue: asyncio.Queue = asyncio.Queue()
 
-        # Run blocking constructors in a thread to keep the event loop responsive.
-        tool_router, session = await asyncio.to_thread(
-            self._create_session_sync,
-            session_id=session_id,
-            user_id=user_id,
-            hf_username=hf_username,
-            hf_token=hf_token,
-            model=model,
-            event_queue=event_queue,
-        )
+        reserved = True
+        try:
+            # Run blocking constructors in a thread to keep the event loop responsive.
+            tool_router, session = await asyncio.to_thread(
+                self._create_session_sync,
+                session_id=session_id,
+                user_id=user_id,
+                hf_username=hf_username,
+                hf_token=hf_token,
+                model=model,
+                event_queue=event_queue,
+            )
 
-        # Create wrapper
-        agent_session = AgentSession(
-            session_id=session_id,
-            session=session,
-            tool_router=tool_router,
-            submission_queue=submission_queue,
-            user_id=user_id,
-            hf_username=hf_username,
-            hf_token=hf_token,
-        )
+            # Create wrapper
+            agent_session = AgentSession(
+                session_id=session_id,
+                session=session,
+                tool_router=tool_router,
+                submission_queue=submission_queue,
+                user_id=user_id,
+                hf_username=hf_username,
+                hf_token=hf_token,
+            )
 
-        await self._start_agent_session(
-            agent_session=agent_session,
-            event_queue=event_queue,
-            tool_router=tool_router,
-        )
-        await self.persist_session_snapshot(agent_session, runtime_state="idle")
-        self._start_cpu_sandbox_preload(agent_session)
+            await self._start_agent_session(
+                agent_session=agent_session,
+                event_queue=event_queue,
+                tool_router=tool_router,
+            )
+            # The session is now in self.sessions, so active_session_count
+            # reflects it — release the reservation before the slower (and
+            # non-capacity) persistence + preload work.
+            async with self._lock:
+                self._pending_creates -= 1
+                reserved = False
 
-        if is_pro is not None and user_id and user_id != "dev":
-            await self._track_pro_status(agent_session, is_pro=is_pro)
+            await self.persist_session_snapshot(agent_session, runtime_state="idle")
+            self._start_cpu_sandbox_preload(agent_session)
 
-        logger.info(f"Created session {session_id} for user {user_id}")
-        return session_id
+            if is_pro is not None and user_id and user_id != "dev":
+                await self._track_pro_status(agent_session, is_pro=is_pro)
+
+            logger.info(f"Created session {session_id} for user {user_id}")
+            return session_id
+        finally:
+            # Build/start failed before the session was inserted — always
+            # release the reservation so a failed create can't permanently
+            # shrink the pool.
+            if reserved:
+                async with self._lock:
+                    self._pending_creates -= 1
 
     async def _track_pro_status(
         self, agent_session: AgentSession, *, is_pro: bool
@@ -856,6 +959,7 @@ class SessionManager:
             ),
         )
         session.context_manager.items.append(seed)
+        self._touch(agent_session)
         await self.persist_session_snapshot(agent_session, runtime_state="idle")
         return len(parsed)
 
@@ -907,6 +1011,138 @@ class SessionManager:
                 SANDBOX_SHUTDOWN_CLEANUP_TIMEOUT_S,
             )
 
+    async def _reaper_loop(self) -> None:
+        """Periodically release resources held by idle sessions.
+
+        Modeled on EventBroadcaster.run: a long-lived task started in start()
+        and cancelled in close(). Per-sweep exceptions are swallowed so one bad
+        sweep never kills the loop.
+        """
+        while True:
+            try:
+                await asyncio.sleep(REAPER_INTERVAL_S)
+                await self._reap_idle_sessions()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Idle-session reaper sweep failed: %s", e)
+
+    async def _reap_idle_sessions(self) -> None:
+        """Select idle candidates under the lock, then tear each down.
+
+        Candidates are non-dev sessions that are live, not processing, not
+        awaiting tool approval (those are "approve later", not idle — reaping
+        would destroy the sandbox the approved tool needs), and untouched for
+        the idle window. We only snapshot IDs under the lock; the actual
+        teardown in _reap_one re-acquires it, because tearing a session down
+        while holding the lock would deadlock (the lock is non-reentrant).
+        """
+        # Reaping is only safe when sessions stay resumable from Mongo. With no
+        # store, eviction would destroy non-dev chats outright, so don't reap.
+        if not getattr(self._store(), "enabled", False):
+            return
+
+        cutoff = datetime.utcnow() - REAPER_IDLE
+        async with self._lock:
+            candidates = [
+                agent_session.session_id
+                for agent_session in self.sessions.values()
+                if agent_session.is_active
+                and not agent_session.is_processing
+                and not agent_session.is_reaping
+                and agent_session.user_id != "dev"
+                and not agent_session.session.pending_approval
+                and agent_session.last_active_at <= cutoff
+            ]
+        if not candidates:
+            return
+
+        reaped = 0
+        for session_id in candidates:
+            try:
+                if await self._reap_one(session_id, cutoff):
+                    reaped += 1
+            except Exception as e:
+                logger.warning("Failed to reap idle session %s: %s", session_id, e)
+        if reaped:
+            logger.info("Reaped %d idle session(s)", reaped)
+
+    async def _reap_one(self, session_id: str, cutoff: datetime) -> bool:
+        """Tear down one idle session, leaving it resumable from Mongo.
+
+        Re-checks every idle condition under the lock (a user may have become
+        active in the gap since selection), marks the session reaping, persists
+        a resumable snapshot, then evicts it. The runtime task is cancelled
+        *outside* the lock: its own ``finally`` frees the sandbox, and its
+        lock-gated persist no-ops because the session is already popped — so it
+        can't overwrite our resumable snapshot with ``"ended"`` and there's no
+        deadlock. Returns True if the session was reaped.
+        """
+        async with self._lock:
+            agent_session = self.sessions.get(session_id)
+            if (
+                agent_session is None
+                or not agent_session.is_active
+                or agent_session.is_processing
+                or agent_session.is_reaping
+                or agent_session.session.pending_approval
+                or agent_session.last_active_at > cutoff
+                or not agent_session.submission_queue.empty()
+            ):
+                return False
+            agent_session.is_reaping = True
+            # Persist a resumable snapshot *before* eviction so a concurrent
+            # reopen reloads clean state. status="active" (never "ended") keeps
+            # it a normal chat in the sidebar. If the write fails (store down or
+            # a transient error) abort the reap rather than destroy state we
+            # couldn't persist — leave the session live and retry next sweep.
+            try:
+                await self.persist_session_snapshot(
+                    agent_session,
+                    runtime_state="idle",
+                    status="active",
+                    raise_on_error=True,
+                )
+            except Exception as e:
+                agent_session.is_reaping = False
+                logger.warning(
+                    "Skipping reap of %s: could not persist resumable snapshot: %s",
+                    session_id,
+                    e,
+                )
+                return False
+            self.sessions.pop(session_id, None)
+            task = agent_session.task
+            session = agent_session.session
+
+        if task is not None and not task.done():
+            task.cancel()
+            # Use asyncio.wait, not wait_for: wait_for re-raises the cancelled
+            # task's CancelledError, which we'd have to swallow — and that same
+            # bare except would also eat an *outer* cancel aimed at the reaper
+            # itself (close() cancelling _reaper_task), hanging shutdown.
+            # asyncio.wait returns the cancelled task in `done` and lets an
+            # outer cancel propagate cleanly.
+            done, _pending = await asyncio.wait({task}, timeout=REAP_TEARDOWN_TIMEOUT_S)
+            if not done:
+                logger.warning(
+                    "Reaper teardown timed out after %.0fs for %s; orphan "
+                    "sweeper will handle any sandbox straggler",
+                    REAP_TEARDOWN_TIMEOUT_S,
+                    session_id,
+                )
+            elif not task.cancelled():
+                # Surface (and retrieve, to avoid "exception never retrieved")
+                # any non-cancellation teardown error.
+                exc = task.exception()
+                if exc is not None:
+                    logger.warning("Reaper teardown error for %s: %s", session_id, exc)
+        else:
+            # No live task to run the cleanup finally — free the sandbox here so
+            # a reaped session never leaves an orphaned Space behind.
+            await self._cleanup_sandbox(session)
+        return True
+
     async def _run_session(
         self,
         session_id: str,
@@ -941,12 +1177,17 @@ class SessionManager:
                             submission_queue.get(), timeout=1.0
                         )
                         agent_session.is_processing = True
+                        self._touch(agent_session)
                         try:
                             should_continue = await process_submission(
                                 session, submission
                             )
                         finally:
                             agent_session.is_processing = False
+                            # Stamp on turn finish too: a turn that ran longer
+                            # than the idle window would otherwise be reaped the
+                            # instant it completes.
+                            self._touch(agent_session)
                             await self.persist_session_snapshot(agent_session)
                         if not should_continue:
                             break
@@ -993,16 +1234,26 @@ class SessionManager:
             logger.info(f"Session {session_id} ended")
 
     async def submit(self, session_id: str, operation: Operation) -> bool:
-        """Submit an operation to a session."""
+        """Submit an operation to a session.
+
+        Enqueues under the lock and rejects sessions being reaped, so submit
+        and reap can't interleave: either the message is enqueued before the
+        reaper's empty() re-check (which then aborts the reap), or the session
+        is already popped (we return False and the caller reloads a fresh
+        runtime from Mongo). The queue is unbounded, so put_nowait never blocks.
+        """
+        submission = Submission(id=f"sub_{uuid.uuid4().hex[:8]}", operation=operation)
         async with self._lock:
             agent_session = self.sessions.get(session_id)
-
-        if not agent_session or not agent_session.is_active:
-            logger.warning(f"Session {session_id} not found or inactive")
-            return False
-
-        submission = Submission(id=f"sub_{uuid.uuid4().hex[:8]}", operation=operation)
-        await agent_session.submission_queue.put(submission)
+            if (
+                not agent_session
+                or not agent_session.is_active
+                or agent_session.is_reaping
+            ):
+                logger.warning(f"Session {session_id} not found or inactive")
+                return False
+            agent_session.submission_queue.put_nowait(submission)
+            self._touch(agent_session)
         return True
 
     async def submit_user_input(self, session_id: str, text: str) -> bool:
@@ -1042,6 +1293,7 @@ class SessionManager:
             user_message_index
         )
         if success:
+            self._touch(agent_session)
             await self.persist_session_snapshot(agent_session, runtime_state="idle")
         return success
 
@@ -1115,6 +1367,7 @@ class SessionManager:
         if not agent_session or not agent_session.is_active:
             return False
         agent_session.session.update_model(model_id)
+        self._touch(agent_session)
         await self.persist_session_snapshot(agent_session, runtime_state="idle")
         return True
 
@@ -1150,6 +1403,7 @@ class SessionManager:
         else:
             session.auto_approval_enabled = bool(enabled)
             session.auto_approval_cost_cap_usd = cost_cap_usd
+        self._touch(agent_session)
         await self.persist_session_snapshot(agent_session)
         return self._auto_approval_summary(session)
 
@@ -1222,6 +1476,7 @@ class SessionManager:
                 seen.add(name)
 
         agent_session.session.set_notification_destinations(normalized)
+        self._touch(agent_session)
         return normalized
 
     async def list_sessions(self, user_id: str | None = None) -> list[dict[str, Any]]:

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -1072,10 +1072,11 @@ class SessionManager:
 
         Re-checks every idle condition under the lock (a user may have become
         active in the gap since selection), marks the session reaping, persists
-        a resumable snapshot, then evicts it. The runtime task is cancelled
-        *outside* the lock: its own ``finally`` frees the sandbox, and its
-        lock-gated persist no-ops because the session is already popped — so it
-        can't overwrite our resumable snapshot with ``"ended"`` and there's no
+        a resumable snapshot outside the lock, then does one final locked
+        re-check before eviction. The runtime task is cancelled *outside* the
+        lock: its own ``finally`` frees the sandbox, and its identity-gated
+        persist no-ops because the session is already popped — so it can't
+        overwrite our resumable snapshot with ``"ended"`` and there's no
         deadlock. Returns True if the session was reaped.
         """
         async with self._lock:
@@ -1091,25 +1092,42 @@ class SessionManager:
             ):
                 return False
             agent_session.is_reaping = True
-            # Persist a resumable snapshot *before* eviction so a concurrent
-            # reopen reloads clean state. status="active" (never "ended") keeps
-            # it a normal chat in the sidebar. If the write fails (store down or
-            # a transient error) abort the reap rather than destroy state we
-            # couldn't persist — leave the session live and retry next sweep.
-            try:
-                await self.persist_session_snapshot(
-                    agent_session,
-                    runtime_state="idle",
-                    status="active",
-                    raise_on_error=True,
-                )
-            except Exception as e:
+
+        # Persist a resumable snapshot *before* eviction so a concurrent reopen
+        # reloads clean state. status="active" (never "ended") keeps it a normal
+        # chat in the sidebar. Do this outside the manager lock: Mongo writes can
+        # take network round trips, and is_reaping=True is enough to block submit
+        # from enqueueing while the snapshot is in flight.
+        try:
+            await self.persist_session_snapshot(
+                agent_session,
+                runtime_state="idle",
+                status="active",
+                raise_on_error=True,
+            )
+        except Exception as e:
+            async with self._lock:
+                if self.sessions.get(session_id) is agent_session:
+                    agent_session.is_reaping = False
+            logger.warning(
+                "Skipping reap of %s: could not persist resumable snapshot: %s",
+                session_id,
+                e,
+            )
+            return False
+
+        async with self._lock:
+            current = self.sessions.get(session_id)
+            if current is not agent_session:
+                return False
+            if (
+                not agent_session.is_active
+                or agent_session.is_processing
+                or agent_session.session.pending_approval
+                or agent_session.last_active_at > cutoff
+                or not agent_session.submission_queue.empty()
+            ):
                 agent_session.is_reaping = False
-                logger.warning(
-                    "Skipping reap of %s: could not persist resumable snapshot: %s",
-                    session_id,
-                    e,
-                )
                 return False
             self.sessions.pop(session_id, None)
             task = agent_session.task
@@ -1223,10 +1241,10 @@ class SessionManager:
                     logger.warning(f"Final-flush failed for {session_id}: {e}")
 
             async with self._lock:
-                if session_id in self.sessions:
-                    self.sessions[session_id].is_active = False
+                if self.sessions.get(session_id) is agent_session:
+                    agent_session.is_active = False
                     await self.persist_session_snapshot(
-                        self.sessions[session_id],
+                        agent_session,
                         runtime_state="ended",
                         status="ended",
                     )

--- a/frontend/src/components/Chat/ActivityStatusBar.tsx
+++ b/frontend/src/components/Chat/ActivityStatusBar.tsx
@@ -25,7 +25,7 @@ function formatResearchStatus(raw: string): string {
   const s = raw.replace(/^▸\s*/, '');
   const jsonStart = s.indexOf('{');
   const toolName = jsonStart > 0 ? s.slice(0, jsonStart).trim() : s.trim();
-  let args: Record<string, string> = {};
+  const args: Record<string, string> = {};
   if (jsonStart > 0) {
     const jsonStr = s.slice(jsonStart);
     try {

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -39,6 +39,10 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
   } = useAgentChat({
     sessionId,
     isActive,
+    // A backgrounded session that the backend reports mid-turn still needs to
+    // mount its live subscription; idle backgrounded sessions do not (that's
+    // what stops app load from reactivating every historical runtime).
+    isProcessing: sessionMeta?.isProcessing ?? false,
     onReady: () => logger.log(`Session ${sessionId} ready`),
     onError: (error) => logger.error(`Session ${sessionId} error:`, error),
     onSessionDead,

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -23,7 +23,7 @@ interface SessionChatProps {
 
 export default function SessionChat({ sessionId, isActive, onSessionDead }: SessionChatProps) {
   const { isConnected, isProcessing, activityStatus, updateSession } = useAgentStore();
-  const { updateSessionTitle, sessions } = useSessionStore();
+  const { updateSessionTitle, sessions, setSessionProcessing } = useSessionStore();
   const sessionMeta = sessions.find((s) => s.id === sessionId);
   const isExpired = sessionMeta?.expired === true;
 
@@ -86,6 +86,7 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
       if (!text.trim() || busy) return;
 
       updateSession(sessionId, { isProcessing: true, activityStatus: { type: 'thinking' } });
+      setSessionProcessing(sessionId, true);
       sendMessage({ text: text.trim(), metadata: { createdAt: new Date().toISOString() } });
 
       // Auto-title the session from the first user message
@@ -105,7 +106,7 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
           });
       }
     },
-    [sessionId, sendMessage, messages, updateSessionTitle, busy, updateSession],
+    [sessionId, sendMessage, messages, updateSessionTitle, busy, updateSession, setSessionProcessing],
   );
 
   // Don't render UI for background sessions — hooks still run

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -24,17 +24,30 @@ import { logger } from '@/utils/logger';
 interface UseAgentChatOptions {
   sessionId: string;
   isActive: boolean;
+  /** Backend reports this session is mid-turn (from the GET /sessions list). */
+  isProcessing?: boolean;
   onReady?: () => void;
   onError?: (error: string) => void;
   onSessionDead?: (sessionId: string) => void;
 }
 
-export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionDead }: UseAgentChatOptions) {
+export function useAgentChat({ sessionId, isActive, isProcessing = false, onReady, onError, onSessionDead }: UseAgentChatOptions) {
   const callbacksRef = useRef({ onReady, onError, onSessionDead });
   callbacksRef.current = { onReady, onError, onSessionDead };
 
   const isActiveRef = useRef(isActive);
   isActiveRef.current = isActive;
+
+  // Only the active tab — or a session the backend says is mid-turn — gets a
+  // reactivating hydration (the /messages + /session fetch and the SDK's
+  // resume reconnect both call ensure_session_loaded, which spins a runtime +
+  // sandbox back up for any not-currently-live session). Gating on this keeps
+  // app load from reactivating every historical session and refilling the
+  // global active-session pool. A processing session is already live, so
+  // hydrating it returns the existing object without inflating the pool.
+  const shouldReactivate = isActive || isProcessing;
+  const shouldReactivateRef = useRef(shouldReactivate);
+  shouldReactivateRef.current = shouldReactivate;
 
   const { setNeedsAttention, updateSessionYolo } = useSessionStore();
 
@@ -46,6 +59,11 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
     () => ({
       onReady: () => {
         updateSession(sessionId, { isProcessing: false });
+        // Mirror to the sidebar store too: agentStore drives the live UI, but
+        // SessionMeta.isProcessing (sessionStore) is what feeds shouldReactivate.
+        // Only mergeServerSessions sets it, so without clearing it here a
+        // finished background task keeps reactivating until the next list fetch.
+        useSessionStore.getState().setSessionProcessing(sessionId, false);
         if (isActiveRef.current) {
           useAgentStore.getState().setConnected(true);
         }
@@ -54,12 +72,14 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
       },
       onShutdown: () => {
         updateSession(sessionId, { isProcessing: false });
+        useSessionStore.getState().setSessionProcessing(sessionId, false);
         if (isActiveRef.current) {
           useAgentStore.getState().setConnected(false);
         }
       },
       onError: (error: string) => {
         updateSession(sessionId, { isProcessing: false });
+        useSessionStore.getState().setSessionProcessing(sessionId, false);
         callbacksRef.current.onError?.(error);
       },
       onProcessing: () => {
@@ -67,12 +87,15 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
           isProcessing: true,
           activityStatus: { type: 'thinking' },
         });
+        useSessionStore.getState().setSessionProcessing(sessionId, true);
       },
       onProcessingDone: () => {
         updateSession(sessionId, { isProcessing: false });
+        useSessionStore.getState().setSessionProcessing(sessionId, false);
       },
       onUndoComplete: () => {
         updateSession(sessionId, { isProcessing: false });
+        useSessionStore.getState().setSessionProcessing(sessionId, false);
       },
       onCompacted: (oldTokens: number, newTokens: number) => {
         logger.log(`Context compacted: ${oldTokens} -> ${newTokens} tokens`);
@@ -197,7 +220,14 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
           );
         }
 
-        updateSession(sessionId, { activityStatus: { type: 'waiting-approval' } });
+        // Approval pauses the turn: the backend has returned and set
+        // is_processing=False, and no turn_complete/onProcessingDone fires on
+        // this path. Clear processing in both stores (sessionStore.isProcessing
+        // feeds shouldReactivate) so a backgrounded waiting-approval session
+        // doesn't stay "processing" until the next /sessions merge —
+        // activityStatus still surfaces the waiting-approval state.
+        updateSession(sessionId, { isProcessing: false, activityStatus: { type: 'waiting-approval' } });
+        useSessionStore.getState().setSessionProcessing(sessionId, false);
 
         // Build panel data for this session's pending approval
         const firstTool = tools[0];
@@ -349,14 +379,17 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
     experimental_throttle: 80,
     // On mount, the SDK calls transport.reconnectToStream() which checks
     // is_processing and subscribes to the live event stream if the agent
-    // is mid-turn.  Without this, page refresh kills live updates.
-    resume: true,
+    // is mid-turn.  Without this, page refresh kills live updates. Gated on
+    // shouldReactivate so an idle backgrounded session isn't reactivated on
+    // app load just to find there's nothing to resume.
+    resume: shouldReactivate,
     // After all approval responses are set, auto-send to continue the agent loop.
     // Without this, addToolApprovalResponse only updates the UI — it won't trigger
     // sendMessages on the transport.
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (error) => {
       updateSession(sessionId, { isProcessing: false });
+      useSessionStore.getState().setSessionProcessing(sessionId, false);
       // Premium-model daily cap: open the cap dialog instead of the generic error
       // banner. Transport marks the error with this sentinel.
       if (error.message === 'CLAUDE_QUOTA_EXHAUSTED') {
@@ -374,7 +407,13 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
   chatActionsRef.current.messages = chat.messages;
 
   // -- Hydrate from backend on mount (page refresh recovery) --------------
+  // Gated on shouldReactivate: an idle backgrounded session renders from its
+  // localStorage message cache + the sidebar list payload, with no per-session
+  // fetch that would reactivate its runtime/sandbox. Re-runs when a session
+  // becomes active (user selects it) or the list reports it processing, which
+  // is exactly when reactivation is wanted.
   useEffect(() => {
+    if (!shouldReactivate) return;
     let cancelled = false;
     (async () => {
       try {
@@ -450,7 +489,7 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
       }
     })();
     return () => { cancelled = true; };
-  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [sessionId, shouldReactivate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // -- Re-hydrate + reconnect on wake from sleep ----------------------------
   // The Vercel AI SDK only calls reconnectToStream() on mount, NOT on
@@ -627,6 +666,10 @@ export function useAgentChat({ sessionId, isActive, onReady, onError, onSessionD
 
     const onVisible = async () => {
       if (document.visibilityState !== 'visible') return;
+      // Idle backgrounded sessions stay dormant on tab refocus too — otherwise
+      // every refocus would re-hydrate (and reactivate) every session, refilling
+      // the pool the reaper just drained. Only the active/processing session wakes.
+      if (!shouldReactivateRef.current) return;
 
       // Always re-hydrate messages on wake
       const result = await hydrateMessages();

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -53,17 +53,26 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
 
   // Helper: update this session's state (mirrors to globals if active)
   const updateSession = useAgentStore.getState().updateSession;
+  const setProcessingState = useCallback(
+    (
+      next: boolean,
+      updates: Partial<import('@/store/agentStore').PerSessionState> = {},
+    ) => {
+      updateSession(sessionId, { ...updates, isProcessing: next });
+      useSessionStore.getState().setSessionProcessing(sessionId, next);
+    },
+    [sessionId, updateSession],
+  );
 
   // -- Build side-channel callbacks (stable ref) --------------------------
   const sideChannel = useMemo<SideChannelCallbacks>(
     () => ({
       onReady: () => {
-        updateSession(sessionId, { isProcessing: false });
         // Mirror to the sidebar store too: agentStore drives the live UI, but
         // SessionMeta.isProcessing (sessionStore) is what feeds shouldReactivate.
         // Only mergeServerSessions sets it, so without clearing it here a
         // finished background task keeps reactivating until the next list fetch.
-        useSessionStore.getState().setSessionProcessing(sessionId, false);
+        setProcessingState(false);
         if (isActiveRef.current) {
           useAgentStore.getState().setConnected(true);
         }
@@ -71,31 +80,25 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         callbacksRef.current.onReady?.();
       },
       onShutdown: () => {
-        updateSession(sessionId, { isProcessing: false });
-        useSessionStore.getState().setSessionProcessing(sessionId, false);
+        setProcessingState(false);
         if (isActiveRef.current) {
           useAgentStore.getState().setConnected(false);
         }
       },
       onError: (error: string) => {
-        updateSession(sessionId, { isProcessing: false });
-        useSessionStore.getState().setSessionProcessing(sessionId, false);
+        setProcessingState(false);
         callbacksRef.current.onError?.(error);
       },
       onProcessing: () => {
-        updateSession(sessionId, {
-          isProcessing: true,
+        setProcessingState(true, {
           activityStatus: { type: 'thinking' },
         });
-        useSessionStore.getState().setSessionProcessing(sessionId, true);
       },
       onProcessingDone: () => {
-        updateSession(sessionId, { isProcessing: false });
-        useSessionStore.getState().setSessionProcessing(sessionId, false);
+        setProcessingState(false);
       },
       onUndoComplete: () => {
-        updateSession(sessionId, { isProcessing: false });
-        useSessionStore.getState().setSessionProcessing(sessionId, false);
+        setProcessingState(false);
       },
       onCompacted: (oldTokens: number, newTokens: number) => {
         logger.log(`Context compacted: ${oldTokens} -> ${newTokens} tokens`);
@@ -226,8 +229,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         // feeds shouldReactivate) so a backgrounded waiting-approval session
         // doesn't stay "processing" until the next /sessions merge —
         // activityStatus still surfaces the waiting-approval state.
-        updateSession(sessionId, { isProcessing: false, activityStatus: { type: 'waiting-approval' } });
-        useSessionStore.getState().setSessionProcessing(sessionId, false);
+        setProcessingState(false, { activityStatus: { type: 'waiting-approval' } });
 
         // Build panel data for this session's pending approval
         const firstTool = tools[0];
@@ -337,7 +339,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       onInterrupted: () => { /* no-op — handled by stop() caller */ },
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sessionId],
+    [sessionId, setProcessingState],
   );
 
   // -- Create transport (one per session, stable for lifetime) ------------
@@ -388,8 +390,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
     // sendMessages on the transport.
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: (error) => {
-      updateSession(sessionId, { isProcessing: false });
-      useSessionStore.getState().setSessionProcessing(sessionId, false);
+      setProcessingState(false);
       // Premium-model daily cap: open the cap dialog instead of the generic error
       // banner. Transport marks the error with this sentinel.
       if (error.message === 'CLAUDE_QUOTA_EXHAUSTED') {
@@ -468,8 +469,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
           // atomic update so the UI never sees isProcessing=false with stale
           // tool states (which would coerce them to 'output-available').
           const savedResearch = loadResearch(sessionId);
-          updateSession(sessionId, {
-            isProcessing: true,
+          setProcessingState(true, {
             activityStatus: savedResearch?.stats.startedAt
               ? { type: 'tool', toolName: 'research', description: 'Resuming research...' }
               : { type: 'thinking' },
@@ -479,9 +479,10 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             }),
           });
         } else if (pendingIds && pendingIds.size > 0) {
-          updateSession(sessionId, { activityStatus: { type: 'waiting-approval' } });
+          setProcessingState(false, { activityStatus: { type: 'waiting-approval' } });
           clearResearch(sessionId);
         } else {
+          setProcessingState(false);
           clearResearch(sessionId);
         }
       } catch {
@@ -489,7 +490,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       }
     })();
     return () => { cancelled = true; };
-  }, [sessionId, shouldReactivate]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [sessionId, shouldReactivate, setProcessingState]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // -- Re-hydrate + reconnect on wake from sleep ----------------------------
   // The Vercel AI SDK only calls reconnectToStream() on mount, NOT on
@@ -684,7 +685,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
 
       // If the backend is still processing, reconnect to the live event stream
       if (info?.is_processing) {
-        updateSession(sessionId, { isProcessing: true, activityStatus: { type: 'thinking' } });
+        setProcessingState(true, { activityStatus: { type: 'thinking' } });
 
         // Stop any previous reconnection
         stopReconnect();
@@ -709,7 +710,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
 
           // If backend stopped processing, clean up
           if (fresh.info && !fresh.info.is_processing) {
-            updateSession(sessionId, { isProcessing: false });
+            setProcessingState(false);
             stopReconnect();
           }
         }, 3000);
@@ -721,7 +722,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       document.removeEventListener('visibilitychange', onVisible);
       stopReconnect();
     };
-  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [sessionId, setProcessingState]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // -- Persist messages ---------------------------------------------------
   const prevLenRef = useRef(initialMessages.length);
@@ -756,11 +757,11 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         setMsgs(updated);
         saveMessages(sessionId, updated);
       }
-      updateSession(sessionId, { isProcessing: false });
+      setProcessingState(false);
     } catch (e) {
       logger.error('Undo failed:', e);
     }
-  }, [sessionId, updateSession]);
+  }, [sessionId, setProcessingState]);
 
   // -- Approve tools ------------------------------------------------------
   const approveTools = useCallback(
@@ -784,8 +785,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       setNeedsAttention(sessionId, false);
       const hasApproved = approvals.some(a => a.approved);
       if (hasApproved) {
-        updateSession(sessionId, {
-          isProcessing: true,
+        setProcessingState(true, {
           activityStatus: { type: 'thinking' },
         });
       }
@@ -796,7 +796,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
 
       return true;
     },
-    [sessionId, chat, updateSession, setNeedsAttention],
+    [sessionId, chat, setProcessingState, setNeedsAttention],
   );
 
   // -- Stop (interrupt backend agent loop, keep SSE open for events) --------
@@ -804,9 +804,9 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
     // Don't call chat.stop() — keep the SSE stream open so the backend's
     // tool_state_change(cancelled) and interrupted events reach the frontend.
     // The stream closes naturally when the backend sends finish events.
-    updateSession(sessionId, { isProcessing: false });
+    setProcessingState(false);
     apiFetch(`/api/interrupt/${sessionId}`, { method: 'POST' }).catch(() => {});
-  }, [sessionId, updateSession]);
+  }, [sessionId, setProcessingState]);
 
   // -- Edit message + regenerate from that point ----------------------------
   const editAndRegenerate = useCallback(async (messageId: string, newText: string) => {

--- a/frontend/src/store/sessionStore.ts
+++ b/frontend/src/store/sessionStore.ts
@@ -13,6 +13,10 @@ interface SessionStore {
   deleteSession: (id: string) => void;
   switchSession: (id: string) => void;
   setSessionActive: (id: string, isActive: boolean) => void;
+  /** Track whether this session is mid-turn. Set false on terminal events so a
+   *  finished background task stops looking "processing" (which would otherwise
+   *  keep reactivating it until the next GET /sessions merge). */
+  setSessionProcessing: (id: string, isProcessing: boolean) => void;
   updateSessionTitle: (id: string, title: string) => void;
   updateSessionModel: (id: string, model: string | null) => void;
   setNeedsAttention: (id: string, needs: boolean) => void;
@@ -27,6 +31,7 @@ interface SessionStore {
     title?: string | null;
     created_at: string;
     is_active?: boolean;
+    is_processing?: boolean;
     model?: string | null;
     pending_approval?: unknown[] | null;
     auto_approval?: {
@@ -117,6 +122,7 @@ export const useSessionStore = create<SessionStore>()(
                 ...existing,
                 title: server.title || existing.title,
                 isActive: server.is_active ?? existing.isActive,
+                isProcessing: Boolean(server.is_processing),
                 model: server.model ?? existing.model ?? null,
                 needsAttention: Boolean(server.pending_approval?.length) || existing.needsAttention,
                 expired: false,
@@ -139,6 +145,7 @@ export const useSessionStore = create<SessionStore>()(
               title: server.title || `Chat ${merged.length + 1}`,
               createdAt: server.created_at || new Date().toISOString(),
               isActive: server.is_active ?? true,
+              isProcessing: Boolean(server.is_processing),
               needsAttention: Boolean(server.pending_approval?.length),
               model: server.model ?? null,
               expired: false,
@@ -202,6 +209,14 @@ export const useSessionStore = create<SessionStore>()(
         }));
       },
 
+      setSessionProcessing: (id: string, isProcessing: boolean) => {
+        set((state) => ({
+          sessions: state.sessions.map((s) =>
+            s.id === id ? { ...s, isProcessing } : s
+          ),
+        }));
+      },
+
       updateSessionTitle: (id: string, title: string) => {
         set((state) => ({
           sessions: state.sessions.map((s) =>
@@ -229,7 +244,10 @@ export const useSessionStore = create<SessionStore>()(
     {
       name: 'hf-agent-sessions',
       partialize: (state) => ({
-        sessions: state.sessions,
+        // Reset the transient isProcessing flag so a stale `true` from a
+        // previous session can't trigger a reactivating hydration on the next
+        // cold load — it's always re-derived from the live GET /sessions list.
+        sessions: state.sessions.map((s) => ({ ...s, isProcessing: false })),
         activeSessionId: state.activeSessionId,
       }),
     }

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -17,6 +17,13 @@ export interface SessionMeta {
   isActive: boolean;
   needsAttention: boolean;
   model?: string | null;
+  /** True when the backend reports this session is mid-turn (from
+   *  GET /sessions). A processing session is already live in memory, so it
+   *  keeps streaming in the background; idle sessions are NOT hydrated on app
+   *  load, which is what keeps them from refilling the active-session pool.
+   *  Transient — never persisted to localStorage (always re-derived from the
+   *  server list). */
+  isProcessing?: boolean;
   /** True when the backend no longer recognizes this session id (e.g.
    *  after a backend restart). The UI shows a recovery banner and
    *  disables input until the user chooses to restore-with-summary or

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -105,6 +105,8 @@ def _manager_with_store(store: NoopSessionStore) -> SessionManager:
     manager._lock = asyncio.Lock()
     manager.persistence_store = store
     manager.messaging_gateway = CloseableResource()
+    manager._pending_creates = 0
+    manager._reaper_task = None
     return manager
 
 
@@ -621,6 +623,87 @@ async def test_lazy_restore_preserves_auto_approval_policy():
         assert restored.session.auto_approval_cost_cap_usd == 5.0
         assert restored.session.auto_approval_estimated_spend_usd == 1.25
         assert restored.session.auto_approval_policy_summary()["remaining_usd"] == 3.75
+    finally:
+        stop.set()
+        await _cancel_runtime_tasks(manager)
+
+
+@pytest.mark.asyncio
+async def test_lazy_restore_injects_sandbox_reset_note_when_session_had_sandbox():
+    store = RestoreStore(
+        metadata={
+            "session_id": "had-sandbox",
+            "user_id": "owner",
+            "model": "test-model",
+            "sandbox_status": "destroyed",
+        }
+    )
+    manager = _manager_with_store(store)
+    stop = _install_fake_runtime(manager)
+
+    try:
+        restored = await manager.ensure_session_loaded("had-sandbox", user_id="owner")
+
+        assert restored is not None
+        items = restored.session.context_manager.items
+        assert len(items) == 1
+        assert "sandbox was reset" in items[0].content
+    finally:
+        stop.set()
+        await _cancel_runtime_tasks(manager)
+
+
+@pytest.mark.asyncio
+async def test_lazy_restore_skips_sandbox_reset_note_when_no_sandbox():
+    store = RestoreStore(
+        metadata={
+            "session_id": "no-sandbox",
+            "user_id": "owner",
+            "model": "test-model",
+        }
+    )
+    manager = _manager_with_store(store)
+    stop = _install_fake_runtime(manager)
+
+    try:
+        restored = await manager.ensure_session_loaded("no-sandbox", user_id="owner")
+
+        assert restored is not None
+        assert restored.session.context_manager.items == []
+    finally:
+        stop.set()
+        await _cancel_runtime_tasks(manager)
+
+
+@pytest.mark.asyncio
+async def test_lazy_restore_skips_sandbox_note_when_pending_approval():
+    """The sandbox-reset note must be skipped when an approval is pending: it
+    would land between the restored assistant tool-calls and their results,
+    orphaning the tool results on approval (the provider rejects the ordering)."""
+    store = RestoreStore(
+        metadata={
+            "session_id": "had-sandbox-pending",
+            "user_id": "owner",
+            "model": "test-model",
+            "sandbox_status": "destroyed",
+            "pending_approval": [
+                {"tool": "bash", "tool_call_id": "call_1", "arguments": {}}
+            ],
+        }
+    )
+    manager = _manager_with_store(store)
+    stop = _install_fake_runtime(manager)
+
+    try:
+        restored = await manager.ensure_session_loaded(
+            "had-sandbox-pending", user_id="owner"
+        )
+
+        assert restored is not None
+        items = restored.session.context_manager.items
+        assert not any("sandbox was reset" in getattr(m, "content", "") for m in items)
+        # The pending approval itself is still restored.
+        assert restored.session.pending_approval is not None
     finally:
         stop.set()
         await _cancel_runtime_tasks(manager)

--- a/tests/unit/test_session_reaper.py
+++ b/tests/unit/test_session_reaper.py
@@ -1,0 +1,500 @@
+"""Tests for the idle-session reaper and the global create-slot reservation.
+
+Covers Parts B (hard global cap), C (idle reaper + activity stamps + safe
+teardown + submit/reap race), and E (per-user concurrent cap interacts with
+reaping) of the session-limit fix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+import session_manager as sm  # noqa: E402
+from agent.core.session_persistence import NoopSessionStore  # noqa: E402
+from session_manager import (  # noqa: E402
+    AgentSession,
+    Operation,
+    SessionCapacityError,
+    SessionManager,
+)
+from agent.core.session import OpType  # noqa: E402
+
+
+class RecordingStore(NoopSessionStore):
+    """Captures every save_snapshot call so tests can assert persistence."""
+
+    enabled = True
+
+    def __init__(self) -> None:
+        self.snapshots: list[dict[str, Any]] = []
+
+    async def save_snapshot(self, **kwargs: Any) -> None:
+        self.snapshots.append(kwargs)
+
+    def snapshots_for(self, session_id: str) -> list[dict[str, Any]]:
+        return [s for s in self.snapshots if s.get("session_id") == session_id]
+
+
+class FakeSession:
+    """Minimal Session stand-in supporting both persistence and _run_session."""
+
+    def __init__(self, *, hf_token: str | None = "token") -> None:
+        self.hf_token = hf_token
+        self.context_manager = SimpleNamespace(items=[])
+        self.pending_approval: Any = None
+        self.turn_count = 0
+        self.config = SimpleNamespace(model_name="test-model", save_sessions=False)
+        self.notification_destinations: list[str] = []
+        self.auto_approval_enabled = False
+        self.auto_approval_cost_cap_usd = None
+        self.auto_approval_estimated_spend_usd = 0.0
+        self.is_running = True
+
+    async def send_event(self, event: Any) -> None:
+        return None
+
+
+class FakeToolRouter:
+    async def __aenter__(self) -> "FakeToolRouter":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+def _manager() -> SessionManager:
+    manager = object.__new__(SessionManager)
+    manager.config = SimpleNamespace(model_name="test-model")
+    manager.sessions = {}
+    manager._lock = asyncio.Lock()
+    manager.persistence_store = RecordingStore()
+    manager.messaging_gateway = SimpleNamespace()
+    manager._pending_creates = 0
+    manager._reaper_task = None
+    return manager
+
+
+def _make_agent_session(
+    session_id: str,
+    *,
+    user_id: str = "owner",
+    last_active_at: datetime | None = None,
+    is_processing: bool = False,
+    pending_approval: Any = None,
+) -> AgentSession:
+    session = FakeSession()
+    session.pending_approval = pending_approval
+    agent_session = AgentSession(
+        session_id=session_id,
+        session=session,  # type: ignore[arg-type]
+        tool_router=FakeToolRouter(),  # type: ignore[arg-type]
+        submission_queue=asyncio.Queue(),
+        user_id=user_id,
+        hf_token="token",
+    )
+    agent_session.is_processing = is_processing
+    if last_active_at is not None:
+        agent_session.last_active_at = last_active_at
+    return agent_session
+
+
+async def _start_real_run_session(
+    manager: SessionManager,
+    session_id: str,
+    *,
+    user_id: str = "owner",
+    last_active_at: datetime | None = None,
+) -> AgentSession:
+    """Insert a session and start the REAL _run_session task for it."""
+    agent_session = _make_agent_session(
+        session_id, user_id=user_id, last_active_at=last_active_at
+    )
+    event_queue: asyncio.Queue = asyncio.Queue()
+    await manager._start_agent_session(
+        agent_session=agent_session,
+        event_queue=event_queue,
+        tool_router=agent_session.tool_router,
+    )
+    await asyncio.sleep(0)  # let the run loop reach its queue wait
+    return agent_session
+
+
+def _install_fake_create(manager: SessionManager) -> asyncio.Event:
+    """Replace blocking constructors + run loop with fakes for create tests."""
+    stop = asyncio.Event()
+
+    def fake_create_session_sync(**kwargs: Any):
+        return object(), FakeSession(hf_token=kwargs.get("hf_token"))
+
+    async def fake_run_session(*_: Any) -> None:
+        await stop.wait()
+
+    manager._create_session_sync = fake_create_session_sync  # type: ignore[method-assign]
+    manager._run_session = fake_run_session  # type: ignore[method-assign]
+    manager._start_cpu_sandbox_preload = lambda _agent_session: None  # type: ignore[method-assign]
+    return stop
+
+
+async def _cancel_tasks(manager: SessionManager) -> None:
+    tasks = [
+        agent_session.task
+        for agent_session in manager.sessions.values()
+        if agent_session.task and not agent_session.task.done()
+    ]
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+# ── Reaper happy path ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reaper_evicts_idle_session_as_resumable():
+    manager = _manager()
+    cleaned: list[Any] = []
+
+    async def fake_cleanup(session: Any) -> None:
+        cleaned.append(session)
+
+    manager._cleanup_sandbox = fake_cleanup  # type: ignore[method-assign]
+
+    agent_session = await _start_real_run_session(
+        manager,
+        "stale",
+        last_active_at=datetime.utcnow() - timedelta(hours=3),
+    )
+    session = agent_session.session
+
+    await manager._reap_idle_sessions()
+
+    # Evicted from the live pool, sandbox torn down by the task's finally.
+    assert "stale" not in manager.sessions
+    assert cleaned == [session]
+
+    # Persisted resumable (status="active", runtime_state="idle"), never "ended".
+    store = manager.persistence_store
+    snapshots = store.snapshots_for("stale")
+    assert snapshots, "reaper should persist a snapshot"
+    assert all(s["status"] == "active" for s in snapshots)
+    assert snapshots[-1]["runtime_state"] == "idle"
+    assert not any(s["status"] == "ended" for s in snapshots)
+
+
+# ── Spared sessions ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # Fresh: touched just now.
+        {"last_active_at": None},
+        # Currently processing a turn.
+        {
+            "last_active_at": datetime.utcnow() - timedelta(hours=5),
+            "is_processing": True,
+        },
+        # Awaiting tool approval ("approve later", not idle).
+        {
+            "last_active_at": datetime.utcnow() - timedelta(hours=5),
+            "pending_approval": {"tool_calls": [object()]},
+        },
+        # Dev sessions are never reaped.
+        {"last_active_at": datetime.utcnow() - timedelta(hours=5), "user_id": "dev"},
+    ],
+    ids=["fresh", "processing", "pending_approval", "dev"],
+)
+async def test_reaper_spares(kwargs):
+    manager = _manager()
+    agent_session = _make_agent_session("spared", **kwargs)
+    manager.sessions["spared"] = agent_session
+
+    await manager._reap_idle_sessions()
+
+    assert "spared" in manager.sessions
+    assert agent_session.is_reaping is False
+
+
+# ── Submit / reap race ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reap_aborts_when_message_enqueued_first():
+    """A message enqueued before teardown makes the queue non-empty, so the
+    reaper's re-check aborts — the message is never lost."""
+    manager = _manager()
+    agent_session = _make_agent_session(
+        "racing", last_active_at=datetime.utcnow() - timedelta(hours=3)
+    )
+    manager.sessions["racing"] = agent_session
+    agent_session.submission_queue.put_nowait(object())
+
+    cutoff = datetime.utcnow() - sm.REAPER_IDLE
+    reaped = await manager._reap_one("racing", cutoff)
+
+    assert reaped is False
+    assert "racing" in manager.sessions
+    assert agent_session.is_reaping is False
+    assert agent_session.submission_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_rejected_while_reaping():
+    """submit() refuses a session being reaped instead of silently enqueuing
+    onto a dying runtime (the caller then reloads a fresh one)."""
+    manager = _manager()
+    agent_session = _make_agent_session("reaping")
+    agent_session.is_reaping = True
+    manager.sessions["reaping"] = agent_session
+
+    ok = await manager.submit("reaping", Operation(op_type=OpType.USER_INPUT, data={}))
+
+    assert ok is False
+    assert agent_session.submission_queue.empty()
+
+
+# ── Turn-finish timestamp ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_turn_finish_restamps_activity(monkeypatch):
+    """A turn that runs longer than the idle window must not be reaped the
+    instant it finishes — the turn-finish stamp resets the idle clock."""
+    manager = _manager()
+
+    async def fake_cleanup(session: Any) -> None:
+        return None
+
+    manager._cleanup_sandbox = fake_cleanup  # type: ignore[method-assign]
+
+    agent_session = await _start_real_run_session(
+        manager, "longturn", last_active_at=datetime.utcnow()
+    )
+
+    async def fake_process(session: Any, submission: Any) -> bool:
+        # Simulate a turn that has been running far longer than the idle
+        # window before it completes.
+        agent_session.last_active_at = datetime.utcnow() - timedelta(hours=3)
+        return True
+
+    monkeypatch.setattr(sm, "process_submission", fake_process)
+
+    agent_session.submission_queue.put_nowait(
+        sm.Submission(id="s1", operation=Operation(op_type=OpType.USER_INPUT, data={}))
+    )
+
+    # Wait for the turn-finish stamp to land.
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if datetime.utcnow() - agent_session.last_active_at < timedelta(minutes=1):
+            break
+
+    assert datetime.utcnow() - agent_session.last_active_at < timedelta(minutes=1)
+
+    await _cancel_tasks(manager)
+
+
+# ── Global reservation race (Part B) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_creates_cannot_exceed_global_cap(monkeypatch):
+    manager = _manager()
+    stop = _install_fake_create(manager)
+    monkeypatch.setattr(sm, "MAX_SESSIONS", 3)
+
+    try:
+        results = await asyncio.gather(
+            *[manager.create_session(user_id="owner") for _ in range(10)],
+            return_exceptions=True,
+        )
+        created = [r for r in results if isinstance(r, str)]
+        errors = [r for r in results if isinstance(r, SessionCapacityError)]
+
+        assert len(created) == 3
+        assert len(errors) == 7
+        assert all(e.error_type == "global" for e in errors)
+        assert len(manager.sessions) == 3
+        assert manager._pending_creates == 0
+    finally:
+        stop.set()
+        await _cancel_tasks(manager)
+
+
+@pytest.mark.asyncio
+async def test_failed_build_releases_reservation(monkeypatch):
+    manager = _manager()
+    _install_fake_create(manager)
+    monkeypatch.setattr(sm, "MAX_SESSIONS", 5)
+
+    def boom(**_: Any):
+        raise RuntimeError("build failed")
+
+    manager._create_session_sync = boom  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await manager.create_session(user_id="owner")
+
+    # The reservation must be released so a failed create can't shrink the pool.
+    assert manager._pending_creates == 0
+    assert manager.sessions == {}
+
+
+# ── Per-user concurrent cap interacts with reclaimed slots (Part E) ──────
+
+
+@pytest.mark.asyncio
+async def test_per_user_cap_frees_up_after_slot_reclaimed():
+    manager = _manager()
+    stop = _install_fake_create(manager)
+
+    try:
+        for i in range(sm.MAX_SESSIONS_PER_USER):
+            manager.sessions[f"owner-{i}"] = _make_agent_session(
+                f"owner-{i}", user_id="owner"
+            )
+
+        # At the concurrent cap → rejected.
+        with pytest.raises(SessionCapacityError) as exc:
+            await manager.create_session(user_id="owner")
+        assert exc.value.error_type == "per_user"
+
+        # Reclaiming a slot (the reaper evicts an idle session) frees capacity.
+        manager.sessions.pop("owner-0")
+        new_id = await manager.create_session(user_id="owner")
+
+        assert isinstance(new_id, str)
+        assert manager._count_user_sessions("owner") == sm.MAX_SESSIONS_PER_USER
+    finally:
+        stop.set()
+        await _cancel_tasks(manager)
+
+
+# ── Persistence safety (resumability invariant) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reaper_skips_when_persistence_disabled():
+    """With no usable store a reaped session couldn't be restored, so eviction
+    would destroy non-dev chats outright. The sweep must be a no-op."""
+    manager = _manager()
+    manager.persistence_store = NoopSessionStore()  # enabled = False
+    agent_session = _make_agent_session(
+        "idle", last_active_at=datetime.utcnow() - timedelta(hours=5)
+    )
+    manager.sessions["idle"] = agent_session
+
+    await manager._reap_idle_sessions()
+
+    assert "idle" in manager.sessions
+    assert agent_session.is_reaping is False
+
+
+@pytest.mark.asyncio
+async def test_reap_aborts_when_snapshot_write_fails():
+    """If the resumable snapshot can't be written (e.g. a transient Mongo
+    error), abort rather than evict unrecoverable state — leave it live."""
+    manager = _manager()
+
+    class FailingStore(RecordingStore):
+        async def save_snapshot(self, **kwargs: Any) -> None:
+            raise RuntimeError("mongo write failed")
+
+    manager.persistence_store = FailingStore()
+    agent_session = _make_agent_session(
+        "idle", last_active_at=datetime.utcnow() - timedelta(hours=5)
+    )
+    manager.sessions["idle"] = agent_session
+
+    cutoff = datetime.utcnow() - sm.REAPER_IDLE
+    reaped = await manager._reap_one("idle", cutoff)
+
+    assert reaped is False
+    assert "idle" in manager.sessions
+    assert agent_session.is_reaping is False
+
+
+@pytest.mark.asyncio
+async def test_reap_aborts_when_message_write_fails_silently():
+    """The real store swallows message bulk_write errors for best-effort callers
+    and only surfaces them when asked to be strict. The reaper must request
+    strict mode, so a silent message-write failure still aborts the reap (not
+    only metadata/connection failures that already make save_snapshot raise)."""
+    manager = _manager()
+
+    class StrictModeStore(RecordingStore):
+        # Mirrors MongoSessionStore: message-write failure is swallowed unless
+        # the caller passes raise_on_error (which the reaper does).
+        async def save_snapshot(
+            self, *, raise_on_error: bool = False, **kwargs: Any
+        ) -> None:
+            if raise_on_error:
+                raise RuntimeError("message bulk_write failed")
+
+    manager.persistence_store = StrictModeStore()
+    agent_session = _make_agent_session(
+        "idle", last_active_at=datetime.utcnow() - timedelta(hours=5)
+    )
+    manager.sessions["idle"] = agent_session
+
+    cutoff = datetime.utcnow() - sm.REAPER_IDLE
+    reaped = await manager._reap_one("idle", cutoff)
+
+    assert reaped is False
+    assert "idle" in manager.sessions
+    assert agent_session.is_reaping is False
+
+
+# ── Shutdown safety (cancellation must propagate) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reaper_teardown_propagates_outer_cancellation():
+    """Cancelling the reaper while it awaits a slow teardown must propagate, so
+    close() can't hang. Regression for the CancelledError-conflation bug: the
+    old wait_for + bare-except swallowed the reaper's own cancellation."""
+    manager = _manager()
+
+    release = asyncio.Event()
+
+    async def slow_cleanup(session: Any) -> None:
+        await release.wait()  # block teardown so _reap_one parks in the wait
+
+    manager._cleanup_sandbox = slow_cleanup  # type: ignore[method-assign]
+
+    agent_session = await _start_real_run_session(
+        manager, "slow", last_active_at=datetime.utcnow() - timedelta(hours=3)
+    )
+    cutoff = datetime.utcnow() - sm.REAPER_IDLE
+
+    reap_task = asyncio.create_task(manager._reap_one("slow", cutoff))
+    # Let _reap_one persist + pop, then enter the teardown wait (the session
+    # task is stuck in slow_cleanup, so the wait won't complete on its own).
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        if "slow" not in manager.sessions:
+            break
+    await asyncio.sleep(0.02)
+
+    # Simulate close() cancelling the reaper mid-teardown.
+    reap_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await reap_task
+
+    # Unblock the stuck teardown and reap the orphaned session task.
+    release.set()
+    if agent_session.task is not None:
+        await asyncio.gather(agent_session.task, return_exceptions=True)

--- a/tests/unit/test_session_reaper.py
+++ b/tests/unit/test_session_reaper.py
@@ -458,6 +458,57 @@ async def test_reap_aborts_when_message_write_fails_silently():
     assert agent_session.is_reaping is False
 
 
+# ── Reap / restore race ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_old_reaped_task_does_not_end_freshly_restored_session():
+    """If a user reopens after the reaper pops the old wrapper but before the
+    old task finishes sandbox cleanup, the old finally must not mark the fresh
+    wrapper ended."""
+    manager = _manager()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def slow_cleanup(session: Any) -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    manager._cleanup_sandbox = slow_cleanup  # type: ignore[method-assign]
+
+    old = await _start_real_run_session(
+        manager,
+        "restore-race",
+        last_active_at=datetime.utcnow() - timedelta(hours=3),
+    )
+    cutoff = datetime.utcnow() - sm.REAPER_IDLE
+    reap_task = asyncio.create_task(manager._reap_one("restore-race", cutoff))
+
+    for _ in range(100):
+        await asyncio.sleep(0.01)
+        if "restore-race" not in manager.sessions and cleanup_started.is_set():
+            break
+
+    assert "restore-race" not in manager.sessions
+    assert cleanup_started.is_set()
+
+    fresh = _make_agent_session("restore-race")
+    async with manager._lock:
+        manager.sessions["restore-race"] = fresh
+
+    release_cleanup.set()
+    assert await reap_task is True
+    if old.task is not None:
+        assert old.task.done()
+
+    assert manager.sessions["restore-race"] is fresh
+    assert fresh.is_active is True
+    assert all(
+        snapshot.get("status") != "ended"
+        for snapshot in manager.persistence_store.snapshots_for("restore-race")
+    )
+
+
 # ── Shutdown safety (cancellation must propagate) ────────────────────────
 
 


### PR DESCRIPTION
Users hit "Server is at capacity (379/200)" and couldn't create sessions: idle/forgotten runtimes never left the global pool, the frontend reactivated every historical session on load, and concurrent creates could overshoot the cap.

Backend:
- Idle-session reaper (2h): releases the sandbox + RAM of inactive sessions and evicts them from the live pool, leaving them resumable from Mongo (persisted resumable, never "ended"). Teardown uses asyncio.wait so a shutdown cancel can't be swallowed; submit() enqueues under the lock and refuses sessions being reaped. Reaping is skipped when persistence is disabled and aborts if the resumable snapshot (incl. the message bulk_write, via save_snapshot strict mode) can't be durably written.
- Global create-slot reservation closes the check-then-create race that let concurrent creates exceed MAX_SESSIONS.
- last_active_at drives the reaper, stamped on genuine activity only.
- Restore injects a sandbox-reset note so the agent knows its sandbox was wiped, skipped when an approval is pending (would orphan the tool results).

Frontend:
- Only the active or backend-processing session reactivates its runtime on load and tab refocus; idle sessions render from cache, so opening the app no longer refills the pool. isProcessing is cleared on all terminal and approval paths.

Tests: reaper happy path/spared cases, submit-reap race, turn-finish restamp, global reservation race, persistence-disabled and write-failure aborts, shutdown cancellation propagation, restore-note inject/skip.