### PR TITLE
Remove old Claude model support

### DIFF
--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -2,7 +2,6 @@
 
 HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 
-CLAUDE_OPUS_47_MODEL_ID = "anthropic/claude-opus-4.7:fal-ai"
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
 CLAUDE_SONNET_46_MODEL_ID = "anthropic/claude-sonnet-4-6:fal-ai"
 GPT_55_MODEL_ID = "openai/gpt-5.5:fal-ai"
@@ -14,7 +13,6 @@ DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:deepinfra"
 DEFAULT_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 
 PREMIUM_MODEL_IDS = {
-    CLAUDE_OPUS_47_MODEL_ID,
     CLAUDE_OPUS_48_MODEL_ID,
     CLAUDE_SONNET_46_MODEL_ID,
     GPT_55_MODEL_ID,

--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -3,7 +3,6 @@
 HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
-CLAUDE_SONNET_46_MODEL_ID = "anthropic/claude-sonnet-4-6:fal-ai"
 GPT_55_MODEL_ID = "openai/gpt-5.5:fal-ai"
 KIMI_K26_MODEL_ID = "moonshotai/Kimi-K2.6"
 MINIMAX_M27_MODEL_ID = "MiniMaxAI/MiniMax-M2.7"
@@ -14,7 +13,6 @@ DEFAULT_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 
 PREMIUM_MODEL_IDS = {
     CLAUDE_OPUS_48_MODEL_ID,
-    CLAUDE_SONNET_46_MODEL_ID,
     GPT_55_MODEL_ID,
 }
 

--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -2,7 +2,6 @@
 
 HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 
-CLAUDE_OPUS_46_MODEL_ID = "anthropic/claude-opus-4.6:fal-ai"
 CLAUDE_OPUS_47_MODEL_ID = "anthropic/claude-opus-4.7:fal-ai"
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
 CLAUDE_SONNET_46_MODEL_ID = "anthropic/claude-sonnet-4-6:fal-ai"
@@ -15,7 +14,6 @@ DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:deepinfra"
 DEFAULT_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 
 PREMIUM_MODEL_IDS = {
-    CLAUDE_OPUS_46_MODEL_ID,
     CLAUDE_OPUS_47_MODEL_ID,
     CLAUDE_OPUS_48_MODEL_ID,
     CLAUDE_SONNET_46_MODEL_ID,

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -27,7 +27,6 @@ from agent.core.local_models import (
     is_reserved_local_model_id,
 )
 from agent.core.model_ids import (
-    CLAUDE_OPUS_46_MODEL_ID,
     CLAUDE_OPUS_47_MODEL_ID,
     CLAUDE_OPUS_48_MODEL_ID,
     GPT_55_MODEL_ID,
@@ -43,7 +42,6 @@ from agent.core.model_ids import (
 SUGGESTED_MODELS = [
     {"id": CLAUDE_OPUS_48_MODEL_ID, "label": "Claude Opus 4.8"},
     {"id": CLAUDE_OPUS_47_MODEL_ID, "label": "Claude Opus 4.7"},
-    {"id": CLAUDE_OPUS_46_MODEL_ID, "label": "Claude Opus 4.6"},
     {"id": GPT_55_MODEL_ID, "label": "GPT-5.5"},
     {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": KIMI_K26_MODEL_ID, "label": "Kimi K2.6"},

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -27,7 +27,6 @@ from agent.core.local_models import (
     is_reserved_local_model_id,
 )
 from agent.core.model_ids import (
-    CLAUDE_OPUS_47_MODEL_ID,
     CLAUDE_OPUS_48_MODEL_ID,
     GPT_55_MODEL_ID,
     KIMI_K26_MODEL_ID,
@@ -41,7 +40,6 @@ from agent.core.model_ids import (
 # policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
     {"id": CLAUDE_OPUS_48_MODEL_ID, "label": "Claude Opus 4.8"},
-    {"id": CLAUDE_OPUS_47_MODEL_ID, "label": "Claude Opus 4.7"},
     {"id": GPT_55_MODEL_ID, "label": "GPT-5.5"},
     {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": KIMI_K26_MODEL_ID, "label": "Kimi K2.6"},

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -17,10 +17,7 @@ from litellm import Message, acompletion
 from agent.core import telemetry
 from agent.core.doom_loop import check_for_doom_loop
 from agent.core.llm_params import _resolve_llm_params
-from agent.core.model_ids import (
-    CLAUDE_SONNET_46_MODEL_ID,
-    strip_huggingface_model_prefix,
-)
+from agent.core.model_ids import strip_huggingface_model_prefix
 from agent.core.session import Event
 
 logger = logging.getLogger(__name__)
@@ -223,11 +220,8 @@ RESEARCH_TOOL_SPEC = {
 
 
 def _get_research_model(main_model: str) -> str:
-    """Pick a cheaper model for research based on the main model."""
-    normalized = strip_huggingface_model_prefix(main_model) or main_model
-    if normalized.startswith("anthropic/claude-opus"):
-        return CLAUDE_SONNET_46_MODEL_ID
-    return normalized
+    """Normalize the main model id for the research sub-call."""
+    return strip_huggingface_model_prefix(main_model) or main_model
 
 
 async def research_handler(
@@ -252,13 +246,11 @@ async def research_handler(
         user_content = f"Context: {context}\n\n{user_content}"
     messages.append(Message(role="user", content=user_content))
 
-    # Use a cheaper/faster model for research
+    # Use the normalized router model for research
     main_model = session.config.model_name
     research_model = _get_research_model(main_model)
-    # Research is a cheap sub-call — cap the main session's effort at "high"
-    # so a user preference of ``max``/``xhigh`` (valid for Opus 4.8) doesn't
-    # propagate to a Sonnet research model that may not accept those levels.
-    # We also haven't probed this sub-model so we don't know its ceiling.
+    # Research is a cheap sub-call — cap the main session's effort at "high".
+    # We also haven't probed this sub-call's model so we don't know its ceiling.
     _pref = getattr(session.config, "reasoning_effort", None)
     _capped = "high" if _pref in ("max", "xhigh") else _pref
     llm_params = _resolve_llm_params(

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -256,7 +256,7 @@ async def research_handler(
     main_model = session.config.model_name
     research_model = _get_research_model(main_model)
     # Research is a cheap sub-call — cap the main session's effort at "high"
-    # so a user preference of ``max``/``xhigh`` (valid for Opus 4.7/4.8) doesn't
+    # so a user preference of ``max``/``xhigh`` (valid for Opus 4.8) doesn't
     # propagate to a Sonnet research model that may not accept those levels.
     # We also haven't probed this sub-model so we don't know its ceiling.
     _pref = getattr(session.config, "reasoning_effort", None)

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -256,7 +256,7 @@ async def research_handler(
     main_model = session.config.model_name
     research_model = _get_research_model(main_model)
     # Research is a cheap sub-call — cap the main session's effort at "high"
-    # so a user preference of ``max``/``xhigh`` (valid for Opus 4.6/4.7) doesn't
+    # so a user preference of ``max``/``xhigh`` (valid for Opus 4.7/4.8) doesn't
     # propagate to a Sonnet research model that may not accept those levels.
     # We also haven't probed this sub-model so we don't know its ceiling.
     _pref = getattr(session.config, "reasoning_effort", None)

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -55,7 +55,6 @@ from agent.core.hf_access import get_jobs_access
 from agent.core.hf_tokens import resolve_hf_request_token
 from agent.core.llm_params import _resolve_llm_params
 from agent.core.model_ids import (
-    CLAUDE_OPUS_46_MODEL_ID,
     DEEPSEEK_V4_PRO_MODEL_ID,
     DEFAULT_MODEL_ID,
     GLM_51_MODEL_ID,
@@ -84,12 +83,6 @@ def _available_models() -> list[dict[str, Any]]:
             "provider": "huggingface",
             "tier": "pro",
             "recommended": True,
-        },
-        {
-            "id": CLAUDE_OPUS_46_MODEL_ID,
-            "label": "Claude Opus 4.6",
-            "provider": "huggingface",
-            "tier": "pro",
         },
         {
             "id": DEFAULT_GPT_MODEL_ID,

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -25,7 +25,6 @@ import JobsUpgradeDialog from '@/components/JobsUpgradeDialog';
 import { useAgentStore } from '@/store/agentStore';
 import { useSessionStore } from '@/store/sessionStore';
 import {
-  CLAUDE_OPUS_46_MODEL_PATH,
   CLAUDE_MODEL_PATH,
   GPT_55_MODEL_PATH,
   isClaudePath,
@@ -55,13 +54,6 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
     modelPath: CLAUDE_MODEL_PATH,
     avatarUrl: getHfAvatarUrl(CLAUDE_MODEL_PATH),
     recommended: true,
-  },
-  {
-    id: 'claude-opus-4-6',
-    name: 'Claude Opus 4.6',
-    description: 'Hugging Face',
-    modelPath: CLAUDE_OPUS_46_MODEL_PATH,
-    avatarUrl: getHfAvatarUrl(CLAUDE_OPUS_46_MODEL_PATH),
   },
   {
     id: 'gpt-5.5',

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -6,13 +6,11 @@
  * AVAILABLE_MODELS in backend/routes/agent.py.
  */
 
-export const CLAUDE_OPUS_46_MODEL_PATH = 'anthropic/claude-opus-4.6:fal-ai';
 export const CLAUDE_OPUS_48_MODEL_PATH = 'anthropic/claude-opus-4.8:fal-ai';
 export const CLAUDE_MODEL_PATH = CLAUDE_OPUS_48_MODEL_PATH;
 export const GPT_55_MODEL_PATH = 'openai/gpt-5.5:fal-ai';
 
 const PREMIUM_MODEL_PATHS = new Set([
-  CLAUDE_OPUS_46_MODEL_PATH,
   CLAUDE_OPUS_48_MODEL_PATH,
   GPT_55_MODEL_PATH,
 ]);

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -33,7 +33,6 @@ def _premium_session(model: str = agent.DEFAULT_PREMIUM_MODEL_ID):
 
 def test_premium_model_predicate_uses_router_ids_only():
     assert agent._is_premium_model(agent.DEFAULT_PREMIUM_MODEL_ID)
-    assert agent._is_premium_model(agent.CLAUDE_OPUS_46_MODEL_ID)
     assert agent._is_premium_model(agent.DEFAULT_GPT_MODEL_ID)
     assert agent._is_user_billed(agent.DEFAULT_PREMIUM_MODEL_ID)
     assert not agent._is_premium_model("moonshotai/Kimi-K2.6")

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -26,7 +26,7 @@ def test_non_anthropic_research_model_is_unchanged():
 
 def test_huggingface_prefix_research_model_strips_prefix():
     assert (
-        _get_research_model("huggingface/anthropic/claude-opus-4.6:fal-ai")
+        _get_research_model("huggingface/anthropic/claude-opus-4.8:fal-ai")
         == "anthropic/claude-sonnet-4-6:fal-ai"
     )
 

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -13,10 +13,10 @@ from agent.tools.research_tool import _get_research_model
 from agent.utils import terminal_display
 
 
-def test_router_anthropic_research_downgrades_to_router_sonnet():
+def test_router_anthropic_research_model_is_unchanged():
     assert (
         _get_research_model("anthropic/claude-opus-4.8:fal-ai")
-        == "anthropic/claude-sonnet-4-6:fal-ai"
+        == "anthropic/claude-opus-4.8:fal-ai"
     )
 
 
@@ -27,12 +27,11 @@ def test_non_anthropic_research_model_is_unchanged():
 def test_huggingface_prefix_research_model_strips_prefix():
     assert (
         _get_research_model("huggingface/anthropic/claude-opus-4.8:fal-ai")
-        == "anthropic/claude-sonnet-4-6:fal-ai"
+        == "anthropic/claude-opus-4.8:fal-ai"
     )
 
 
 def test_hf_router_openai_research_model_is_unchanged():
-    # No Sonnet equivalent for GPT — research stays on the same router model.
     assert (
         _get_research_model("huggingface/openai/gpt-5.5:fal-ai")
         == "openai/gpt-5.5:fal-ai"

--- a/tests/unit/test_sft_tagger.py
+++ b/tests/unit/test_sft_tagger.py
@@ -21,9 +21,7 @@ def _traj(events=None, messages=None, model="anthropic/claude-opus-4.8:fal-ai"):
 
 def test_model_family():
     assert "model:opus" in tag_session(_traj(model="anthropic/claude-opus-4.8:fal-ai"))
-    assert "model:sonnet" in tag_session(
-        _traj(model="anthropic/claude-sonnet-4-6:fal-ai")
-    )
+    assert "model:sonnet" in tag_session(_traj(model="example-sonnet-model"))
     assert "model:kimi" in tag_session(_traj(model="moonshotai/Kimi-K2.6"))
     assert "model:other" in tag_session(_traj(model="unknown-model-xyz"))
 

--- a/tests/unit/test_sft_tagger.py
+++ b/tests/unit/test_sft_tagger.py
@@ -21,7 +21,6 @@ def _traj(events=None, messages=None, model="anthropic/claude-opus-4.8:fal-ai"):
 
 def test_model_family():
     assert "model:opus" in tag_session(_traj(model="anthropic/claude-opus-4.8:fal-ai"))
-    assert "model:sonnet" in tag_session(_traj(model="example-sonnet-model"))
     assert "model:kimi" in tag_session(_traj(model="moonshotai/Kimi-K2.6"))
     assert "model:other" in tag_session(_traj(model="unknown-model-xyz"))
 


### PR DESCRIPTION
## Summary
- Remove Claude Opus 4.6, Claude Opus 4.7, and Claude Sonnet 4.6 from supported model constants and lists
- Keep Claude Opus 4.8 as the only Claude model option
- Stop downgrading research sub-calls from Opus to Sonnet; research now uses the normalized selected model
- Update tests and comments to remove stale Claude model references

## Tests
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check .`
- `uv run --frozen --extra dev pytest tests/unit/test_agent_model_gating.py tests/unit/test_cli_rendering.py tests/unit/test_cli_local_models.py tests/unit/test_sft_tagger.py`
- `npm run build`
- `npm run lint` (passes with existing warnings in `frontend/src/main.tsx` and `frontend/src/utils/logger.ts`)
