### PR TITLE
Fix billing usage visibility

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -43,6 +43,7 @@ OAUTH_SCOPE_COOKIE = "hf_oauth_scope_hash"
 REQUIRED_OAUTH_SCOPES: tuple[str, ...] = (
     "openid",
     "profile",
+    "read-billing",
     "read-repos",
     "write-repos",
     "contribute-repos",

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -28,6 +29,24 @@ function formatUsd(value: number | undefined): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(amount);
+}
+
+function preferLiveEstimate(
+  accountValue: number | null | undefined,
+  telemetryValue: number | null | undefined,
+): number | undefined {
+  if (accountValue == null) return telemetryValue ?? undefined;
+  if (accountValue <= 0 && (telemetryValue ?? 0) > 0) return telemetryValue ?? accountValue;
+  return accountValue;
+}
+
+function billingUnavailableMessage(error: string | null | undefined): string | null {
+  if (!error) return null;
+  if (error === 'missing_hf_token') return 'Sign in to view HF account billing usage.';
+  if (error === 'billing_usage_unavailable') {
+    return 'HF billing usage is unavailable for this login. Showing app telemetry estimates.';
+  }
+  return 'HF billing usage is unavailable. Showing app telemetry estimates.';
 }
 
 function UsageRow({
@@ -87,12 +106,16 @@ function AccountUsageSection({
       <UsageGrid>
         <UsageRow
           label="Inference Providers"
-          value={formatUsd(account?.inference_providers_usd ?? telemetry?.inference_usd)}
+          value={formatUsd(
+            preferLiveEstimate(account?.inference_providers_usd, telemetry?.inference_usd),
+          )}
           strong
         />
         <UsageRow
           label={account ? 'HF Jobs' : 'HF Jobs estimated'}
-          value={formatUsd(account?.hf_jobs_usd ?? telemetry?.hf_jobs_estimated_usd)}
+          value={formatUsd(
+            preferLiveEstimate(account?.hf_jobs_usd, telemetry?.hf_jobs_estimated_usd),
+          )}
         />
       </UsageGrid>
     </Box>
@@ -140,8 +163,12 @@ export default function UsageMeter() {
   }, [activeSessionId, fetchUsage]);
 
   const sessionTotal =
-    usage?.hf_account?.current_session?.total_usd ?? usage?.session?.total_usd ?? 0;
+    preferLiveEstimate(
+      usage?.hf_account?.current_session?.total_usd,
+      usage?.session?.total_usd,
+    ) ?? 0;
   const links = useMemo(() => usage?.links ?? {}, [usage?.links]);
+  const billingMessage = billingUnavailableMessage(usage?.hf_account?.error);
   const open = Boolean(anchorEl);
 
   return (
@@ -199,6 +226,11 @@ export default function UsageMeter() {
           </Typography>
         ) : (
           <>
+            {billingMessage && (
+              <Alert severity="info" sx={{ mt: 1.5, py: 0.25 }}>
+                {billingMessage}
+              </Alert>
+            )}
             <AccountUsageSection
               title="Current session"
               account={usage?.hf_account?.current_session ?? null}

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -31,22 +31,17 @@ function formatUsd(value: number | undefined): string {
   }).format(amount);
 }
 
-function preferLiveEstimate(
-  accountValue: number | null | undefined,
-  telemetryValue: number | null | undefined,
-): number | undefined {
-  if (accountValue == null) return telemetryValue ?? undefined;
-  if (accountValue <= 0 && (telemetryValue ?? 0) > 0) return telemetryValue ?? accountValue;
-  return accountValue;
+function formatCount(value: number | undefined): string {
+  return new Intl.NumberFormat('en-US').format(value ?? 0);
 }
 
 function billingUnavailableMessage(error: string | null | undefined): string | null {
   if (!error) return null;
   if (error === 'missing_hf_token') return 'Sign in to view HF account billing usage.';
   if (error === 'billing_usage_unavailable') {
-    return 'HF billing usage is unavailable for this login. Showing app telemetry estimates.';
+    return 'HF billing usage is unavailable. Showing app-observed calls and tokens; inference cost may be incomplete.';
   }
-  return 'HF billing usage is unavailable. Showing app telemetry estimates.';
+  return 'HF billing usage is unavailable. Showing app-observed calls and tokens; inference cost may be incomplete.';
 }
 
 function UsageRow({
@@ -98,6 +93,9 @@ function AccountUsageSection({
   account: HfAccountUsageBucket | null | undefined;
   telemetry: UsageBucket | null | undefined;
 }) {
+  const useJobEstimate =
+    !account || (account.hf_jobs_usd <= 0 && (telemetry?.hf_jobs_estimated_usd ?? 0) > 0);
+
   return (
     <Box sx={{ py: 1 }}>
       <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 700 }}>
@@ -106,16 +104,19 @@ function AccountUsageSection({
       <UsageGrid>
         <UsageRow
           label="Inference Providers"
-          value={formatUsd(
-            preferLiveEstimate(account?.inference_providers_usd, telemetry?.inference_usd),
-          )}
+          value={account ? formatUsd(account.inference_providers_usd) : 'Unavailable'}
           strong
         />
         <UsageRow
-          label={account ? 'HF Jobs' : 'HF Jobs estimated'}
+          label={useJobEstimate ? 'HF Jobs estimated' : 'HF Jobs'}
           value={formatUsd(
-            preferLiveEstimate(account?.hf_jobs_usd, telemetry?.hf_jobs_estimated_usd),
+            useJobEstimate ? telemetry?.hf_jobs_estimated_usd : account?.hf_jobs_usd,
           )}
+        />
+        <UsageRow label="LLM calls" value={formatCount(telemetry?.llm_calls)} />
+        <UsageRow
+          label="Tokens"
+          value={formatCount(telemetry?.total_tokens)}
         />
       </UsageGrid>
     </Box>
@@ -162,11 +163,7 @@ export default function UsageMeter() {
     void fetchUsage(activeSessionId);
   }, [activeSessionId, fetchUsage]);
 
-  const sessionTotal =
-    preferLiveEstimate(
-      usage?.hf_account?.current_session?.total_usd,
-      usage?.session?.total_usd,
-    ) ?? 0;
+  const sessionTotal = usage?.hf_account?.current_session?.total_usd;
   const links = useMemo(() => usage?.links ?? {}, [usage?.links]);
   const billingMessage = billingUnavailableMessage(usage?.hf_account?.error);
   const open = Boolean(anchorEl);
@@ -190,7 +187,7 @@ export default function UsageMeter() {
             '&:hover': { borderColor: 'primary.main', color: 'primary.main' },
           }}
         >
-          {formatUsd(sessionTotal)}
+          {sessionTotal == null ? 'Usage' : formatUsd(sessionTotal)}
         </Button>
       </Tooltip>
       <Popover
@@ -217,7 +214,7 @@ export default function UsageMeter() {
           Usage
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          Session billing is inferred from HF account usage since session start.
+          Session billing uses HF account usage since session start.
         </Typography>
 
         {error ? (

--- a/tests/unit/test_auth_token_propagation.py
+++ b/tests/unit/test_auth_token_propagation.py
@@ -120,6 +120,7 @@ async def test_oauth_login_requests_collection_write_scope(monkeypatch):
     scopes = set(params["scope"][0].split())
 
     assert "write-collections" in scopes
+    assert "read-billing" in scopes
 
 
 def test_oauth_callback_detects_missing_required_collection_scope():
@@ -127,6 +128,14 @@ def test_oauth_callback_detects_missing_required_collection_scope():
 
     assert auth._missing_required_scopes({"scope": " ".join(granted)}) == {
         "write-collections"
+    }
+
+
+def test_oauth_callback_detects_missing_required_billing_scope():
+    granted = [scope for scope in auth.OAUTH_SCOPES if scope != "read-billing"]
+
+    assert auth._missing_required_scopes({"scope": " ".join(granted)}) == {
+        "read-billing"
     }
 
 

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -242,6 +242,42 @@ async def test_runtime_usage_interprets_naive_timestamps_in_browser_timezone():
 
 
 @pytest.mark.asyncio
+async def test_hf_account_usage_reports_missing_token_error():
+    manager = _Manager({})
+
+    usage = await build_usage_response(
+        manager,
+        user_id="owner",
+        timezone_name="UTC",
+        now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+    )
+
+    assert usage["hf_account"]["available"] is False
+    assert usage["hf_account"]["error"] == "missing_hf_token"
+
+
+@pytest.mark.asyncio
+async def test_hf_account_usage_reports_billing_unavailable_error(monkeypatch):
+    manager = _Manager({})
+
+    async def fake_fetch(_token, *, start, end):
+        return None
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+
+    usage = await build_usage_response(
+        manager,
+        user_id="owner",
+        hf_token="hf_fake",
+        timezone_name="UTC",
+        now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+    )
+
+    assert usage["hf_account"]["available"] is False
+    assert usage["hf_account"]["error"] == "billing_usage_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_hf_account_usage_uses_session_start_for_current_delta(monkeypatch):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
     manager = _Manager(


### PR DESCRIPTION
## Summary
- request and validate the HF `read-billing` OAuth scope
- show a usage-meter notice when HF billing usage is unavailable
- keep Inference Providers cost display tied to HF billing readback instead of LiteLLM pricing
- show app-observed LLM calls and tokens when billing readback is unavailable

## Tests
- `uv run pytest tests/unit/test_auth_token_propagation.py tests/unit/test_usage.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `npm run build`
- `npm run lint` (passes with existing warnings in `frontend/src/main.tsx` and `frontend/src/utils/logger.ts`)

## Deploy note
Before deploying this to the Space, add `read-billing` to the Space-only README frontmatter on `space-main` so the Space OAuth app is configured to grant the scope. Existing users will be forced through OAuth again because the scope fingerprint changes.
