### PR TITLE
Implement paid model tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Notes:
 - Vite proxies `/api` and `/auth` to `http://localhost:7860`.
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
-- Production defaults to Claude Sonnet 4.6 through the HF Router (`anthropic/claude-sonnet-4-6:fal-ai`). Non-local LLM calls use `https://router.huggingface.co/v1` with Hugging Face tokens. Subsidized premium calls use the Space/operator `INFERENCE_TOKEN` plus `X-HF-Bill-To` from `HF_BILL_TO` (default `smolagents`); Opus and GPT-5.5 daily sessions are Pro-only, and after the daily allowance, premium calls bill the user's own HF token. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
+- Production defaults to Kimi K2.6 for non-Pro accounts and Opus 4.8 for Pro accounts through the HF Router. Non-local LLM calls use `https://router.huggingface.co/v1` with Hugging Face tokens. Opus and GPT-5.5 are paid-tier models: Pro users get `PRO_DAILY_SESSIONS` included paid-tier sessions per UTC day, and paid-tier usage outside that allowance bills the user's own HF token. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
 
 ## Development Checks
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ model prefixes).
 
 In the web app, non-Pro users default to Kimi K2.6. HF Pro users default to
 Claude Opus 4.8 and get `PRO_DAILY_SESSIONS` included paid-tier sessions per
