### PR TITLE
Make LLM health check use request token

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -148,7 +148,7 @@ class HealthResponse(BaseModel):
 class LLMHealthResponse(BaseModel):
     """LLM provider health check response."""
 
-    status: str  # "ok" | "error"
+    status: str  # "ok" | "error" | "skipped"
     model: str
     error: str | None = None
     error_type: str | None = (

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -51,6 +51,7 @@ from session_manager import (
 
 from agent.core.hf_access import get_jobs_access
 from agent.core.hf_tokens import resolve_hf_request_token
+from agent.core.local_models import local_model_provider
 from agent.core.llm_params import _resolve_llm_params
 from agent.core.model_ids import (
     CLAUDE_OPUS_48_MODEL_ID,
@@ -59,6 +60,7 @@ from agent.core.model_ids import (
     GPT_55_MODEL_ID,
     KIMI_K26_MODEL_ID,
     MINIMAX_M27_MODEL_ID,
+    strip_huggingface_model_prefix,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,6 +144,11 @@ def _user_hf_token(user: dict[str, Any] | None) -> str | None:
     if not isinstance(user, dict):
         return None
     return user.get(INTERNAL_HF_TOKEN_KEY)
+
+
+def _model_requires_hf_router_token(model_id: str | None) -> bool:
+    normalized = strip_huggingface_model_prefix(model_id) or model_id or ""
+    return local_model_provider(normalized) is None
 
 
 def _reject_oversize_dataset_upload(request: Request) -> None:
@@ -241,7 +248,7 @@ async def health_check() -> HealthResponse:
 
 
 @router.get("/health/llm", response_model=LLMHealthResponse)
-async def llm_health_check() -> LLMHealthResponse:
+async def llm_health_check(request: Request) -> LLMHealthResponse:
     """Check if the LLM provider is reachable and the API key is valid.
 
     Makes a minimal 1-token completion call.  Catches common errors:
@@ -251,8 +258,16 @@ async def llm_health_check() -> LLMHealthResponse:
     - timeout / network → provider unreachable
     """
     model = session_manager.config.model_name
+    hf_token = resolve_hf_request_token(request)
+    if _model_requires_hf_router_token(model) and not hf_token:
+        return LLMHealthResponse(status="skipped", model=model)
+
     try:
-        llm_params = _resolve_llm_params(model, reasoning_effort="high")
+        llm_params = _resolve_llm_params(
+            model,
+            hf_token,
+            reasoning_effort="high",
+        )
         await acompletion(
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=1,

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -251,7 +251,9 @@ async def health_check() -> HealthResponse:
 async def llm_health_check(request: Request) -> LLMHealthResponse:
     """Check if the LLM provider is reachable and the API key is valid.
 
-    Makes a minimal 1-token completion call.  Catches common errors:
+    Makes a minimal 1-token completion call when a token is available. For
+    token-less HF Router requests, returns ``status="skipped"`` instead of
+    making an unauthenticated probe. Catches common errors:
     - 401 → invalid API key
     - 402/insufficient_quota → out of credits
     - 429 → rate limited

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -33,6 +33,75 @@ def test_default_model_for_user_is_plan_aware():
 
 
 @pytest.mark.asyncio
+async def test_llm_health_uses_request_hf_token(monkeypatch):
+    class Request:
+        headers = {"Authorization": "Bearer user-token"}
+        cookies = {}
+
+    resolved = []
+    completions = []
+
+    def fake_resolve_llm_params(
+        model_name,
+        session_hf_token=None,
+        reasoning_effort=None,
+        strict=False,
+    ):
+        resolved.append((model_name, session_hf_token, reasoning_effort, strict))
+        return {
+            "model": f"openai/{model_name}",
+            "api_base": "https://router.huggingface.co/v1",
+            "api_key": session_hf_token,
+        }
+
+    async def fake_acompletion(**kwargs):
+        completions.append(kwargs)
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "config",
+        SimpleNamespace(model_name=agent.DEFAULT_FREE_MODEL_ID),
+    )
+    monkeypatch.setattr(agent, "_resolve_llm_params", fake_resolve_llm_params)
+    monkeypatch.setattr(agent, "acompletion", fake_acompletion)
+
+    response = await agent.llm_health_check(Request())
+
+    assert response.status == "ok"
+    assert resolved == [(agent.DEFAULT_FREE_MODEL_ID, "user-token", "high", False)]
+    assert completions[0]["api_key"] == "user-token"
+
+
+@pytest.mark.asyncio
+async def test_llm_health_skips_router_probe_without_token(monkeypatch):
+    class Request:
+        headers = {}
+        cookies = {}
+
+    def fail_resolve_llm_params(*args, **kwargs):
+        raise AssertionError(
+            "health check should not resolve router params without token"
+        )
+
+    async def fail_acompletion(**kwargs):
+        raise AssertionError("health check should not call LiteLLM without token")
+
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(
+        agent.session_manager,
+        "config",
+        SimpleNamespace(model_name=agent.DEFAULT_FREE_MODEL_ID),
+    )
+    monkeypatch.setattr(agent, "_resolve_llm_params", fail_resolve_llm_params)
+    monkeypatch.setattr(agent, "acompletion", fail_acompletion)
+
+    response = await agent.llm_health_check(Request())
+
+    assert response.status == "skipped"
+    assert response.model == agent.DEFAULT_FREE_MODEL_ID
+
+
+@pytest.mark.asyncio
 async def test_empty_session_model_uses_plan_default():
     assert (
         await agent._model_override_for_new_session(None, {"plan": "pro"})


### PR DESCRIPTION
## Summary

- Make `/api/health/llm` resolve the request HF token before probing HF Router models.
- Skip unauthenticated HF Router health probes instead of surfacing a false invalid API key error.
- Add unit coverage for request-token propagation and the no-token skip path.

## Tests

- `uv run --extra dev pytest tests/unit/test_agent_model_gating.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