-UTC day. Anyone can choose the paid tier, and usage outside the included Pro
+UTC day (default: 5). Anyone can choose the paid tier, and usage outside the included Pro
 allowance is billed to their Hugging Face account.
 
 #### Local models

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ ml-intern "fine-tune llama on my dataset"
 **Options:**
 
 ```bash
-ml-intern --model anthropic/claude-sonnet-4-6:fal-ai "your prompt"
 ml-intern --model moonshotai/Kimi-K2.6 "your prompt"
+ml-intern --model anthropic/claude-opus-4.8:fal-ai "your prompt"
 ml-intern --model openai/gpt-5.5:fal-ai "your prompt"
 ml-intern --model ollama/llama3.1:8b "your prompt"
 ml-intern --model vllm/meta-llama/Llama-3.1-8B-Instruct "your prompt"
@@ -68,8 +68,10 @@ Run `ml-intern` then `/model` to see the full list of suggested model ids
 (Claude, GPT, HF Router models like MiniMax, Kimi, GLM, DeepSeek, and local
 model prefixes).
 
-In the web app, subsidized daily sessions for Claude Opus 4.8 and GPT-5.5 are
-available only to HF Pro users; Claude Sonnet 4.6 is the default premium model.
+In the web app, non-Pro users default to Kimi K2.6. HF Pro users default to
+Claude Opus 4.8 and get `PRO_DAILY_SESSIONS` included paid-tier sessions per
+UTC day. Anyone can choose the paid tier, and usage outside the included Pro
+allowance is billed to their Hugging Face account.
 
 #### Local models
 
@@ -386,7 +388,7 @@ Edit `configs/cli_agent_config.json` for CLI defaults, or
 
 ```json
 {
-  "model_name": "anthropic/claude-sonnet-4-6:fal-ai",
+  "model_name": "moonshotai/Kimi-K2.6",
   "mcpServers": {
     "your-server-name": {
       "transport": "http",

--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -92,7 +92,7 @@ class CompactionFailedError(Exception):
     Typically means an individual preserved message (system, first user, or
     untouched tail) exceeds what truncation can fix in one pass. The caller
     must terminate the session; retrying produces an infinite loop that burns
-    premium inference budget.
+    paid-tier inference budget.
     """
 
 
@@ -133,7 +133,7 @@ async def summarize_messages(
     ``session`` is optional; when provided, the call is recorded via
     ``telemetry.record_llm_call`` so its cost lands in the session's
     ``total_cost_usd``. Without it, the call still happens but is
-    invisible in telemetry, which used to hide a significant share of premium
+    invisible in telemetry, which used to hide a significant share of paid-tier
     inference spend.
 
     Returns ``(summary_text, completion_tokens)``.
@@ -145,7 +145,7 @@ async def summarize_messages(
         model_name,
         hf_token,
         reasoning_effort="high",
-        bill_to_user=getattr(session, "premium_user_billed", False),
+        bill_to_user=getattr(session, "paid_user_billed", False),
     )
     llm_params = with_prompt_cache_params(
         llm_params, session_id=getattr(session, "session_id", None)
@@ -527,7 +527,7 @@ class ContextManager:
         a giant tool output stuck in the untouched tail) is too large for
         truncation to fix. The caller must terminate the session — retrying
         is what caused the 2026-05-03 infinite-compaction-loop pattern that
-        burned premium inference budget invisibly.
+        burned paid-tier inference budget invisibly.
         """
         if not self.needs_compaction:
             return
@@ -617,7 +617,7 @@ class ContextManager:
 
         # Hard verify: if compaction didn't bring us below the threshold even
         # after truncating oversized preserved messages, retrying just burns
-        # premium inference budget on the same useless compaction call. Raise so the
+        # paid-tier inference budget on the same useless compaction call. Raise so the
         # caller can terminate the session cleanly. Pre-2026-05-04, the
         # caller looped indefinitely (~$3/Opus retry) until the pod was
         # killed — invisible to the dataset because the session never

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -540,7 +540,7 @@ async def _heal_effort_and_rebuild_params(
         model,
         session.hf_token,
         reasoning_effort=session.effective_effort_for(model),
-        bill_to_user=getattr(session, "premium_user_billed", False),
+        bill_to_user=getattr(session, "paid_user_billed", False),
     )
 
 
@@ -591,7 +591,7 @@ async def _compact_and_notify(session: Session) -> None:
 
     Catches ``CompactionFailedError`` and ends the session cleanly instead
     of letting the caller retry. Pre-2026-05-04 the caller looped on
-    ContextWindowExceededError → compact → re-trigger, burning premium
+    ContextWindowExceededError → compact → re-trigger, burning paid-tier
     inference budget while the session never reached the upload path.
     """
     from agent.context_manager.manager import CompactionFailedError
@@ -1207,7 +1207,7 @@ class Handlers:
                     reasoning_effort=session.effective_effort_for(
                         session.config.model_name
                     ),
-                    bill_to_user=getattr(session, "premium_user_billed", False),
+                    bill_to_user=getattr(session, "paid_user_billed", False),
                 )
                 if session.stream:
                     llm_result = await _call_llm_streaming(

--- a/agent/core/effort_probe.py
+++ b/agent/core/effort_probe.py
@@ -188,7 +188,7 @@ async def probe_effort(
                 hf_token,
                 reasoning_effort=effort,
                 strict=True,
-                bill_to_user=getattr(session, "premium_user_billed", False),
+                bill_to_user=getattr(session, "paid_user_billed", False),
             )
         except UnsupportedEffortError:
             # Provider can't even accept this effort name (e.g. "max" on

--- a/agent/core/llm_params.py
+++ b/agent/core/llm_params.py
@@ -22,7 +22,7 @@ from agent.core.local_models import (
 )
 from agent.core.model_ids import (
     HF_ROUTER_BASE_URL,
-    is_premium_model_id,
+    is_paid_model_id,
     strip_huggingface_model_prefix,
 )
 
@@ -129,8 +129,8 @@ def _resolve_llm_params(
       3. huggingface_hub cache — ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` /
          local ``hf auth login`` cache.
 
-    Pass ``bill_to_user=True`` only after the daily subsidized allowance is
-    spent. Premium router ids then use the caller's own token, skip
+    Pass ``bill_to_user=True`` when paid-tier usage should be billed to the
+    caller. Paid router ids then use the caller's own token, skip
     ``INFERENCE_TOKEN``, and omit ``X-HF-Bill-To``.
     """
     normalized_model = strip_huggingface_model_prefix(model_name) or model_name
@@ -142,7 +142,7 @@ def _resolve_llm_params(
         return _resolve_local_model_params(normalized_model, reasoning_effort, strict)
 
     hf_model = normalized_model
-    bill_user = bill_to_user and is_premium_model_id(hf_model)
+    bill_user = bill_to_user and is_paid_model_id(hf_model)
     api_key = (
         resolve_hf_token(session_hf_token, include_cached=False)
         if bill_user

--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -4,27 +4,22 @@ HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 
 # Keep these as verbatim HF Router ids; version punctuation differs by model.
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
-CLAUDE_SONNET_46_MODEL_ID = "anthropic/claude-sonnet-4-6:fal-ai"
 GPT_55_MODEL_ID = "openai/gpt-5.5:fal-ai"
 KIMI_K26_MODEL_ID = "moonshotai/Kimi-K2.6"
 MINIMAX_M27_MODEL_ID = "MiniMaxAI/MiniMax-M2.7"
 GLM_51_MODEL_ID = "zai-org/GLM-5.1"
 DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:deepinfra"
 
-DEFAULT_MODEL_ID = CLAUDE_SONNET_46_MODEL_ID
+DEFAULT_FREE_MODEL_ID = KIMI_K26_MODEL_ID
+DEFAULT_PAID_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
+DEFAULT_MODEL_ID = DEFAULT_FREE_MODEL_ID
 
-PREMIUM_MODEL_IDS = {
-    CLAUDE_SONNET_46_MODEL_ID,
+PAID_MODEL_IDS = {
     CLAUDE_OPUS_48_MODEL_ID,
     GPT_55_MODEL_ID,
 }
 
-PRO_ONLY_PREMIUM_MODEL_IDS = {
-    CLAUDE_OPUS_48_MODEL_ID,
-    GPT_55_MODEL_ID,
-}
-
-KNOWN_ROUTER_MODEL_IDS = PREMIUM_MODEL_IDS | {
+KNOWN_ROUTER_MODEL_IDS = PAID_MODEL_IDS | {
     KIMI_K26_MODEL_ID,
     MINIMAX_M27_MODEL_ID,
     GLM_51_MODEL_ID,
@@ -39,14 +34,9 @@ def strip_huggingface_model_prefix(model_id: str | None) -> str | None:
     return model_id.removeprefix("huggingface/")
 
 
-def is_premium_model_id(model_id: str | None) -> bool:
+def is_paid_model_id(model_id: str | None) -> bool:
     normalized = strip_huggingface_model_prefix(model_id)
-    return bool(normalized and normalized in PREMIUM_MODEL_IDS)
-
-
-def is_pro_only_premium_model_id(model_id: str | None) -> bool:
-    normalized = strip_huggingface_model_prefix(model_id)
-    return bool(normalized and normalized in PRO_ONLY_PREMIUM_MODEL_IDS)
+    return bool(normalized and normalized in PAID_MODEL_IDS)
 
 
 def is_known_router_model_id(model_id: str | None) -> bool:

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -28,7 +28,6 @@ from agent.core.local_models import (
 )
 from agent.core.model_ids import (
     CLAUDE_OPUS_48_MODEL_ID,
-    CLAUDE_SONNET_46_MODEL_ID,
     GPT_55_MODEL_ID,
     KIMI_K26_MODEL_ID,
     strip_huggingface_model_prefix,
@@ -40,11 +39,10 @@ from agent.core.model_ids import (
 # ":cheapest", ":preferred", or ":<provider>" to override the default routing
 # policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
-    {"id": CLAUDE_SONNET_46_MODEL_ID, "label": "Claude Sonnet 4.6"},
     {"id": CLAUDE_OPUS_48_MODEL_ID, "label": "Claude Opus 4.8"},
     {"id": GPT_55_MODEL_ID, "label": "GPT-5.5"},
-    {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": KIMI_K26_MODEL_ID, "label": "Kimi K2.6"},
+    {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
     {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},
     {"id": "deepseek-ai/DeepSeek-V4-Pro:deepinfra", "label": "DeepSeek V4 Pro"},
 ]

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -119,11 +119,11 @@ class Session:
         self.session_id = session_id or str(uuid.uuid4())
         self.config = config
         self.is_running = True
-        # Billing mode for premium HF Router usage. The backend quota gate
-        # flips this on once the user is past their subsidized daily allowance,
-        # so the LLM call bills the user's own HF token instead of the Space.
+        # Billing mode for paid-tier HF Router usage. The backend quota gate
+        # flips this on when usage should bill the user's own HF token instead
+        # of the Space.
         # Persisted with the session so it survives idle-reclaim.
-        self.premium_user_billed: bool = False
+        self.paid_user_billed: bool = False
         self.current_plan: list[dict[str, str]] = []
         self._cancelled = asyncio.Event()
         self.pending_approval: Optional[dict[str, Any]] = None

--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -174,9 +174,9 @@ class MongoSessionStore(NoopSessionStore):
         message_count: int = 0,
         turn_count: int = 0,
         pending_approval: list[dict[str, Any]] | None = None,
-        claude_counted: bool = False,
-        claude_counted_day: str | None = None,
-        premium_user_billed: bool = False,
+        paid_counted: bool = False,
+        paid_counted_day: str | None = None,
+        paid_user_billed: bool = False,
         notification_destinations: list[str] | None = None,
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
@@ -207,9 +207,9 @@ class MongoSessionStore(NoopSessionStore):
                     "message_count": message_count,
                     "turn_count": turn_count,
                     "pending_approval": pending_approval or [],
-                    "claude_counted": claude_counted,
-                    "claude_counted_day": claude_counted_day,
-                    "premium_user_billed": premium_user_billed,
+                    "paid_counted": paid_counted,
+                    "paid_counted_day": paid_counted_day,
+                    "paid_user_billed": paid_user_billed,
                     "notification_destinations": notification_destinations or [],
                     "auto_approval_enabled": auto_approval_enabled,
                     "auto_approval_cost_cap_usd": auto_approval_cost_cap_usd,
@@ -231,9 +231,9 @@ class MongoSessionStore(NoopSessionStore):
         status: str = "active",
         turn_count: int = 0,
         pending_approval: list[dict[str, Any]] | None = None,
-        claude_counted: bool = False,
-        claude_counted_day: str | None = None,
-        premium_user_billed: bool = False,
+        paid_counted: bool = False,
+        paid_counted_day: str | None = None,
+        paid_user_billed: bool = False,
         created_at: datetime | None = None,
         notification_destinations: list[str] | None = None,
         auto_approval_enabled: bool = False,
@@ -257,9 +257,9 @@ class MongoSessionStore(NoopSessionStore):
             message_count=len(messages),
             turn_count=turn_count,
             pending_approval=pending_approval,
-            claude_counted=claude_counted,
-            claude_counted_day=claude_counted_day,
-            premium_user_billed=premium_user_billed,
+            paid_counted=paid_counted,
+            paid_counted_day=paid_counted_day,
+            paid_user_billed=paid_user_billed,
             notification_destinations=notification_destinations,
             auto_approval_enabled=auto_approval_enabled,
             auto_approval_cost_cap_usd=auto_approval_cost_cap_usd,
@@ -412,16 +412,18 @@ class MongoSessionStore(NoopSessionStore):
     async def get_quota(self, user_id: str, day: str) -> int | None:
         if not self._ready():
             return None
-        doc = await self.db.claude_quotas.find_one({"_id": f"{user_id}:{day}"})
+        doc = await self.db.paid_tier_quotas.find_one({"_id": f"{user_id}:{day}"})
         return int(doc.get("count", 0)) if doc else 0
 
     async def try_increment_quota(self, user_id: str, day: str, cap: int) -> int | None:
         if not self._ready():
             return None
+        if cap <= 0:
+            return None
         key = f"{user_id}:{day}"
         now = _now()
         try:
-            await self.db.claude_quotas.insert_one(
+            await self.db.paid_tier_quotas.insert_one(
                 {
                     "_id": key,
                     "user_id": user_id,
@@ -433,7 +435,7 @@ class MongoSessionStore(NoopSessionStore):
             return 1
         except DuplicateKeyError:
             pass
-        doc = await self.db.claude_quotas.find_one_and_update(
+        doc = await self.db.paid_tier_quotas.find_one_and_update(
             {"_id": key, "count": {"$lt": cap}},
             {"$inc": {"count": 1}, "$set": {"updated_at": now}},
             return_document=ReturnDocument.AFTER,
@@ -443,7 +445,7 @@ class MongoSessionStore(NoopSessionStore):
     async def refund_quota(self, user_id: str, day: str) -> None:
         if not self._ready():
             return
-        await self.db.claude_quotas.update_one(
+        await self.db.paid_tier_quotas.update_one(
             {"_id": f"{user_id}:{day}", "count": {"$gt": 0}},
             {"$inc": {"count": -1}, "$set": {"updated_at": _now()}},
         )

--- a/agent/main.py
+++ b/agent/main.py
@@ -85,7 +85,7 @@ def _validate_cli_model_override(model: str) -> str:
     if not model_switcher.is_valid_model_id(model):
         raise ValueError(
             "Invalid model id. Use an HF Router id like "
-            "'anthropic/claude-sonnet-4-6:fal-ai' or a supported local prefix."
+            "'moonshotai/Kimi-K2.6' or a supported local prefix."
         )
     return model.removeprefix("huggingface/")
 

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -258,7 +258,7 @@ async def research_handler(
         research_model,
         getattr(session, "hf_token", None),
         reasoning_effort=_capped,
-        bill_to_user=getattr(session, "premium_user_billed", False),
+        bill_to_user=getattr(session, "paid_user_billed", False),
     )
     llm_params = with_prompt_cache_params(
         llm_params, session_id=getattr(session, "session_id", None)

--- a/backend/models.py
+++ b/backend/models.py
@@ -105,8 +105,8 @@ class SessionInfo(BaseModel):
     auto_approval: SessionAutoApprovalInfo = Field(
         default_factory=SessionAutoApprovalInfo
     )
-    premium_user_billed: bool = False
-    premium_quota_counted: bool = False
+    paid_user_billed: bool = False
+    paid_quota_counted: bool = False
 
 
 class SessionNotificationsRequest(BaseModel):

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -57,13 +57,12 @@ from agent.core.llm_params import _resolve_llm_params
 from agent.core.model_ids import (
     CLAUDE_OPUS_48_MODEL_ID,
     DEEPSEEK_V4_PRO_MODEL_ID,
-    DEFAULT_MODEL_ID,
+    DEFAULT_FREE_MODEL_ID as MODEL_DEFAULT_FREE_ID,
+    DEFAULT_PAID_MODEL_ID as MODEL_DEFAULT_PAID_ID,
     GLM_51_MODEL_ID,
     GPT_55_MODEL_ID,
-    KIMI_K26_MODEL_ID,
     MINIMAX_M27_MODEL_ID,
-    is_premium_model_id,
-    is_pro_only_premium_model_id,
+    is_paid_model_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,42 +70,35 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["agent"])
 _background_teardown_tasks: set[asyncio.Task] = set()
 
-DEFAULT_PREMIUM_MODEL_ID = DEFAULT_MODEL_ID
+DEFAULT_PAID_MODEL_ID = MODEL_DEFAULT_PAID_ID
 DEFAULT_OPUS_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 DEFAULT_GPT_MODEL_ID = GPT_55_MODEL_ID
-DEFAULT_FREE_MODEL_ID = KIMI_K26_MODEL_ID
+DEFAULT_FREE_MODEL_ID = MODEL_DEFAULT_FREE_ID
 DATASET_UPLOAD_MULTIPART_SLACK_BYTES = 1024 * 1024
 
 
 def _available_models() -> list[dict[str, Any]]:
     models = [
         {
-            "id": DEFAULT_PREMIUM_MODEL_ID,
-            "label": "Claude Sonnet 4.6",
-            "provider": "huggingface",
-            "tier": "pro",
-            "recommended": True,
-            "minimum_plan": "free",
-        },
-        {
             "id": DEFAULT_OPUS_MODEL_ID,
             "label": "Claude Opus 4.8",
             "provider": "huggingface",
-            "tier": "pro",
-            "minimum_plan": "pro",
+            "tier": "paid",
+            "minimum_plan": "free",
         },
         {
             "id": DEFAULT_GPT_MODEL_ID,
             "label": "GPT-5.5",
             "provider": "huggingface",
-            "tier": "pro",
-            "minimum_plan": "pro",
+            "tier": "paid",
+            "minimum_plan": "free",
         },
         {
             "id": DEFAULT_FREE_MODEL_ID,
             "label": "Kimi K2.6",
             "provider": "huggingface",
             "tier": "free",
+            "recommended": True,
             "minimum_plan": "free",
         },
         {
@@ -137,118 +129,57 @@ def _available_models() -> list[dict[str, Any]]:
 AVAILABLE_MODELS = _available_models()
 
 
-def _is_premium_model(model_id: str) -> bool:
-    return is_premium_model_id(model_id)
+def _is_paid_model(model_id: str) -> bool:
+    return is_paid_model_id(model_id)
 
 
-def _is_pro_only_premium_model(model_id: str | None) -> bool:
-    return is_pro_only_premium_model_id(model_id)
-
-
-def _model_unavailable_for_plan(model_id: str | None, plan: str | None) -> bool:
-    return plan != "pro" and _is_pro_only_premium_model(model_id)
-
-
-def _reject_model_unavailable_for_plan(
-    model_id: str | None,
-    user: dict[str, Any],
-) -> None:
-    plan = user.get("plan", "free")
-    if not _model_unavailable_for_plan(model_id, plan):
-        return
-    raise HTTPException(
-        status_code=403,
-        detail={
-            "error": "model_requires_pro",
-            "plan": plan,
-            "model": model_id,
-            "message": "Claude Opus 4.8 and GPT-5.5 daily sessions require HF Pro.",
-        },
-    )
-
-
-def _is_user_billed(model_id: str) -> bool:
-    return _is_premium_model(model_id)
+def _default_model_for_plan(plan: str | None) -> str:
+    return DEFAULT_PAID_MODEL_ID if plan == "pro" else DEFAULT_FREE_MODEL_ID
 
 
 async def _model_override_for_new_session(
     request: Request,
     requested_model: str | None,
+    user: dict[str, Any],
 ) -> str | None:
     """Return the model override to use when creating a new session.
 
-    Explicit model requests are allowed and charged at message-submit time
-    when premium. Empty requests use the configured default model.
+    Explicit model requests are allowed and charged at message-submit time when
+    paid. Empty requests use the plan-specific default model.
     """
-    return requested_model
+    return requested_model or _default_model_for_plan(user.get("plan", "free"))
 
 
-def _premium_cap_message(plan: str) -> str:
-    """Over-allowance message for a premium model that can't fall back to user
-    billing. Defensive: every current premium model is user-billable and
-    overflows to the user's own HF account instead of reaching this.
-    """
-    if plan == "pro":
-        return (
-            "Daily premium model limit reached. Use a free model and try premium "
-            "models again tomorrow."
-        )
-    return (
-        "Daily premium model limit reached. Upgrade to HF Pro for "
-        f"{user_quotas.CLAUDE_PRO_DAILY}/day or use a free model."
-    )
-
-
-async def _enforce_premium_model_quota(
+async def _enforce_paid_model_quota(
     user: dict[str, Any],
     agent_session: AgentSession,
 ) -> None:
-    """Charge the user's daily premium-model quota on first use in a session.
+    """Charge the user's daily paid-tier quota on first use in a session.
 
     Runs at *message-submit* time, not session-create time — so spinning up a
-    premium-model session to look around doesn't burn quota. The
-    ``claude_counted_day`` flag on ``AgentSession`` guards against re-counting
+    paid-tier session to look around doesn't burn quota. The
+    ``paid_counted_day`` flag on ``AgentSession`` guards against re-counting
     the same session on the same day, while still counting old sessions when
     they are used again on a later day.
 
-    Subsidizes the daily allowance (free = 2 for default premium, pro = 20
-    across premium models), organization-billed through the HF Router. Opus and
-    GPT-5.5 are pro-only before quota is charged. Past the allowance, premium
-    router models flip the session to ``premium_user_billed`` so the call bills
-    the user's own HF token instead of blocking. No-ops when the model isn't
-    premium or when this session's billing has already been decided for today.
+    Pro users get ``PRO_DAILY_SESSIONS`` organization-billed paid-tier sessions
+    per UTC day. Non-Pro users and Pro users past that allowance are billed to
+    their own Hugging Face account. No-ops when the model isn't paid-tier or
+    when this session's billing has already been decided for today.
     """
     model_name = agent_session.session.config.model_name
-    if not _is_premium_model(model_name):
+    if not _is_paid_model(model_name):
         return
-    _reject_model_unavailable_for_plan(model_name, user)
     quota_day = user_quotas.current_quota_day()
-    if agent_session.claude_counted and agent_session.claude_counted_day == quota_day:
+    if agent_session.paid_counted and agent_session.paid_counted_day == quota_day:
         return
     user_id = user["user_id"]
     plan = user.get("plan", "free")
     cap = user_quotas.daily_cap_for(plan)
-    within_allowance = await user_quotas.try_increment_claude(user_id, cap) is not None
-    if not within_allowance:
-        if not _is_user_billed(model_name):
-            raise HTTPException(
-                status_code=429,
-                detail={
-                    "error": "premium_model_daily_cap",
-                    "plan": plan,
-                    "cap": cap,
-                    "message": _premium_cap_message(plan),
-                },
-            )
-        # Past the subsidized allowance on a user-billable model: bill the
-        # user's own HF (OAuth) token for this session instead of blocking.
-        agent_session.session.premium_user_billed = True
-    else:
-        # A session that overflowed on a previous day can use today's
-        # subsidized allowance again if quota is available.
-        agent_session.session.premium_user_billed = False
-    agent_session.claude_counted = True
-    agent_session.claude_counted_day = quota_day
+    within_allowance = await user_quotas.try_increment_paid(user_id, cap) is not None
+    agent_session.session.paid_user_billed = not within_allowance
+    agent_session.paid_counted = True
+    agent_session.paid_counted_day = quota_day
     await session_manager.persist_session_snapshot(agent_session)
 
 
@@ -412,6 +343,10 @@ async def get_model() -> dict:
     """Get current model and available models. No auth required."""
     return {
         "current": session_manager.config.model_name,
+        "defaults": {
+            "free": DEFAULT_FREE_MODEL_ID,
+            "pro": DEFAULT_PAID_MODEL_ID,
+        },
         "available": AVAILABLE_MODELS,
     }
 
@@ -494,7 +429,7 @@ async def create_session(
     behalf of the user.
 
     Optional body ``{"model"?: <id>}`` selects the session's LLM; unknown
-    ids are rejected (400). The premium-model quota runs at message-submit
+    ids are rejected (400). The paid-tier quota runs at message-submit
     time, not here — spinning up a session to look around is free.
 
     Returns 503 if the server or user has reached the session limit.
@@ -502,7 +437,7 @@ async def create_session(
     # Extract the user's HF token (Bearer header, HttpOnly cookie, or env var)
     hf_token = resolve_hf_request_token(request)
 
-    # Optional model override. Empty body falls back to the config default.
+    # Optional model override. Empty body falls back to the plan-specific default.
     model: str | None = None
     try:
         body = await request.json()
@@ -514,10 +449,8 @@ async def create_session(
     valid_ids = {m["id"] for m in AVAILABLE_MODELS}
     if model and model not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
-    _reject_model_unavailable_for_plan(model, user)
 
-    # Empty requests use the configured default, which may be premium.
-    model = await _model_override_for_new_session(request, model)
+    model = await _model_override_for_new_session(request, model, user)
 
     try:
         session_id = await session_manager.create_session(
@@ -533,7 +466,7 @@ async def create_session(
     return SessionResponse(
         session_id=session_id,
         ready=True,
-        model=model or session_manager.config.model_name,
+        model=model,
     )
 
 
@@ -547,7 +480,7 @@ async def restore_session_summary(
     session's context as a user-role system note.
 
     Optional ``"model"`` in the body overrides the session's LLM. The
-    premium-model quota runs before summarization because that call uses the
+    paid-tier quota runs before summarization because that call uses the
     session model immediately.
     """
     messages = body.get("messages")
@@ -560,9 +493,8 @@ async def restore_session_summary(
     valid_ids = {m["id"] for m in AVAILABLE_MODELS}
     if model and model not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model}")
-    _reject_model_unavailable_for_plan(model, user)
 
-    model = await _model_override_for_new_session(request, model)
+    model = await _model_override_for_new_session(request, model, user)
 
     try:
         session_id = await session_manager.create_session(
@@ -581,7 +513,7 @@ async def restore_session_summary(
         request,
         preload_sandbox=False,
     )
-    await _enforce_premium_model_quota(user, agent_session)
+    await _enforce_paid_model_quota(user, agent_session)
 
     try:
         summarized = await session_manager.seed_from_summary(session_id, messages)
@@ -598,7 +530,7 @@ async def restore_session_summary(
     return SessionResponse(
         session_id=session_id,
         ready=True,
-        model=model or session_manager.config.model_name,
+        model=model,
     )
 
 
@@ -623,7 +555,7 @@ async def set_session_model(
 
     Takes effect on the next LLM call in that session — other sessions
     (including other browser tabs) are unaffected. Model switches don't
-    charge quota — the premium-model quota only fires at message-submit time.
+    charge quota — the paid-tier quota only fires at message-submit time.
     """
     agent_session = await _check_session_access(session_id, user, request)
     model_id = body.get("model")
@@ -632,7 +564,6 @@ async def set_session_model(
     valid_ids = {m["id"] for m in AVAILABLE_MODELS}
     if model_id not in valid_ids:
         raise HTTPException(status_code=400, detail=f"Unknown model: {model_id}")
-    _reject_model_unavailable_for_plan(model_id, user)
     if not agent_session:
         raise HTTPException(status_code=404, detail="Session not found")
     await session_manager.update_session_model(session_id, model_id)
@@ -767,16 +698,16 @@ async def set_session_yolo(
 
 @router.get("/user/quota")
 async def get_user_quota(user: dict = Depends(get_current_user)) -> dict:
-    """Return the user's plan tier and today's premium-model quota state."""
+    """Return the user's plan tier and today's paid-tier quota state."""
     plan = user.get("plan", "free")
-    used = await user_quotas.get_claude_used_today(user["user_id"])
+    used = await user_quotas.get_paid_used_today(user["user_id"])
     cap = user_quotas.daily_cap_for(plan)
     remaining = max(0, cap - used)
     return {
         "plan": plan,
-        "premium_used_today": used,
-        "premium_daily_cap": cap,
-        "premium_remaining": remaining,
+        "paid_used_today": used,
+        "paid_daily_cap": cap,
+        "paid_remaining": remaining,
     }
 
 
@@ -863,7 +794,7 @@ async def submit_input(
         body = SubmitRequest(**payload)
     except ValidationError as exc:
         raise RequestValidationError(exc.errors()) from exc
-    await _enforce_premium_model_quota(user, agent_session)
+    await _enforce_paid_model_quota(user, agent_session)
     success = await session_manager.submit_user_input(body.session_id, body.text)
     if not success:
         raise HTTPException(status_code=404, detail="Session not found or inactive")
@@ -915,12 +846,12 @@ async def chat_sse(
     text = body.get("text")
     approvals = body.get("approvals")
 
-    # Gate user-message sends against the daily premium-model quota. Approvals are
+    # Gate user-message sends against the daily paid-tier quota. Approvals are
     # continuations of an in-progress turn, so the relevant quota decision was
     # made when that user message was submitted.
     if text is not None and not approvals:
         try:
-            await _enforce_premium_model_quota(user, agent_session)
+            await _enforce_paid_model_quota(user, agent_session)
         except HTTPException:
             broadcaster.unsubscribe(sub_id)
             raise

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -14,7 +14,6 @@ from agent.config import load_config
 from agent.core.agent_loop import process_submission
 from agent.core.model_ids import (
     DEFAULT_MODEL_ID,
-    KIMI_K26_MODEL_ID,
     is_known_router_model_id,
     strip_huggingface_model_prefix,
 )
@@ -113,10 +112,10 @@ class AgentSession:
     is_reaping: bool = False
     broadcaster: Any = None
     title: str | None = None
-    # True once this session has ever been counted against premium quota.
-    # claude_counted_day decides whether it has already consumed today's cap.
-    claude_counted: bool = False
-    claude_counted_day: str | None = None
+    # True once this session has ever been counted against paid-tier quota.
+    # paid_counted_day decides whether it has already consumed today's cap.
+    paid_counted: bool = False
+    paid_counted_day: str | None = None
 
 
 def _quota_day_today() -> str:
@@ -125,14 +124,14 @@ def _quota_day_today() -> str:
 
 def _quota_counted_today(agent_session: AgentSession) -> bool:
     return (
-        agent_session.claude_counted
-        and agent_session.claude_counted_day == _quota_day_today()
+        agent_session.paid_counted
+        and agent_session.paid_counted_day == _quota_day_today()
     )
 
 
-def _premium_user_billed_today(agent_session: AgentSession) -> bool:
+def _paid_user_billed_today(agent_session: AgentSession) -> bool:
     return bool(
-        getattr(agent_session.session, "premium_user_billed", False)
+        getattr(agent_session.session, "paid_user_billed", False)
         and _quota_counted_today(agent_session)
     )
 
@@ -232,22 +231,20 @@ class SessionManager:
     def _model_from_saved_metadata(
         model: str | None,
         *,
-        premium_user_billed: bool,
-        claude_counted: bool,
+        paid_user_billed: bool,
+        paid_counted: bool,
     ) -> tuple[str, bool, bool]:
         normalized = strip_huggingface_model_prefix(model)
         if normalized and is_known_router_model_id(normalized):
-            return normalized, premium_user_billed, claude_counted
+            return normalized, paid_user_billed, paid_counted
 
-        fallback_model = KIMI_K26_MODEL_ID if premium_user_billed else DEFAULT_MODEL_ID
+        fallback_model = DEFAULT_MODEL_ID
         logger.warning(
             "Saved session model %r failed validation; using %r",
             model,
             fallback_model,
         )
-        if fallback_model == KIMI_K26_MODEL_ID:
-            return fallback_model, False, False
-        return fallback_model, premium_user_billed, claude_counted
+        return fallback_model, False, False
 
     def _create_session_sync(
         self,
@@ -618,10 +615,10 @@ class SessionManager:
                 pending_approval=self._serialize_pending_approval(
                     agent_session.session
                 ),
-                claude_counted=agent_session.claude_counted,
-                claude_counted_day=agent_session.claude_counted_day,
-                premium_user_billed=getattr(
-                    agent_session.session, "premium_user_billed", False
+                paid_counted=agent_session.paid_counted,
+                paid_counted_day=agent_session.paid_counted_day,
+                paid_user_billed=getattr(
+                    agent_session.session, "paid_user_billed", False
                 ),
                 created_at=agent_session.created_at,
                 notification_destinations=list(
@@ -711,18 +708,16 @@ class SessionManager:
 
         from litellm import Message
 
-        model, premium_user_billed, claude_counted = self._model_from_saved_metadata(
+        model, paid_user_billed, paid_counted = self._model_from_saved_metadata(
             meta.get("model") or self.config.model_name,
-            premium_user_billed=bool(meta.get("premium_user_billed", False)),
-            claude_counted=bool(meta.get("claude_counted")),
+            paid_user_billed=bool(meta.get("paid_user_billed", False)),
+            paid_counted=bool(meta.get("paid_counted")),
         )
-        claude_counted_day = (
-            str(meta.get("claude_counted_day"))
-            if meta.get("claude_counted_day")
-            else None
+        paid_counted_day = (
+            str(meta.get("paid_counted_day")) if meta.get("paid_counted_day") else None
         )
-        if not claude_counted:
-            claude_counted_day = None
+        if not paid_counted:
+            paid_counted_day = None
         event_queue: asyncio.Queue = asyncio.Queue()
         submission_queue: asyncio.Queue = asyncio.Queue()
         tool_router, session = await asyncio.to_thread(
@@ -781,7 +776,7 @@ class SessionManager:
         self._restore_pending_approval(session, meta.get("pending_approval") or [])
         session.turn_count = int(meta.get("turn_count") or 0)
         session.auto_approval_enabled = bool(meta.get("auto_approval_enabled", False))
-        session.premium_user_billed = premium_user_billed
+        session.paid_user_billed = paid_user_billed
         raw_cap = meta.get("auto_approval_cost_cap_usd")
         session.auto_approval_cost_cap_usd = (
             float(raw_cap) if isinstance(raw_cap, int | float) else None
@@ -805,8 +800,8 @@ class SessionManager:
             created_at=created_at,
             is_active=True,
             is_processing=False,
-            claude_counted=claude_counted,
-            claude_counted_day=claude_counted_day,
+            paid_counted=paid_counted,
+            paid_counted_day=paid_counted_day,
             title=meta.get("title"),
         )
         started = await self._start_agent_session(
@@ -1533,8 +1528,8 @@ class SessionManager:
                 agent_session.session.notification_destinations
             ),
             "auto_approval": self._auto_approval_summary(agent_session.session),
-            "premium_user_billed": _premium_user_billed_today(agent_session),
-            "premium_quota_counted": _quota_counted_today(agent_session),
+            "paid_user_billed": _paid_user_billed_today(agent_session),
+            "paid_quota_counted": _quota_counted_today(agent_session),
         }
 
     def set_notification_destinations(
@@ -1589,8 +1584,8 @@ class SessionManager:
                     created_at_str = str(created_at or datetime.utcnow().isoformat())
                 pending = self._pending_docs_for_api(row.get("pending_approval") or [])
                 quota_counted_today = (
-                    bool(row.get("claude_counted", False))
-                    and row.get("claude_counted_day") == _quota_day_today()
+                    bool(row.get("paid_counted", False))
+                    and row.get("paid_counted_day") == _quota_day_today()
                 )
                 results.append(
                     {
@@ -1603,11 +1598,10 @@ class SessionManager:
                         "pending_approval": pending or None,
                         "model": row.get("model"),
                         "title": row.get("title"),
-                        "premium_user_billed": bool(
-                            row.get("premium_user_billed", False)
-                            and quota_counted_today
+                        "paid_user_billed": bool(
+                            row.get("paid_user_billed", False) and quota_counted_today
                         ),
-                        "premium_quota_counted": quota_counted_today,
+                        "paid_quota_counted": quota_counted_today,
                         "notification_destinations": row.get(
                             "notification_destinations"
                         )

--- a/backend/user_quotas.py
+++ b/backend/user_quotas.py
@@ -25,7 +25,7 @@ from agent.core.session_persistence import (
     _reset_store_for_tests,
 )
 
-PRO_DAILY_SESSIONS: int = int(os.environ.get("PRO_DAILY_SESSIONS", "20"))
+PRO_DAILY_SESSIONS: int = int(os.environ.get("PRO_DAILY_SESSIONS", "5"))
 
 # user_id -> (day_utc_iso, count_for_that_day)
 _paid_counts: dict[str, tuple[str, int]] = {}

--- a/backend/user_quotas.py
+++ b/backend/user_quotas.py
@@ -1,21 +1,18 @@
-"""Daily quota for subsidized premium model sessions.
+"""Daily quota for subsidized paid-tier model sessions.
 
-Tracks per-user premium model session starts against a daily cap derived from
+Tracks per-user paid-tier model session starts against a daily cap derived from
 the user's HF plan. MongoDB is the source of truth when configured; the
 in-process dict remains the fallback for local/dev/test runs.
 
-The public names still say ``claude`` because this quota bucket originally
-only covered Claude and the persisted session field uses that name.
-
-Unit: first premium-model submit per session per UTC day, not raw messages. A
-user who sends with an allowed premium model in any session consumes one quota
+Unit: first paid-tier submit per session per UTC day, not raw messages. A
+user who sends with a paid-tier model in any session consumes one quota
 point for that day; continuing the same session on the same day doesn't
-(`AgentSession.claude_counted_day` guards that). Model-level plan gates live in
-``backend.routes.agent``; this module only tracks the per-plan daily cap.
+(`AgentSession.paid_counted_day` guards that). Model-level tier handling lives
+in ``backend.routes.agent``; this module only tracks the per-plan daily cap.
 
 Cap tiers:
-  free user   → CLAUDE_FREE_DAILY (2) for the default premium model
-  pro user    → CLAUDE_PRO_DAILY  (20)
+  free user   → 0 included paid-tier sessions
+  pro user    → PRO_DAILY_SESSIONS
 """
 
 import asyncio
@@ -28,11 +25,10 @@ from agent.core.session_persistence import (
     _reset_store_for_tests,
 )
 
-CLAUDE_FREE_DAILY: int = int(os.environ.get("CLAUDE_FREE_DAILY", "2"))
-CLAUDE_PRO_DAILY: int = int(os.environ.get("CLAUDE_PRO_DAILY", "20"))
+PRO_DAILY_SESSIONS: int = int(os.environ.get("PRO_DAILY_SESSIONS", "20"))
 
 # user_id -> (day_utc_iso, count_for_that_day)
-_claude_counts: dict[str, tuple[str, int]] = {}
+_paid_counts: dict[str, tuple[str, int]] = {}
 _lock = asyncio.Lock()
 
 
@@ -41,36 +37,36 @@ def _today() -> str:
 
 
 def current_quota_day() -> str:
-    """Return the UTC date key used for today's premium-model quota bucket."""
+    """Return the UTC date key used for today's paid-tier quota bucket."""
     return _today()
 
 
 def daily_cap_for(plan: str | None) -> int:
-    """Return the daily Claude-session cap for the given plan."""
-    return CLAUDE_PRO_DAILY if plan == "pro" else CLAUDE_FREE_DAILY
+    """Return the daily included paid-tier session cap for the given plan."""
+    return PRO_DAILY_SESSIONS if plan == "pro" else 0
 
 
-async def get_claude_used_today(user_id: str) -> int:
-    """Return today's Claude session count for the user (0 if none / stale day)."""
+async def get_paid_used_today(user_id: str) -> int:
+    """Return today's paid-tier session count for the user."""
     store = get_session_store()
     if getattr(store, "enabled", False):
         db_count = await store.get_quota(user_id, _today())
         return db_count or 0
 
     async with _lock:
-        entry = _claude_counts.get(user_id)
+        entry = _paid_counts.get(user_id)
         if entry is None:
             return 0
         day, count = entry
         if day != _today():
             # Stale day — drop the entry so the first increment starts fresh.
-            _claude_counts.pop(user_id, None)
+            _paid_counts.pop(user_id, None)
             return 0
         return count
 
 
-async def increment_claude(user_id: str) -> int:
-    """Bump today's Claude session count for the user. Returns the new value."""
+async def increment_paid(user_id: str) -> int:
+    """Bump today's paid-tier session count for the user. Returns the new value."""
     store = get_session_store()
     if getattr(store, "enabled", False):
         db_count = await store.try_increment_quota(user_id, _today(), cap=10**9)
@@ -78,15 +74,15 @@ async def increment_claude(user_id: str) -> int:
 
     async with _lock:
         today = _today()
-        day, count = _claude_counts.get(user_id, (today, 0))
+        day, count = _paid_counts.get(user_id, (today, 0))
         if day != today:
             count = 0
         count += 1
-        _claude_counts[user_id] = (today, count)
+        _paid_counts[user_id] = (today, count)
         return count
 
 
-async def try_increment_claude(user_id: str, cap: int) -> int | None:
+async def try_increment_paid(user_id: str, cap: int) -> int | None:
     """Atomically bump today's count if below *cap*.
 
     Returns the new count, or None when the user is already at the cap.
@@ -97,17 +93,17 @@ async def try_increment_claude(user_id: str, cap: int) -> int | None:
 
     async with _lock:
         today = _today()
-        day, count = _claude_counts.get(user_id, (today, 0))
+        day, count = _paid_counts.get(user_id, (today, 0))
         if day != today:
             count = 0
         if count >= cap:
             return None
         count += 1
-        _claude_counts[user_id] = (today, count)
+        _paid_counts[user_id] = (today, count)
         return count
 
 
-async def refund_claude(user_id: str) -> None:
+async def refund_paid(user_id: str) -> None:
     """Decrement today's count — used when session creation fails after a successful gate."""
     store = get_session_store()
     if getattr(store, "enabled", False):
@@ -115,21 +111,21 @@ async def refund_claude(user_id: str) -> None:
         return
 
     async with _lock:
-        entry = _claude_counts.get(user_id)
+        entry = _paid_counts.get(user_id)
         if entry is None:
             return
         day, count = entry
         if day != _today():
-            _claude_counts.pop(user_id, None)
+            _paid_counts.pop(user_id, None)
             return
         new_count = max(0, count - 1)
         if new_count == 0:
-            _claude_counts.pop(user_id, None)
+            _paid_counts.pop(user_id, None)
         else:
-            _claude_counts[user_id] = (day, new_count)
+            _paid_counts[user_id] = (day, new_count)
 
 
 def _reset_for_tests() -> None:
     """Test-only: clear the in-memory store."""
-    _claude_counts.clear()
+    _paid_counts.clear()
     _reset_store_for_tests(NoopSessionStore())

--- a/configs/cli_agent_config.json
+++ b/configs/cli_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "anthropic/claude-sonnet-4-6:fal-ai",
+  "model_name": "moonshotai/Kimi-K2.6",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "share_traces": true,

--- a/configs/frontend_agent_config.json
+++ b/configs/frontend_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-anthropic/claude-sonnet-4-6:fal-ai}",
+  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-moonshotai/Kimi-K2.6}",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "share_traces": true,

--- a/frontend/src/components/Chat/BillingBanner.tsx
+++ b/frontend/src/components/Chat/BillingBanner.tsx
@@ -1,8 +1,7 @@
 /**
- * Shown above the composer when the active session's premium usage is being
- * billed to the user's own HF account — i.e. they're past the subsidized daily
- * allowance and the session flipped to `premium_user_billed`. Dismissible once
- * per day so we stay transparent about billing without nagging every session.
+ * Shown above the composer when the active session's paid-tier usage is being
+ * billed to the user's own HF account. Dismissible once per day so we stay
+ * transparent about billing without nagging every session.
  */
 import { useState } from 'react';
 import { Box, Link, Typography } from '@mui/material';
@@ -47,7 +46,7 @@ export default function BillingBanner() {
           variant="caption"
           sx={{ flex: 1, color: 'var(--text)', fontSize: '0.78rem', lineHeight: 1.5 }}
         >
-          You've used today's subsidized premium sessions — this session's usage is billed to your{' '}
+          This paid-tier session is billed to your{' '}
           <Link
             href="https://huggingface.co/settings/billing"
             target="_blank"

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -40,7 +40,6 @@ interface ModelOption {
   modelPath: string;
   avatarUrl: string;
   recommended?: boolean;
-  minimumPlan?: 'free' | 'pro';
 }
 
 const getHfAvatarUrl = (modelId: string) => {
@@ -131,7 +130,6 @@ const modelOptionFromApi = (model: {
   label?: string;
   provider?: string;
   recommended?: boolean;
-  minimum_plan?: string;
 }): ModelOption | null => {
   if (!model.id) return null;
   return {
@@ -141,7 +139,6 @@ const modelOptionFromApi = (model: {
     modelPath: model.id,
     avatarUrl: getHfAvatarUrl(model.id.replace(/^huggingface\//, '')),
     recommended: Boolean(model.recommended),
-    minimumPlan: model.minimum_plan === 'pro' ? 'pro' : 'free',
   };
 };
 

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -20,17 +20,16 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import StopIcon from '@mui/icons-material/Stop';
 import AddIcon from '@mui/icons-material/Add';
 import { apiFetch, apiUpload } from '@/utils/api';
-import type { PlanTier, UserQuota } from '@/hooks/useUserQuota';
+import type { UserQuota } from '@/hooks/useUserQuota';
 import JobsUpgradeDialog from '@/components/JobsUpgradeDialog';
 import { useAgentStore } from '@/store/agentStore';
 import { useSessionStore } from '@/store/sessionStore';
 import {
-  CLAUDE_MODEL_PATH,
   CLAUDE_OPUS_48_MODEL_PATH,
   GPT_55_MODEL_PATH,
+  KIMI_K26_MODEL_PATH,
   isClaudePath,
-  isPremiumPath,
-  isProOnlyPath,
+  isPaidPath,
 } from '@/utils/model';
 
 // Model configuration
@@ -51,11 +50,11 @@ const getHfAvatarUrl = (modelId: string) => {
 
 const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   {
-    id: 'claude-sonnet-4-6',
-    name: 'Claude Sonnet 4.6',
+    id: 'kimi-k2.6',
+    name: 'Kimi K2.6',
     description: 'Hugging Face',
-    modelPath: CLAUDE_MODEL_PATH,
-    avatarUrl: getHfAvatarUrl(CLAUDE_MODEL_PATH),
+    modelPath: KIMI_K26_MODEL_PATH,
+    avatarUrl: getHfAvatarUrl(KIMI_K26_MODEL_PATH),
     recommended: true,
   },
   {
@@ -64,7 +63,6 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
     description: 'Hugging Face',
     modelPath: CLAUDE_OPUS_48_MODEL_PATH,
     avatarUrl: getHfAvatarUrl(CLAUDE_OPUS_48_MODEL_PATH),
-    minimumPlan: 'pro',
   },
   {
     id: 'gpt-5.5',
@@ -72,14 +70,6 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
     description: 'Hugging Face',
     modelPath: GPT_55_MODEL_PATH,
     avatarUrl: getHfAvatarUrl(GPT_55_MODEL_PATH),
-    minimumPlan: 'pro',
-  },
-  {
-    id: 'kimi-k2.6',
-    name: 'Kimi K2.6',
-    description: 'Hugging Face',
-    modelPath: 'moonshotai/Kimi-K2.6',
-    avatarUrl: getHfAvatarUrl('moonshotai/Kimi-K2.6'),
   },
   {
     id: 'minimax-m2.7',
@@ -109,7 +99,6 @@ const normalizeModelPath = (path: string | undefined) => (
     .toLowerCase()
     .replace(/^huggingface\//, '')
     .replace(/claude-opus-4\.(\d)/g, 'claude-opus-4-$1')
-    .replace(/claude-sonnet-4\.(\d)/g, 'claude-sonnet-4-$1')
 );
 
 const findModelByPath = (path: string, options: ModelOption[]): ModelOption | undefined => {
@@ -202,13 +191,7 @@ const DATASET_UPLOAD_ACCEPT = '.csv,.json,.jsonl';
 const DATASET_UPLOAD_EXTENSIONS = new Set(['csv', 'json', 'jsonl']);
 
 const isClaudeModel = (m: ModelOption) => isClaudePath(m.modelPath);
-const isPremiumModel = (m: ModelOption) => isPremiumPath(m.modelPath);
-const isProOnlyModel = (m: ModelOption) => (
-  m.minimumPlan === 'pro' || isProOnlyPath(m.modelPath)
-);
-const isModelAllowedForPlan = (m: ModelOption, plan: PlanTier) => (
-  plan === 'pro' || !isProOnlyModel(m)
-);
+const isPaidModel = (m: ModelOption) => isPaidPath(m.modelPath);
 
 const formatBytes = (bytes: number) => {
   if (bytes < 1024) return `${bytes} B`;
@@ -290,10 +273,7 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
     return () => { cancelled = true; };
   }, [sessionId, updateSessionModel]);
 
-  const plan = quota?.plan ?? 'free';
-  const visibleModelOptions = modelOptions.filter((model) => (
-    isModelAllowedForPlan(model, plan)
-  ));
+  const visibleModelOptions = modelOptions;
   const selectedModel = (
     visibleModelOptions.find(m => m.id === selectedModelId)
     || modelOptions.find(m => m.id === selectedModelId)
@@ -309,16 +289,11 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
   }, [disabled, isProcessing]);
 
   const handleSend = useCallback(() => {
-    const selectedOption = modelOptions.find((model) => model.id === selectedModelId);
-    if (selectedOption && !isModelAllowedForPlan(selectedOption, plan)) {
-      setModelSwitchError('Claude Opus 4.8 and GPT-5.5 daily sessions require HF Pro.');
-      return;
-    }
     if (input.trim() && !disabled && !isUploadingDataset) {
       onSend(input);
       setInput('');
     }
-  }, [input, disabled, isUploadingDataset, onSend, modelOptions, selectedModelId, plan]);
+  }, [input, disabled, isUploadingDataset, onSend]);
 
   const handleDatasetUploadClick = useCallback(() => {
     fileInputRef.current?.click();
@@ -424,10 +399,6 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
   const handleSelectModel = async (model: ModelOption) => {
     handleModelClose();
     if (!sessionId) return;
-    if (!isModelAllowedForPlan(model, plan)) {
-      setModelSwitchError('Claude Opus 4.8 and GPT-5.5 daily sessions require HF Pro.');
-      return;
-    }
     try {
       const res = await apiFetch(`/api/session/${sessionId}/model`, {
         method: 'POST',
@@ -486,14 +457,14 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, [awaitingTopUp, jobsUpgradeRequired, handleJobsRetry]);
 
-  // Show the remaining subsidized premium-session allowance for today.
-  const premiumChip = (() => {
+  // Show the remaining included paid-tier session allowance for today.
+  const paidChip = (() => {
     if (!quota) return null;
-    const remaining = Math.max(0, quota.premiumRemaining);
+    const remaining = Math.max(0, quota.paidRemaining);
     if (remaining === 0) {
-      return quota.plan === 'pro' ? '0 left – using HF billing' : '0 left – enable billing';
+      return 'Billed to HF';
     }
-    return `${remaining} left today`;
+    return `${remaining} included today`;
   })();
 
   return (
@@ -793,9 +764,9 @@ export default function ChatInput({ sessionId, initialModelPath, onSend, onStop,
                         }}
                       />
                     )}
-                    {isPremiumModel(model) && premiumChip && (
+                    {isPaidModel(model) && paidChip && (
                       <Chip
-                        label={premiumChip}
+                        label={paidChip}
                         size="small"
                         sx={{
                           height: '18px',

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -15,7 +15,7 @@ import ExpiredBanner from '@/components/Chat/ExpiredBanner';
 import BillingBanner from '@/components/Chat/BillingBanner';
 import ChatErrorBanner from '@/components/Chat/ChatErrorBanner';
 import { useUserQuota } from '@/hooks/useUserQuota';
-import { isPremiumPath } from '@/utils/model';
+import { isPaidPath } from '@/utils/model';
 import { apiFetch } from '@/utils/api';
 import { logger } from '@/utils/logger';
 
@@ -90,17 +90,17 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
   const busy = isProcessing || sdkBusy;
   const { quota, refresh: refreshQuota } = useUserQuota({ enabled: isActive });
 
-  // Whether this session's premium usage is being billed to the user's own HF
-  // account (past the subsidized daily allowance). Re-read after each turn,
-  // since the backend flips it at submit time. Only premium-model sessions can
+  // Whether this session's paid-tier usage is being billed to the user's own HF
+  // account. Re-read after each turn, since the backend flips it at submit time.
+  // Only paid-tier sessions can
   // ever be user-billed, so skip the fetch for free models.
-  const [premiumBilled, setPremiumBilled] = useState<boolean | null>(null);
-  const [premiumQuotaCounted, setPremiumQuotaCounted] = useState<boolean | null>(null);
-  const onPremiumModel = isPremiumPath(sessionMeta?.model ?? undefined);
+  const [paidBilled, setPaidBilled] = useState<boolean | null>(null);
+  const [paidQuotaCounted, setPaidQuotaCounted] = useState<boolean | null>(null);
+  const onPaidModel = isPaidPath(sessionMeta?.model ?? undefined);
   useEffect(() => {
-    if (!isActive || !onPremiumModel) {
-      setPremiumBilled(null);
-      setPremiumQuotaCounted(null);
+    if (!isActive || !onPaidModel) {
+      setPaidBilled(null);
+      setPaidQuotaCounted(null);
       return;
     }
     if (busy) return;
@@ -109,25 +109,25 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (!cancelled && d) {
-          setPremiumBilled(Boolean(d.premium_user_billed));
-          setPremiumQuotaCounted(Boolean(d.premium_quota_counted));
+          setPaidBilled(Boolean(d.paid_user_billed));
+          setPaidQuotaCounted(Boolean(d.paid_quota_counted));
         }
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
-  }, [busy, isActive, onPremiumModel, sessionId]);
+  }, [busy, isActive, onPaidModel, sessionId]);
 
-  const sessionPremiumBilled = premiumBilled ?? Boolean(sessionMeta?.premiumUserBilled);
-  const sessionPremiumQuotaCounted =
-    premiumQuotaCounted ?? Boolean(sessionMeta?.premiumQuotaCounted);
-  const premiumBillingNotice =
-    sessionPremiumBilled ||
+  const sessionPaidBilled = paidBilled ?? Boolean(sessionMeta?.paidUserBilled);
+  const sessionPaidQuotaCounted =
+    paidQuotaCounted ?? Boolean(sessionMeta?.paidQuotaCounted);
+  const paidBillingNotice =
+    sessionPaidBilled ||
     (isActive &&
-      onPremiumModel &&
-      quota?.premiumRemaining === 0 &&
-      !sessionPremiumQuotaCounted);
+      onPaidModel &&
+      quota?.paidRemaining === 0 &&
+      !sessionPaidQuotaCounted);
 
   const handleSendMessage = useCallback(
     async (text: string) => {
@@ -175,7 +175,7 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
         <ExpiredBanner sessionId={sessionId} />
       ) : (
         <>
-          {premiumBillingNotice && <BillingBanner />}
+          {paidBillingNotice && <BillingBanner />}
           {chatError && (
             <ChatErrorBanner
               error={chatError}

--- a/frontend/src/hooks/useUserQuota.ts
+++ b/frontend/src/hooks/useUserQuota.ts
@@ -1,5 +1,5 @@
 /**
- * Reads the current user's premium-model daily quota + plan tier from the backend.
+ * Reads the current user's paid-tier daily quota + plan tier from the backend.
  *
  * Fetches once when the user becomes authenticated, and exposes a `refresh()`
  * that callers invoke after a successful session-create / model-switch so the
@@ -13,9 +13,9 @@ export type PlanTier = 'free' | 'pro';
 
 export interface UserQuota {
   plan: PlanTier;
-  premiumUsedToday: number;
-  premiumDailyCap: number;
-  premiumRemaining: number;
+  paidUsedToday: number;
+  paidDailyCap: number;
+  paidRemaining: number;
 }
 
 export function useUserQuota({ enabled = true }: { enabled?: boolean } = {}) {
@@ -32,9 +32,9 @@ export function useUserQuota({ enabled = true }: { enabled?: boolean } = {}) {
       const data = await res.json();
       setQuota({
         plan: (data.plan ?? 'free') as PlanTier,
-        premiumUsedToday: data.premium_used_today ?? 0,
-        premiumDailyCap: data.premium_daily_cap ?? 1,
-        premiumRemaining: data.premium_remaining ?? 0,
+        paidUsedToday: data.paid_used_today ?? 0,
+        paidDailyCap: data.paid_daily_cap ?? 0,
+        paidRemaining: data.paid_remaining ?? 0,
       });
     } catch {
       /* backend unreachable — leave previous value */

--- a/frontend/src/store/sessionStore.ts
+++ b/frontend/src/store/sessionStore.ts
@@ -33,8 +33,8 @@ interface SessionStore {
     is_active?: boolean;
     is_processing?: boolean;
     model?: string | null;
-    premium_user_billed?: boolean;
-    premium_quota_counted?: boolean;
+    paid_user_billed?: boolean;
+    paid_quota_counted?: boolean;
     pending_approval?: unknown[] | null;
     auto_approval?: {
       enabled?: boolean;
@@ -73,8 +73,8 @@ export const useSessionStore = create<SessionStore>()(
           autoApprovalCostCapUsd: null,
           autoApprovalEstimatedSpendUsd: 0,
           autoApprovalRemainingUsd: null,
-          premiumUserBilled: false,
-          premiumQuotaCounted: false,
+          paidUserBilled: false,
+          paidQuotaCounted: false,
         };
         set((state) => ({
           sessions: [...state.sessions, newSession],
@@ -128,8 +128,8 @@ export const useSessionStore = create<SessionStore>()(
                 isActive: server.is_active ?? existing.isActive,
                 isProcessing: Boolean(server.is_processing),
                 model: server.model ?? existing.model ?? null,
-                premiumUserBilled: Boolean(server.premium_user_billed),
-                premiumQuotaCounted: Boolean(server.premium_quota_counted),
+                paidUserBilled: Boolean(server.paid_user_billed),
+                paidQuotaCounted: Boolean(server.paid_quota_counted),
                 needsAttention: Boolean(server.pending_approval?.length) || existing.needsAttention,
                 expired: false,
                 ...(auto
@@ -159,8 +159,8 @@ export const useSessionStore = create<SessionStore>()(
               autoApprovalCostCapUsd: server.auto_approval?.cost_cap_usd ?? null,
               autoApprovalEstimatedSpendUsd: server.auto_approval?.estimated_spend_usd ?? 0,
               autoApprovalRemainingUsd: server.auto_approval?.remaining_usd ?? null,
-              premiumUserBilled: Boolean(server.premium_user_billed),
-              premiumQuotaCounted: Boolean(server.premium_quota_counted),
+              paidUserBilled: Boolean(server.paid_user_billed),
+              paidQuotaCounted: Boolean(server.paid_quota_counted),
             };
             merged.push(newSession);
             byId.set(id, newSession);
@@ -257,8 +257,8 @@ export const useSessionStore = create<SessionStore>()(
         sessions: state.sessions.map((s) => ({
           ...s,
           isProcessing: false,
-          premiumUserBilled: false,
-          premiumQuotaCounted: false,
+          paidUserBilled: false,
+          paidQuotaCounted: false,
         })),
         activeSessionId: state.activeSessionId,
       }),

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -33,8 +33,8 @@ export interface SessionMeta {
   autoApprovalCostCapUsd?: number | null;
   autoApprovalEstimatedSpendUsd?: number;
   autoApprovalRemainingUsd?: number | null;
-  premiumUserBilled?: boolean;
-  premiumQuotaCounted?: boolean;
+  paidUserBilled?: boolean;
+  paidQuotaCounted?: boolean;
 }
 
 export interface ToolApproval {

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -6,18 +6,11 @@
  * AVAILABLE_MODELS in backend/routes/agent.py.
  */
 
-export const CLAUDE_SONNET_46_MODEL_PATH = 'anthropic/claude-sonnet-4-6:fal-ai';
 export const CLAUDE_OPUS_48_MODEL_PATH = 'anthropic/claude-opus-4.8:fal-ai';
-export const CLAUDE_MODEL_PATH = CLAUDE_SONNET_46_MODEL_PATH;
 export const GPT_55_MODEL_PATH = 'openai/gpt-5.5:fal-ai';
+export const KIMI_K26_MODEL_PATH = 'moonshotai/Kimi-K2.6';
 
-const PREMIUM_MODEL_PATHS = new Set([
-  CLAUDE_SONNET_46_MODEL_PATH,
-  CLAUDE_OPUS_48_MODEL_PATH,
-  GPT_55_MODEL_PATH,
-]);
-
-const PRO_ONLY_MODEL_PATHS = new Set([
+const PAID_MODEL_PATHS = new Set([
   CLAUDE_OPUS_48_MODEL_PATH,
   GPT_55_MODEL_PATH,
 ]);
@@ -26,10 +19,6 @@ export function isClaudePath(modelPath: string | undefined): boolean {
   return !!modelPath && modelPath.includes('anthropic');
 }
 
-export function isPremiumPath(modelPath: string | undefined): boolean {
-  return !!modelPath && PREMIUM_MODEL_PATHS.has(modelPath);
-}
-
-export function isProOnlyPath(modelPath: string | undefined): boolean {
-  return !!modelPath && PRO_ONLY_MODEL_PATHS.has(modelPath);
+export function isPaidPath(modelPath: string | undefined): boolean {
+  return !!modelPath && PAID_MODEL_PATHS.has(modelPath);
 }

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -1,4 +1,4 @@
-"""Tests for premium model handling in backend/routes/agent.py."""
+"""Tests for paid-tier model handling in backend/routes/agent.py."""
 
 import sys
 from pathlib import Path
@@ -21,91 +21,69 @@ def _reset_quota_store():
     agent.user_quotas._reset_for_tests()
 
 
-def _premium_session(model: str = agent.DEFAULT_PREMIUM_MODEL_ID):
+def _paid_session(model: str = agent.DEFAULT_PAID_MODEL_ID):
     return SimpleNamespace(
-        claude_counted=False,
-        claude_counted_day=None,
+        paid_counted=False,
+        paid_counted_day=None,
         session=SimpleNamespace(
             config=SimpleNamespace(model_name=model),
-            premium_user_billed=False,
+            paid_user_billed=False,
         ),
     )
 
 
-def test_premium_model_predicate_uses_router_ids_only():
-    assert agent._is_premium_model(agent.DEFAULT_PREMIUM_MODEL_ID)
-    assert agent._is_premium_model(agent.DEFAULT_OPUS_MODEL_ID)
-    assert agent._is_premium_model(agent.DEFAULT_GPT_MODEL_ID)
-    assert not agent._is_pro_only_premium_model(agent.DEFAULT_PREMIUM_MODEL_ID)
-    assert agent._is_pro_only_premium_model(agent.DEFAULT_OPUS_MODEL_ID)
-    assert agent._is_pro_only_premium_model(agent.DEFAULT_GPT_MODEL_ID)
-    assert agent._is_user_billed(agent.DEFAULT_PREMIUM_MODEL_ID)
-    assert not agent._is_premium_model("moonshotai/Kimi-K2.6")
-    assert not agent._is_premium_model("unsupported/model")
+def test_paid_model_predicate_uses_router_ids_only():
+    assert agent._is_paid_model(agent.DEFAULT_OPUS_MODEL_ID)
+    assert agent._is_paid_model(agent.DEFAULT_GPT_MODEL_ID)
+    assert not agent._is_paid_model(agent.DEFAULT_FREE_MODEL_ID)
+    assert not agent._is_paid_model("unsupported/model")
 
 
-def test_available_models_mark_opus_and_gpt_as_pro_only():
+def test_available_models_expose_free_and_paid_tiers():
     models = {model["id"]: model for model in agent.AVAILABLE_MODELS}
 
-    assert models[agent.DEFAULT_PREMIUM_MODEL_ID]["label"] == "Claude Sonnet 4.6"
-    assert models[agent.DEFAULT_PREMIUM_MODEL_ID]["minimum_plan"] == "free"
-    assert models[agent.DEFAULT_OPUS_MODEL_ID]["minimum_plan"] == "pro"
-    assert models[agent.DEFAULT_GPT_MODEL_ID]["minimum_plan"] == "pro"
+    assert len(models) == 6
+    assert agent.DEFAULT_FREE_MODEL_ID in models
+    assert agent.DEFAULT_OPUS_MODEL_ID in models
+    assert agent.DEFAULT_GPT_MODEL_ID in models
+    assert models[agent.DEFAULT_FREE_MODEL_ID]["tier"] == "free"
+    assert models[agent.DEFAULT_FREE_MODEL_ID]["recommended"] is True
+    assert models[agent.DEFAULT_OPUS_MODEL_ID]["tier"] == "paid"
+    assert models[agent.DEFAULT_GPT_MODEL_ID]["tier"] == "paid"
+    assert models[agent.DEFAULT_OPUS_MODEL_ID]["minimum_plan"] == "free"
+    assert models[agent.DEFAULT_GPT_MODEL_ID]["minimum_plan"] == "free"
 
 
 @pytest.mark.asyncio
-async def test_default_session_uses_configured_default_model():
-    model = await agent._model_override_for_new_session(None, None)
+async def test_default_session_model_is_plan_aware():
+    free_model = await agent._model_override_for_new_session(
+        None,
+        None,
+        {"user_id": "u1", "plan": "free"},
+    )
+    pro_model = await agent._model_override_for_new_session(
+        None,
+        None,
+        {"user_id": "u2", "plan": "pro"},
+    )
 
-    assert model is None
+    assert free_model == agent.DEFAULT_FREE_MODEL_ID
+    assert pro_model == agent.DEFAULT_PAID_MODEL_ID
 
 
 @pytest.mark.asyncio
-async def test_explicit_premium_session_allowed_for_authenticated_user():
+async def test_explicit_paid_session_allowed_for_any_authenticated_user():
     model = await agent._model_override_for_new_session(
         None,
-        agent.DEFAULT_PREMIUM_MODEL_ID,
+        agent.DEFAULT_GPT_MODEL_ID,
+        {"user_id": "u1", "plan": "free"},
     )
 
-    assert model == agent.DEFAULT_PREMIUM_MODEL_ID
+    assert model == agent.DEFAULT_GPT_MODEL_ID
 
 
 @pytest.mark.asyncio
-async def test_switching_to_premium_model_is_allowed_for_authenticated_user(
-    monkeypatch,
-):
-    updated = []
-
-    async def fake_check_session_access(session_id, user, request=None):
-        assert session_id == "s1"
-        assert user["user_id"] == "u1"
-        return SimpleNamespace(user_id="u1")
-
-    async def fake_update_session_model(session_id, model_id):
-        updated.append((session_id, model_id))
-
-    monkeypatch.setattr(agent, "_check_session_access", fake_check_session_access)
-    monkeypatch.setattr(
-        agent.session_manager,
-        "update_session_model",
-        fake_update_session_model,
-    )
-
-    response = await agent.set_session_model(
-        "s1",
-        {"model": agent.DEFAULT_PREMIUM_MODEL_ID},
-        request=None,
-        user={"user_id": "u1", "plan": "free"},
-    )
-
-    assert response == {"session_id": "s1", "model": agent.DEFAULT_PREMIUM_MODEL_ID}
-    assert updated == [("s1", agent.DEFAULT_PREMIUM_MODEL_ID)]
-
-
-@pytest.mark.asyncio
-async def test_switching_to_pro_only_premium_model_is_allowed_for_pro_user(
-    monkeypatch,
-):
+async def test_switching_to_paid_model_is_allowed_for_free_user(monkeypatch):
     updated = []
 
     async def fake_check_session_access(session_id, user, request=None):
@@ -127,36 +105,11 @@ async def test_switching_to_pro_only_premium_model_is_allowed_for_pro_user(
         "s1",
         {"model": agent.DEFAULT_GPT_MODEL_ID},
         request=None,
-        user={"user_id": "u1", "plan": "pro"},
+        user={"user_id": "u1", "plan": "free"},
     )
 
     assert response == {"session_id": "s1", "model": agent.DEFAULT_GPT_MODEL_ID}
     assert updated == [("s1", agent.DEFAULT_GPT_MODEL_ID)]
-
-
-@pytest.mark.asyncio
-async def test_switching_to_pro_only_premium_model_is_rejected_for_free_user(
-    monkeypatch,
-):
-    async def fake_check_session_access(session_id, user, request=None):
-        return SimpleNamespace(user_id=user["user_id"])
-
-    async def fail_if_updated(session_id, model_id):
-        raise AssertionError("free users should not switch to pro-only models")
-
-    monkeypatch.setattr(agent, "_check_session_access", fake_check_session_access)
-    monkeypatch.setattr(agent.session_manager, "update_session_model", fail_if_updated)
-
-    with pytest.raises(HTTPException) as exc_info:
-        await agent.set_session_model(
-            "s1",
-            {"model": agent.DEFAULT_GPT_MODEL_ID},
-            request=None,
-            user={"user_id": "u1", "plan": "free"},
-        )
-
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail["error"] == "model_requires_pro"
 
 
 @pytest.mark.asyncio
@@ -179,7 +132,7 @@ async def test_switching_to_unknown_model_id_is_rejected(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_premium_quota_charges_without_user_billing_inside_allowance(monkeypatch):
+async def test_free_user_paid_model_is_user_billed_from_first_submit(monkeypatch):
     persisted = []
 
     async def fake_persist_session_snapshot(agent_session):
@@ -191,22 +144,22 @@ async def test_premium_quota_charges_without_user_billing_inside_allowance(monke
         fake_persist_session_snapshot,
     )
 
-    agent_session = _premium_session()
+    agent_session = _paid_session()
 
-    await agent._enforce_premium_model_quota(
+    await agent._enforce_paid_model_quota(
         {"user_id": "u1", "plan": "free"},
         agent_session,
     )
 
-    assert agent_session.claude_counted is True
-    assert agent_session.claude_counted_day == agent.user_quotas.current_quota_day()
-    assert agent_session.session.premium_user_billed is False
+    assert agent_session.paid_counted is True
+    assert agent_session.paid_counted_day == agent.user_quotas.current_quota_day()
+    assert agent_session.session.paid_user_billed is True
     assert persisted == [agent_session]
-    assert await agent.user_quotas.get_claude_used_today("u1") == 1
+    assert await agent.user_quotas.get_paid_used_today("u1") == 0
 
 
 @pytest.mark.asyncio
-async def test_premium_quota_counts_same_session_once_per_day(monkeypatch):
+async def test_paid_quota_counts_same_session_once_per_day(monkeypatch):
     async def fake_persist_session_snapshot(_agent_session):
         return None
 
@@ -216,24 +169,24 @@ async def test_premium_quota_counts_same_session_once_per_day(monkeypatch):
         fake_persist_session_snapshot,
     )
 
-    agent_session = _premium_session()
+    agent_session = _paid_session()
 
-    await agent._enforce_premium_model_quota(
-        {"user_id": "u1", "plan": "free"},
+    await agent._enforce_paid_model_quota(
+        {"user_id": "u1", "plan": "pro"},
         agent_session,
     )
-    await agent._enforce_premium_model_quota(
-        {"user_id": "u1", "plan": "free"},
+    await agent._enforce_paid_model_quota(
+        {"user_id": "u1", "plan": "pro"},
         agent_session,
     )
 
-    assert agent_session.claude_counted is True
-    assert agent_session.claude_counted_day == agent.user_quotas.current_quota_day()
-    assert await agent.user_quotas.get_claude_used_today("u1") == 1
+    assert agent_session.paid_counted is True
+    assert agent_session.paid_counted_day == agent.user_quotas.current_quota_day()
+    assert await agent.user_quotas.get_paid_used_today("u1") == 1
 
 
 @pytest.mark.asyncio
-async def test_premium_quota_counts_stale_session_again_today(monkeypatch):
+async def test_paid_quota_counts_stale_session_again_today(monkeypatch):
     async def fake_persist_session_snapshot(_agent_session):
         return None
 
@@ -243,127 +196,47 @@ async def test_premium_quota_counts_stale_session_again_today(monkeypatch):
         fake_persist_session_snapshot,
     )
 
-    agent_session = _premium_session()
-    agent_session.claude_counted = True
-    agent_session.claude_counted_day = "2000-01-01"
-    agent_session.session.premium_user_billed = True
+    agent_session = _paid_session()
+    agent_session.paid_counted = True
+    agent_session.paid_counted_day = "2000-01-01"
+    agent_session.session.paid_user_billed = True
 
-    await agent._enforce_premium_model_quota(
+    await agent._enforce_paid_model_quota(
+        {"user_id": "u1", "plan": "pro"},
+        agent_session,
+    )
+
+    assert agent_session.paid_counted is True
+    assert agent_session.paid_counted_day == agent.user_quotas.current_quota_day()
+    assert agent_session.session.paid_user_billed is False
+    assert await agent.user_quotas.get_paid_used_today("u1") == 1
+
+
+@pytest.mark.asyncio
+async def test_free_model_does_not_consume_paid_quota(monkeypatch):
+    async def fail_if_persisted(_agent_session):
+        raise AssertionError("free model should not consume paid-tier quota")
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "persist_session_snapshot",
+        fail_if_persisted,
+    )
+
+    agent_session = _paid_session(agent.DEFAULT_FREE_MODEL_ID)
+
+    await agent._enforce_paid_model_quota(
         {"user_id": "u1", "plan": "free"},
         agent_session,
     )
 
-    assert agent_session.claude_counted is True
-    assert agent_session.claude_counted_day == agent.user_quotas.current_quota_day()
-    assert agent_session.session.premium_user_billed is False
-    assert await agent.user_quotas.get_claude_used_today("u1") == 1
+    assert agent_session.paid_counted is False
+    assert agent_session.paid_counted_day is None
+    assert await agent.user_quotas.get_paid_used_today("u1") == 0
 
 
 @pytest.mark.asyncio
-async def test_free_user_gets_two_subsidized_premium_sessions_then_user_billing(
-    monkeypatch,
-):
-    async def fake_persist_session_snapshot(_agent_session):
-        return None
-
-    monkeypatch.setattr(
-        agent.session_manager,
-        "persist_session_snapshot",
-        fake_persist_session_snapshot,
-    )
-
-    first = _premium_session()
-    await agent._enforce_premium_model_quota({"user_id": "g1", "plan": "free"}, first)
-    assert first.session.premium_user_billed is False
-
-    second = _premium_session()
-    await agent._enforce_premium_model_quota({"user_id": "g1", "plan": "free"}, second)
-    assert second.session.premium_user_billed is False
-
-    third = _premium_session()
-    await agent._enforce_premium_model_quota({"user_id": "g1", "plan": "free"}, third)
-    assert third.session.premium_user_billed is True
-    assert third.claude_counted_day == agent.user_quotas.current_quota_day()
-    assert await agent.user_quotas.get_claude_used_today("g1") == 2
-
-
-@pytest.mark.asyncio
-async def test_free_model_does_not_consume_premium_quota(monkeypatch):
-    async def fail_if_persisted(_agent_session):
-        raise AssertionError("free model should not consume premium quota")
-
-    monkeypatch.setattr(
-        agent.session_manager,
-        "persist_session_snapshot",
-        fail_if_persisted,
-    )
-
-    agent_session = _premium_session("moonshotai/Kimi-K2.6")
-
-    await agent._enforce_premium_model_quota(
-        {"user_id": "u1", "plan": "free"},
-        agent_session,
-    )
-
-    assert agent_session.claude_counted is False
-    assert agent_session.claude_counted_day is None
-    assert await agent.user_quotas.get_claude_used_today("u1") == 0
-
-
-@pytest.mark.asyncio
-async def test_free_user_cannot_spend_quota_on_pro_only_premium_model(monkeypatch):
-    async def fail_if_persisted(_agent_session):
-        raise AssertionError("rejected model should not persist quota state")
-
-    monkeypatch.setattr(
-        agent.session_manager,
-        "persist_session_snapshot",
-        fail_if_persisted,
-    )
-
-    agent_session = _premium_session(agent.DEFAULT_OPUS_MODEL_ID)
-
-    with pytest.raises(HTTPException) as exc_info:
-        await agent._enforce_premium_model_quota(
-            {"user_id": "u1", "plan": "free"},
-            agent_session,
-        )
-
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail["error"] == "model_requires_pro"
-    assert agent_session.claude_counted is False
-    assert agent_session.claude_counted_day is None
-    assert await agent.user_quotas.get_claude_used_today("u1") == 0
-
-
-@pytest.mark.asyncio
-async def test_downgraded_user_cannot_continue_counted_pro_only_session(monkeypatch):
-    async def fail_if_persisted(_agent_session):
-        raise AssertionError("already-counted rejected session should not persist")
-
-    monkeypatch.setattr(
-        agent.session_manager,
-        "persist_session_snapshot",
-        fail_if_persisted,
-    )
-
-    agent_session = _premium_session(agent.DEFAULT_OPUS_MODEL_ID)
-    agent_session.claude_counted = True
-
-    with pytest.raises(HTTPException) as exc_info:
-        await agent._enforce_premium_model_quota(
-            {"user_id": "u1", "plan": "free"},
-            agent_session,
-        )
-
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail["error"] == "model_requires_pro"
-    assert agent_session.claude_counted is True
-    assert await agent.user_quotas.get_claude_used_today("u1") == 0
-
-
-@pytest.mark.asyncio
-async def test_pro_user_uses_pro_premium_quota(monkeypatch):
+async def test_pro_user_uses_paid_tier_quota(monkeypatch):
     async def fake_persist_session_snapshot(_agent_session):
         return None
 
@@ -374,37 +247,37 @@ async def test_pro_user_uses_pro_premium_quota(monkeypatch):
     )
 
     for index in range(2):
-        agent_session = _premium_session()
-        await agent._enforce_premium_model_quota(
+        agent_session = _paid_session()
+        await agent._enforce_paid_model_quota(
             {"user_id": "pro-user", "plan": "pro"},
             agent_session,
         )
-        assert agent_session.claude_counted is True
-        assert agent_session.claude_counted_day == agent.user_quotas.current_quota_day()
-        assert agent_session.session.premium_user_billed is False
-        assert await agent.user_quotas.get_claude_used_today("pro-user") == index + 1
+        assert agent_session.paid_counted is True
+        assert agent_session.paid_counted_day == agent.user_quotas.current_quota_day()
+        assert agent_session.session.paid_user_billed is False
+        assert await agent.user_quotas.get_paid_used_today("pro-user") == index + 1
 
 
 @pytest.mark.asyncio
-async def test_pro_user_billable_overflow_also_bills_user(monkeypatch):
+async def test_pro_user_overflow_bills_user(monkeypatch):
     async def fake_persist(_agent_session):
         return None
 
     monkeypatch.setattr(agent.session_manager, "persist_session_snapshot", fake_persist)
     monkeypatch.setattr(agent.user_quotas, "daily_cap_for", lambda plan: 1)
 
-    await agent._enforce_premium_model_quota(
-        {"user_id": "p1", "plan": "pro"}, _premium_session()
+    await agent._enforce_paid_model_quota(
+        {"user_id": "p1", "plan": "pro"}, _paid_session()
     )
-    over = _premium_session()
-    await agent._enforce_premium_model_quota({"user_id": "p1", "plan": "pro"}, over)
-    assert over.session.premium_user_billed is True
+    over = _paid_session()
+    await agent._enforce_paid_model_quota({"user_id": "p1", "plan": "pro"}, over)
+    assert over.session.paid_user_billed is True
 
 
 @pytest.mark.asyncio
-async def test_restore_summary_enforces_premium_quota_before_seed(monkeypatch):
+async def test_restore_summary_enforces_paid_quota_before_seed(monkeypatch):
     events = []
-    agent_session = _premium_session()
+    agent_session = _paid_session()
 
     class Request:
         headers = {}
@@ -423,49 +296,49 @@ async def test_restore_summary_enforces_premium_quota_before_seed(monkeypatch):
     async def fake_enforce_quota(user, session):
         assert user["user_id"] == "u1"
         assert session is agent_session
-        session.session.premium_user_billed = True
+        session.session.paid_user_billed = False
         events.append(("quota", session.session.config.model_name))
 
     async def fake_seed(session_id, messages):
-        events.append(("seed", session_id, agent_session.session.premium_user_billed))
+        events.append(("seed", session_id, agent_session.session.paid_user_billed))
         return len(messages)
 
     monkeypatch.setattr(agent.session_manager, "create_session", fake_create_session)
     monkeypatch.setattr(agent, "_check_session_access", fake_check_session_access)
-    monkeypatch.setattr(agent, "_enforce_premium_model_quota", fake_enforce_quota)
+    monkeypatch.setattr(agent, "_enforce_paid_model_quota", fake_enforce_quota)
     monkeypatch.setattr(agent.session_manager, "seed_from_summary", fake_seed)
 
     response = await agent.restore_session_summary(
         Request(),
         {"messages": [{"role": "user", "content": "resume this"}]},
-        {"user_id": "u1", "plan": "free"},
+        {"user_id": "u1", "plan": "pro"},
     )
 
     assert response.session_id == "s1"
     assert events == [
-        ("create", None),
+        ("create", agent.DEFAULT_PAID_MODEL_ID),
         ("check", "s1", False),
-        ("quota", agent.DEFAULT_PREMIUM_MODEL_ID),
-        ("seed", "s1", True),
+        ("quota", agent.DEFAULT_PAID_MODEL_ID),
+        ("seed", "s1", False),
     ]
 
 
 @pytest.mark.asyncio
-async def test_user_quota_response_uses_premium_fields_only(monkeypatch):
+async def test_user_quota_response_uses_paid_fields(monkeypatch):
     async def fake_get_used_today(user_id):
         assert user_id == "u1"
         return 2
 
-    monkeypatch.setattr(agent.user_quotas, "get_claude_used_today", fake_get_used_today)
+    monkeypatch.setattr(agent.user_quotas, "get_paid_used_today", fake_get_used_today)
     monkeypatch.setattr(agent.user_quotas, "daily_cap_for", lambda plan: 5)
 
     response = await agent.get_user_quota({"user_id": "u1", "plan": "pro"})
 
     assert response == {
         "plan": "pro",
-        "premium_used_today": 2,
-        "premium_daily_cap": 5,
-        "premium_remaining": 3,
+        "paid_used_today": 2,
+        "paid_daily_cap": 5,
+        "paid_remaining": 3,
     }
 
 

--- a/tests/unit/test_cli_local_models.py
+++ b/tests/unit/test_cli_local_models.py
@@ -30,11 +30,13 @@ def test_openai_compat_prefix_is_not_supported():
     assert not model_switcher.is_valid_model_id("openai-compat/custom-model")
 
 
-def test_suggested_models_include_router_claude_models_and_no_native_ids():
+def test_suggested_models_include_paid_and_free_router_models_and_no_native_ids():
     ids = {m["id"] for m in model_switcher.SUGGESTED_MODELS}
 
-    assert "anthropic/claude-sonnet-4-6:fal-ai" in ids
+    assert len(ids) == 6
+    assert "moonshotai/Kimi-K2.6" in ids
     assert "anthropic/claude-opus-4.8:fal-ai" in ids
+    assert "openai/gpt-5.5:fal-ai" in ids
     assert all(model_id.count("/") >= 1 for model_id in ids)
 
 

--- a/tests/unit/test_llm_params.py
+++ b/tests/unit/test_llm_params.py
@@ -9,19 +9,19 @@ from agent.core.llm_params import (
 from agent.core.model_ids import HF_ROUTER_BASE_URL
 
 
-def test_hf_router_params_for_default_premium_model(monkeypatch):
+def test_hf_router_params_for_default_free_model(monkeypatch):
     monkeypatch.setenv("INFERENCE_TOKEN", "inference-token")
     monkeypatch.setenv("HF_BILL_TO", "smolagents")
 
     params = _resolve_llm_params(
-        "anthropic/claude-sonnet-4-6:fal-ai",
+        "moonshotai/Kimi-K2.6",
         "session-token",
         reasoning_effort="high",
         strict=True,
     )
 
     assert params == {
-        "model": "openai/anthropic/claude-sonnet-4-6:fal-ai",
+        "model": "openai/moonshotai/Kimi-K2.6",
         "api_base": HF_ROUTER_BASE_URL,
         "api_key": "inference-token",
         "extra_headers": {"X-HF-Bill-To": "smolagents"},
@@ -52,7 +52,7 @@ def test_hf_router_drops_unsupported_effort_in_non_strict_mode(monkeypatch):
     assert "extra_body" not in params
 
 
-def test_user_billed_premium_uses_session_token_without_bill_to(monkeypatch):
+def test_user_billed_paid_model_uses_session_token_without_bill_to(monkeypatch):
     monkeypatch.setenv("INFERENCE_TOKEN", "inference-token")
     monkeypatch.setenv("HF_BILL_TO", "smolagents")
 
@@ -71,7 +71,7 @@ def test_user_billed_premium_uses_session_token_without_bill_to(monkeypatch):
     assert params["extra_body"] == {"reasoning_effort": "high"}
 
 
-def test_user_billed_premium_does_not_fall_back_to_cached_token(monkeypatch):
+def test_user_billed_paid_model_does_not_fall_back_to_cached_token(monkeypatch):
     import huggingface_hub
 
     monkeypatch.setenv("INFERENCE_TOKEN", "inference-token")

--- a/tests/unit/test_prompt_caching.py
+++ b/tests/unit/test_prompt_caching.py
@@ -6,7 +6,7 @@ from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_cach
 
 def _anthropic_fal_params() -> dict:
     return {
-        "model": "openai/anthropic/claude-sonnet-4-6:fal-ai",
+        "model": "openai/anthropic/claude-opus-4.8:fal-ai",
         "api_base": HF_ROUTER_BASE_URL,
     }
 
@@ -167,7 +167,7 @@ def test_prompt_caching_is_noop_for_non_router_fal_model():
         {"role": "user", "content": "current question"},
     ]
     llm_params = {
-        "model": "openai/anthropic/claude-sonnet-4-6:fal-ai",
+        "model": "openai/anthropic/claude-opus-4.8:fal-ai",
         "api_base": "http://localhost:8000/v1",
     }
 

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -16,7 +16,7 @@ _BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
 if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
-from agent.core.model_ids import DEFAULT_MODEL_ID, KIMI_K26_MODEL_ID  # noqa: E402
+from agent.core.model_ids import DEFAULT_MODEL_ID  # noqa: E402
 from agent.core.session_persistence import NoopSessionStore  # noqa: E402
 from session_manager import AgentSession, SessionManager  # noqa: E402
 
@@ -128,32 +128,28 @@ def _runtime_agent_session(
     )
 
 
-def test_unknown_saved_model_defaults_to_claude():
-    model, premium_user_billed, claude_counted = (
-        SessionManager._model_from_saved_metadata(
-            "unsupported/model",
-            premium_user_billed=False,
-            claude_counted=False,
-        )
+def test_unknown_saved_model_defaults_to_default_model():
+    model, paid_user_billed, paid_counted = SessionManager._model_from_saved_metadata(
+        "unsupported/model",
+        paid_user_billed=False,
+        paid_counted=False,
     )
 
     assert model == DEFAULT_MODEL_ID
-    assert premium_user_billed is False
-    assert claude_counted is False
+    assert paid_user_billed is False
+    assert paid_counted is False
 
 
-def test_unknown_saved_user_billed_model_defaults_to_free_model():
-    model, premium_user_billed, claude_counted = (
-        SessionManager._model_from_saved_metadata(
-            "unsupported/model",
-            premium_user_billed=True,
-            claude_counted=True,
-        )
+def test_unknown_saved_user_billed_model_defaults_to_default_model_without_billing():
+    model, paid_user_billed, paid_counted = SessionManager._model_from_saved_metadata(
+        "unsupported/model",
+        paid_user_billed=True,
+        paid_counted=True,
     )
 
-    assert model == KIMI_K26_MODEL_ID
-    assert premium_user_billed is False
-    assert claude_counted is False
+    assert model == DEFAULT_MODEL_ID
+    assert paid_user_billed is False
+    assert paid_counted is False
 
 
 @pytest.mark.asyncio
@@ -755,9 +751,9 @@ async def test_list_sessions_dev_uses_store_dev_visibility():
                         "user_id": "alice",
                         "model": "m",
                         "created_at": datetime.now(UTC),
-                        "premium_user_billed": True,
-                        "claude_counted": True,
-                        "claude_counted_day": datetime.now(UTC).date().isoformat(),
+                        "paid_user_billed": True,
+                        "paid_counted": True,
+                        "paid_counted_day": datetime.now(UTC).date().isoformat(),
                         "auto_approval_enabled": True,
                         "auto_approval_cost_cap_usd": 5.0,
                         "auto_approval_estimated_spend_usd": 2.0,
@@ -779,8 +775,8 @@ async def test_list_sessions_dev_uses_store_dev_visibility():
     assert store.seen_user_id == "dev"
     assert {session["session_id"] for session in sessions} == {"s1", "s2"}
     yolo = next(session for session in sessions if session["session_id"] == "s1")
-    assert yolo["premium_user_billed"] is True
-    assert yolo["premium_quota_counted"] is True
+    assert yolo["paid_user_billed"] is True
+    assert yolo["paid_quota_counted"] is True
     assert yolo["auto_approval"] == {
         "enabled": True,
         "cost_cap_usd": 5.0,
@@ -789,23 +785,23 @@ async def test_list_sessions_dev_uses_store_dev_visibility():
     }
 
 
-def test_get_session_info_marks_stale_premium_quota_as_unused_today():
+def test_get_session_info_marks_stale_paid_quota_as_unused_today():
     manager = _manager_with_store(NoopSessionStore())
     agent_session = _runtime_agent_session("s1", user_id="alice")
-    agent_session.claude_counted = True
-    agent_session.claude_counted_day = "2000-01-01"
-    agent_session.session.premium_user_billed = True
+    agent_session.paid_counted = True
+    agent_session.paid_counted_day = "2000-01-01"
+    agent_session.session.paid_user_billed = True
     manager.sessions["s1"] = agent_session
 
     info = manager.get_session_info("s1")
 
     assert info is not None
-    assert info["premium_user_billed"] is False
-    assert info["premium_quota_counted"] is False
+    assert info["paid_user_billed"] is False
+    assert info["paid_quota_counted"] is False
 
 
 @pytest.mark.asyncio
-async def test_list_sessions_marks_stale_premium_quota_as_unused_today():
+async def test_list_sessions_marks_stale_paid_quota_as_unused_today():
     class ListStore(NoopSessionStore):
         enabled = True
 
@@ -816,9 +812,9 @@ async def test_list_sessions_marks_stale_premium_quota_as_unused_today():
                     "user_id": user_id,
                     "model": "m",
                     "created_at": datetime.now(UTC),
-                    "premium_user_billed": True,
-                    "claude_counted": True,
-                    "claude_counted_day": "2000-01-01",
+                    "paid_user_billed": True,
+                    "paid_counted": True,
+                    "paid_counted_day": "2000-01-01",
                 }
             ]
 
@@ -826,5 +822,5 @@ async def test_list_sessions_marks_stale_premium_quota_as_unused_today():
 
     sessions = await manager.list_sessions(user_id="alice")
 
-    assert sessions[0]["premium_user_billed"] is False
-    assert sessions[0]["premium_quota_counted"] is False
+    assert sessions[0]["paid_user_billed"] is False
+    assert sessions[0]["paid_quota_counted"] is False

--- a/tests/unit/test_user_quotas.py
+++ b/tests/unit/test_user_quotas.py
@@ -128,11 +128,11 @@ async def test_refund_on_stale_day_resets_rather_than_underflow():
 
 
 @pytest.mark.asyncio
-async def test_pro_user_cap_reached_at_twenty():
+async def test_pro_user_cap_reached_at_default_daily_sessions():
     cap = user_quotas.daily_cap_for("pro")
-    assert cap == 20
-    for i in range(1, 21):
+    assert cap == 5
+    for i in range(1, cap + 1):
         assert await user_quotas.increment_paid("pro_user") == i
-    # 21st would exceed — the gate in routes/agent.py enforces this; here
+    # Next session would exceed — the gate in routes/agent.py enforces this; here
     # we just confirm the counter tracks past the cap so that check works.
-    assert await user_quotas.increment_paid("pro_user") == 21
+    assert await user_quotas.increment_paid("pro_user") == cap + 1

--- a/tests/unit/test_user_quotas.py
+++ b/tests/unit/test_user_quotas.py
@@ -1,4 +1,4 @@
-"""Tests for backend/user_quotas.py — the in-memory premium quota store."""
+"""Tests for backend/user_quotas.py — the in-memory paid-tier quota store."""
 
 import asyncio
 import sys
@@ -25,56 +25,63 @@ def _reset_store():
 
 
 def test_daily_cap_for_known_plans():
-    assert user_quotas.daily_cap_for("free") == user_quotas.CLAUDE_FREE_DAILY
-    assert user_quotas.daily_cap_for("pro") == user_quotas.CLAUDE_PRO_DAILY
-    assert user_quotas.daily_cap_for("org") == user_quotas.CLAUDE_FREE_DAILY
+    assert user_quotas.daily_cap_for("free") == 0
+    assert user_quotas.daily_cap_for("pro") == user_quotas.PRO_DAILY_SESSIONS
+    assert user_quotas.daily_cap_for("org") == 0
 
 
 def test_daily_cap_for_unknown_or_missing_defaults_to_free():
-    assert user_quotas.daily_cap_for(None) == user_quotas.CLAUDE_FREE_DAILY
-    assert user_quotas.daily_cap_for("") == user_quotas.CLAUDE_FREE_DAILY
-    assert user_quotas.daily_cap_for("mystery") == user_quotas.CLAUDE_FREE_DAILY
+    assert user_quotas.daily_cap_for(None) == 0
+    assert user_quotas.daily_cap_for("") == 0
+    assert user_quotas.daily_cap_for("mystery") == 0
 
 
 @pytest.mark.asyncio
 async def test_increment_and_read_back_same_day():
-    assert await user_quotas.get_claude_used_today("u1") == 0
-    assert await user_quotas.increment_claude("u1") == 1
-    assert await user_quotas.increment_claude("u1") == 2
-    assert await user_quotas.get_claude_used_today("u1") == 2
+    assert await user_quotas.get_paid_used_today("u1") == 0
+    assert await user_quotas.increment_paid("u1") == 1
+    assert await user_quotas.increment_paid("u1") == 2
+    assert await user_quotas.get_paid_used_today("u1") == 2
 
 
 @pytest.mark.asyncio
 async def test_independent_users_do_not_share_counts():
-    await user_quotas.increment_claude("alice")
-    await user_quotas.increment_claude("alice")
-    await user_quotas.increment_claude("bob")
-    assert await user_quotas.get_claude_used_today("alice") == 2
-    assert await user_quotas.get_claude_used_today("bob") == 1
+    await user_quotas.increment_paid("alice")
+    await user_quotas.increment_paid("alice")
+    await user_quotas.increment_paid("bob")
+    assert await user_quotas.get_paid_used_today("alice") == 2
+    assert await user_quotas.get_paid_used_today("bob") == 1
 
 
 @pytest.mark.asyncio
 async def test_stale_day_resets_before_next_read():
-    await user_quotas.increment_claude("u1")
+    await user_quotas.increment_paid("u1")
     # Simulate yesterday's entry still in the store.
-    user_quotas._claude_counts["u1"] = ("2000-01-01", 99)
-    assert await user_quotas.get_claude_used_today("u1") == 0
+    user_quotas._paid_counts["u1"] = ("2000-01-01", 99)
+    assert await user_quotas.get_paid_used_today("u1") == 0
     # And a fresh increment starts from 0.
-    assert await user_quotas.increment_claude("u1") == 1
+    assert await user_quotas.increment_paid("u1") == 1
 
 
 @pytest.mark.asyncio
 async def test_concurrent_increments_under_lock_do_not_lose_writes():
     """50 coroutines bumping the same user must land at exactly 50."""
-    await asyncio.gather(*[user_quotas.increment_claude("race") for _ in range(50)])
-    assert await user_quotas.get_claude_used_today("race") == 50
+    await asyncio.gather(*[user_quotas.increment_paid("race") for _ in range(50)])
+    assert await user_quotas.get_paid_used_today("race") == 50
 
 
 @pytest.mark.asyncio
 async def test_try_increment_returns_none_at_cap():
-    assert await user_quotas.try_increment_claude("freebie", 1) == 1
-    assert await user_quotas.try_increment_claude("freebie", 1) is None
-    assert await user_quotas.get_claude_used_today("freebie") == 1
+    assert await user_quotas.try_increment_paid("probie", 1) == 1
+    assert await user_quotas.try_increment_paid("probie", 1) is None
+    assert await user_quotas.get_paid_used_today("probie") == 1
+
+
+@pytest.mark.asyncio
+async def test_try_increment_returns_none_at_zero_cap_without_counting():
+    assert await user_quotas.try_increment_paid("freebie", 0) is None
+    assert await user_quotas.get_paid_used_today("freebie") == 0
+    assert "freebie" not in user_quotas._paid_counts
 
 
 @pytest.mark.asyncio
@@ -92,42 +99,32 @@ async def test_try_increment_delegates_cap_to_enabled_store():
 
     _reset_store_for_tests(StoreAtCap())
 
-    assert await user_quotas.try_increment_claude("mongo-user", 1) is None
-    assert await user_quotas.get_claude_used_today("mongo-user") == 1
-    assert "mongo-user" not in user_quotas._claude_counts
+    assert await user_quotas.try_increment_paid("mongo-user", 1) is None
+    assert await user_quotas.get_paid_used_today("mongo-user") == 1
+    assert "mongo-user" not in user_quotas._paid_counts
 
 
 @pytest.mark.asyncio
 async def test_refund_decrements_and_drops_entry_at_zero():
-    await user_quotas.increment_claude("u1")
-    assert await user_quotas.get_claude_used_today("u1") == 1
-    await user_quotas.refund_claude("u1")
-    assert await user_quotas.get_claude_used_today("u1") == 0
-    assert "u1" not in user_quotas._claude_counts
+    await user_quotas.increment_paid("u1")
+    assert await user_quotas.get_paid_used_today("u1") == 1
+    await user_quotas.refund_paid("u1")
+    assert await user_quotas.get_paid_used_today("u1") == 0
+    assert "u1" not in user_quotas._paid_counts
 
 
 @pytest.mark.asyncio
 async def test_refund_on_nonexistent_user_is_noop():
-    await user_quotas.refund_claude("ghost")  # should not raise
-    assert await user_quotas.get_claude_used_today("ghost") == 0
+    await user_quotas.refund_paid("ghost")  # should not raise
+    assert await user_quotas.get_paid_used_today("ghost") == 0
 
 
 @pytest.mark.asyncio
 async def test_refund_on_stale_day_resets_rather_than_underflow():
-    user_quotas._claude_counts["u1"] = ("2000-01-01", 5)
-    await user_quotas.refund_claude("u1")
+    user_quotas._paid_counts["u1"] = ("2000-01-01", 5)
+    await user_quotas.refund_paid("u1")
     # Stale entry dropped; today's count stays 0.
-    assert await user_quotas.get_claude_used_today("u1") == 0
-
-
-@pytest.mark.asyncio
-async def test_free_user_cap_reached_at_two():
-    cap = user_quotas.daily_cap_for("free")
-    assert cap == 2
-    assert await user_quotas.increment_claude("freebie") == 1
-    used = await user_quotas.increment_claude("freebie")
-    assert used == 2
-    assert used >= cap
+    assert await user_quotas.get_paid_used_today("u1") == 0
 
 
 @pytest.mark.asyncio
@@ -135,7 +132,7 @@ async def test_pro_user_cap_reached_at_twenty():
     cap = user_quotas.daily_cap_for("pro")
     assert cap == 20
     for i in range(1, 21):
-        assert await user_quotas.increment_claude("pro_user") == i
+        assert await user_quotas.increment_paid("pro_user") == i
     # 21st would exceed — the gate in routes/agent.py enforces this; here
     # we just confirm the counter tracks past the cap so that check works.
-    assert await user_quotas.increment_claude("pro_user") == 21
+    assert await user_quotas.increment_paid("pro_user") == 21


### PR DESCRIPTION
## Summary
- Replace the premium and Pro-only model policy with free and paid tiers.
- Make Kimi K2.6 the non-Pro default and Opus 4.8 the Pro default.
- Allow any user to select Opus 4.8 or GPT-5.5, with paid-tier usage outside included Pro allowance billed to the user account.
- Preserve UTC daily quota accounting across sessions with the paid_counted_day session marker.
- Remove Claude Sonnet from model catalogs, defaults, docs, and tests.

## Testing
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- uv run --extra dev pytest tests/unit/test_agent_model_gating.py tests/unit/test_user_quotas.py tests/unit/test_session_manager_persistence.py tests/unit/test_session_persistence.py tests/unit/test_llm_params.py tests/unit/test_cli_local_models.py tests/unit/test_prompt_caching.py
- uv run --frozen --extra dev pytest tests/unit/test_agent_model_gating.py tests/unit/test_cli_local_models.py
- npm run build