### PR TITLE
Reset usage billing window on session activation

### DIFF
--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -167,6 +167,7 @@ class MongoSessionStore(NoopSessionStore):
         title: str | None = None,
         surface: str = "frontend",
         created_at: datetime | None = None,
+        usage_window_started_at: datetime | None = None,
         runtime_state: str = "idle",
         status: str = "active",
         message_count: int = 0,
@@ -195,6 +196,9 @@ class MongoSessionStore(NoopSessionStore):
                 "$set": {
                     "title": title,
                     "model": model,
+                    "usage_window_started_at": (
+                        usage_window_started_at or created_at or now
+                    ),
                     "status": status,
                     "runtime_state": runtime_state,
                     "updated_at": now,
@@ -224,6 +228,7 @@ class MongoSessionStore(NoopSessionStore):
         turn_count: int = 0,
         pending_approval: list[dict[str, Any]] | None = None,
         created_at: datetime | None = None,
+        usage_window_started_at: datetime | None = None,
         notification_destinations: list[str] | None = None,
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
@@ -247,6 +252,7 @@ class MongoSessionStore(NoopSessionStore):
             turn_count=turn_count,
             pending_approval=pending_approval,
             notification_destinations=notification_destinations,
+            usage_window_started_at=usage_window_started_at,
             auto_approval_enabled=auto_approval_enabled,
             auto_approval_cost_cap_usd=auto_approval_cost_cap_usd,
             auto_approval_estimated_spend_usd=auto_approval_estimated_spend_usd,

--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -168,6 +168,7 @@ class MongoSessionStore(NoopSessionStore):
         surface: str = "frontend",
         created_at: datetime | None = None,
         usage_window_started_at: datetime | None = None,
+        usage_window_baseline: dict[str, Any] | None = None,
         runtime_state: str = "idle",
         status: str = "active",
         message_count: int = 0,
@@ -199,6 +200,7 @@ class MongoSessionStore(NoopSessionStore):
                     "usage_window_started_at": (
                         usage_window_started_at or created_at or now
                     ),
+                    "usage_window_baseline": usage_window_baseline,
                     "status": status,
                     "runtime_state": runtime_state,
                     "updated_at": now,
@@ -229,6 +231,7 @@ class MongoSessionStore(NoopSessionStore):
         pending_approval: list[dict[str, Any]] | None = None,
         created_at: datetime | None = None,
         usage_window_started_at: datetime | None = None,
+        usage_window_baseline: dict[str, Any] | None = None,
         notification_destinations: list[str] | None = None,
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
@@ -253,6 +256,7 @@ class MongoSessionStore(NoopSessionStore):
             pending_approval=pending_approval,
             notification_destinations=notification_destinations,
             usage_window_started_at=usage_window_started_at,
+            usage_window_baseline=usage_window_baseline,
             auto_approval_enabled=auto_approval_enabled,
             auto_approval_cost_cap_usd=auto_approval_cost_cap_usd,
             auto_approval_estimated_spend_usd=auto_approval_estimated_spend_usd,

--- a/backend/models.py
+++ b/backend/models.py
@@ -94,6 +94,7 @@ class SessionInfo(BaseModel):
 
     session_id: str
     created_at: str
+    usage_window_started_at: str | None = None
     is_active: bool
     is_processing: bool = False
     message_count: int

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -7,6 +7,7 @@ dependency. In dev mode (no OAUTH_CLIENT_ID), auth is bypassed automatically.
 import asyncio
 import json
 import logging
+from datetime import datetime
 from typing import Any
 
 from dependencies import (
@@ -63,7 +64,7 @@ from agent.core.model_ids import (
     MINIMAX_M27_MODEL_ID,
     strip_huggingface_model_prefix,
 )
-from usage import build_usage_response
+from usage import build_usage_response, capture_hf_account_usage_baseline
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,20 @@ DEFAULT_OPUS_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 DEFAULT_GPT_MODEL_ID = GPT_55_MODEL_ID
 DEFAULT_FREE_MODEL_ID = KIMI_K26_MODEL_ID
 DATASET_UPLOAD_MULTIPART_SLACK_BYTES = 1024 * 1024
+
+
+async def _reset_usage_window_with_hf_baseline(
+    session_id: str,
+    hf_token: str | None,
+) -> dict[str, Any] | None:
+    baseline = await capture_hf_account_usage_baseline(hf_token)
+    captured_at = baseline.get("captured_at") if baseline else None
+    started_at = captured_at if isinstance(captured_at, datetime) else datetime.utcnow()
+    return await session_manager.reset_session_usage_window(
+        session_id,
+        started_at=started_at,
+        baseline=baseline,
+    )
 
 
 def _available_models() -> list[dict[str, Any]]:
@@ -431,6 +446,8 @@ async def create_session(
     except SessionCapacityError as e:
         raise HTTPException(status_code=503, detail=str(e))
 
+    await _reset_usage_window_with_hf_baseline(session_id, hf_token)
+
     return SessionResponse(
         session_id=session_id,
         ready=True,
@@ -471,6 +488,8 @@ async def restore_session_summary(
         )
     except SessionCapacityError as e:
         raise HTTPException(status_code=503, detail=str(e))
+
+    await _reset_usage_window_with_hf_baseline(session_id, hf_token)
 
     await _check_session_access(
         session_id,
@@ -515,7 +534,8 @@ async def activate_session(
 ) -> SessionInfo:
     """Mark a session as actively revisited and reset its usage meter window."""
     await _check_session_access(session_id, user, request)
-    info = await session_manager.reset_session_usage_window(session_id)
+    hf_token = resolve_hf_request_token(request)
+    info = await _reset_usage_window_with_hf_baseline(session_id, hf_token)
     if not info:
         raise HTTPException(status_code=404, detail="Session not found")
     return SessionInfo(**info)

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -507,6 +507,20 @@ async def get_session(
     return SessionInfo(**info)
 
 
+@router.post("/session/{session_id}/activate", response_model=SessionInfo)
+async def activate_session(
+    session_id: str,
+    request: Request,
+    user: dict = Depends(get_current_user),
+) -> SessionInfo:
+    """Mark a session as actively revisited and reset its usage meter window."""
+    await _check_session_access(session_id, user, request)
+    info = await session_manager.reset_session_usage_window(session_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return SessionInfo(**info)
+
+
 @router.post("/session/{session_id}/model")
 async def set_session_model(
     session_id: str,

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -113,6 +113,7 @@ class AgentSession:
     broadcaster: Any = None
     title: str | None = None
     usage_window_started_at: datetime | None = None
+    usage_window_baseline: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if self.usage_window_started_at is None:
@@ -597,6 +598,7 @@ class SessionManager:
                 ),
                 created_at=agent_session.created_at,
                 usage_window_started_at=agent_session.usage_window_started_at,
+                usage_window_baseline=agent_session.usage_window_baseline,
                 notification_destinations=list(
                     agent_session.session.notification_destinations
                 ),
@@ -759,6 +761,9 @@ class SessionManager:
         usage_window_started_at = meta.get("usage_window_started_at")
         if not isinstance(usage_window_started_at, datetime):
             usage_window_started_at = created_at
+        usage_window_baseline = meta.get("usage_window_baseline")
+        if not isinstance(usage_window_baseline, dict):
+            usage_window_baseline = None
 
         agent_session = AgentSession(
             session_id=session_id,
@@ -770,6 +775,7 @@ class SessionManager:
             hf_token=hf_token,
             created_at=created_at,
             usage_window_started_at=usage_window_started_at,
+            usage_window_baseline=usage_window_baseline,
             is_active=True,
             is_processing=False,
             title=meta.get("title"),
@@ -1508,6 +1514,7 @@ class SessionManager:
         session_id: str,
         *,
         started_at: datetime | None = None,
+        baseline: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Reset the account-billing window used for the visible usage meter."""
         agent_session = self.sessions.get(session_id)
@@ -1516,6 +1523,7 @@ class SessionManager:
 
         window_start = started_at or datetime.utcnow()
         agent_session.usage_window_started_at = window_start
+        agent_session.usage_window_baseline = baseline
         self._touch(agent_session)
 
         store = self._store()
@@ -1523,6 +1531,7 @@ class SessionManager:
             await store.update_session_fields(
                 session_id,
                 usage_window_started_at=window_start,
+                usage_window_baseline=baseline,
                 last_active_at=agent_session.last_active_at,
             )
         return self.get_session_info(session_id)

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -112,6 +112,11 @@ class AgentSession:
     is_reaping: bool = False
     broadcaster: Any = None
     title: str | None = None
+    usage_window_started_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.usage_window_started_at is None:
+            self.usage_window_started_at = self.created_at
 
 
 class SessionCapacityError(Exception):
@@ -591,6 +596,7 @@ class SessionManager:
                     agent_session.session
                 ),
                 created_at=agent_session.created_at,
+                usage_window_started_at=agent_session.usage_window_started_at,
                 notification_destinations=list(
                     agent_session.session.notification_destinations
                 ),
@@ -750,6 +756,9 @@ class SessionManager:
         created_at = meta.get("created_at")
         if not isinstance(created_at, datetime):
             created_at = datetime.utcnow()
+        usage_window_started_at = meta.get("usage_window_started_at")
+        if not isinstance(usage_window_started_at, datetime):
+            usage_window_started_at = created_at
 
         agent_session = AgentSession(
             session_id=session_id,
@@ -760,6 +769,7 @@ class SessionManager:
             hf_username=hf_username,
             hf_token=hf_token,
             created_at=created_at,
+            usage_window_started_at=usage_window_started_at,
             is_active=True,
             is_processing=False,
             title=meta.get("title"),
@@ -1477,6 +1487,9 @@ class SessionManager:
         return {
             "session_id": session_id,
             "created_at": agent_session.created_at.isoformat(),
+            "usage_window_started_at": (
+                agent_session.usage_window_started_at or agent_session.created_at
+            ).isoformat(),
             "is_active": agent_session.is_active,
             "is_processing": agent_session.is_processing,
             "message_count": len(agent_session.session.context_manager.items),
@@ -1489,6 +1502,30 @@ class SessionManager:
             ),
             "auto_approval": self._auto_approval_summary(agent_session.session),
         }
+
+    async def reset_session_usage_window(
+        self,
+        session_id: str,
+        *,
+        started_at: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        """Reset the account-billing window used for the visible usage meter."""
+        agent_session = self.sessions.get(session_id)
+        if not agent_session:
+            return None
+
+        window_start = started_at or datetime.utcnow()
+        agent_session.usage_window_started_at = window_start
+        self._touch(agent_session)
+
+        store = self._store()
+        if getattr(store, "enabled", False):
+            await store.update_session_fields(
+                session_id,
+                usage_window_started_at=window_start,
+                last_active_at=agent_session.last_active_at,
+            )
+        return self.get_session_info(session_id)
 
     def set_notification_destinations(
         self, session_id: str, destinations: list[str]
@@ -1540,11 +1577,21 @@ class SessionManager:
                     created_at_str = created_at.isoformat()
                 else:
                     created_at_str = str(created_at or datetime.utcnow().isoformat())
+                usage_window_started_at = (
+                    row.get("usage_window_started_at") or created_at
+                )
+                if isinstance(usage_window_started_at, datetime):
+                    usage_window_started_at_str = usage_window_started_at.isoformat()
+                else:
+                    usage_window_started_at_str = str(
+                        usage_window_started_at or created_at_str
+                    )
                 pending = self._pending_docs_for_api(row.get("pending_approval") or [])
                 results.append(
                     {
                         "session_id": str(sid),
                         "created_at": created_at_str,
+                        "usage_window_started_at": usage_window_started_at_str,
                         "is_active": row.get("status") != "ended",
                         "is_processing": row.get("runtime_state") == "processing",
                         "message_count": int(row.get("message_count") or 0),

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -319,17 +319,22 @@ async def _fetch_hf_billing_usage_v2(
         return None
 
 
-def _session_started_at(manager: Any, session_id: str | None) -> datetime | None:
+def _session_usage_window_started_at(
+    manager: Any, session_id: str | None
+) -> datetime | None:
     if not session_id:
         return None
     agent_session = getattr(manager, "sessions", {}).get(session_id)
+    usage_window_started_at = getattr(agent_session, "usage_window_started_at", None)
+    if isinstance(usage_window_started_at, datetime):
+        return _utc(usage_window_started_at)
     created_at = getattr(agent_session, "created_at", None)
     if isinstance(created_at, datetime):
         return _utc(created_at)
     return None
 
 
-async def _load_persisted_session_started_at(
+async def _load_persisted_session_usage_window_started_at(
     manager: Any,
     session_id: str | None,
 ) -> datetime | None:
@@ -340,10 +345,14 @@ async def _load_persisted_session_started_at(
         return None
     loaded = await store.load_session(session_id)
     metadata = loaded.get("metadata") if isinstance(loaded, dict) else None
-    created_at = metadata.get("created_at") if isinstance(metadata, dict) else None
-    if isinstance(created_at, datetime):
-        return _utc(created_at)
-    parsed = _parse_timestamp(created_at)
+    started_at = None
+    if isinstance(metadata, dict):
+        started_at = metadata.get("usage_window_started_at") or metadata.get(
+            "created_at"
+        )
+    if isinstance(started_at, datetime):
+        return _utc(started_at)
+    parsed = _parse_timestamp(started_at)
     return _utc(parsed) if parsed is not None else None
 
 
@@ -370,9 +379,11 @@ async def _build_hf_account_usage(
         account_usage["error"] = "missing_hf_token"
         return account_usage
 
-    session_start = _session_started_at(manager, session_id)
+    session_start = _session_usage_window_started_at(manager, session_id)
     if session_start is None:
-        session_start = await _load_persisted_session_started_at(manager, session_id)
+        session_start = await _load_persisted_session_usage_window_started_at(
+            manager, session_id
+        )
 
     window_tasks: dict[str, tuple[datetime, asyncio.Task[dict[str, Any] | None]]] = {
         "month": (

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -265,6 +265,90 @@ def _account_bucket_from_billing_usage(
     return bucket
 
 
+def _baseline_from_account_bucket(
+    bucket: dict[str, Any],
+    *,
+    captured_at: datetime,
+    month_start: datetime,
+) -> dict[str, Any]:
+    return {
+        "captured_at": _utc(captured_at),
+        "month_start": _utc(month_start),
+        "total_usd": bucket.get("total_usd", 0.0),
+        "inference_providers_usd": bucket.get("inference_providers_usd", 0.0),
+        "hf_jobs_usd": bucket.get("hf_jobs_usd", 0.0),
+        "inference_provider_requests": bucket.get("inference_provider_requests", 0),
+        "hf_jobs_minutes": bucket.get("hf_jobs_minutes", 0.0),
+    }
+
+
+def _baseline_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    parsed = _parse_timestamp(value)
+    return _utc(parsed) if parsed is not None else None
+
+
+def _baseline_delta_bucket(
+    bucket: dict[str, Any],
+    baseline: dict[str, Any],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    timezone: str,
+) -> dict[str, Any]:
+    delta = _empty_hf_account_bucket(
+        window_start=window_start,
+        window_end=window_end,
+        timezone=timezone,
+    )
+    for key in ("inference_providers_usd", "hf_jobs_usd", "hf_jobs_minutes"):
+        delta[key] = round(
+            max(0.0, _coerce_float(bucket.get(key)) - _coerce_float(baseline.get(key))),
+            6 if key != "hf_jobs_minutes" else 3,
+        )
+    delta["inference_provider_requests"] = max(
+        0,
+        _coerce_int(bucket.get("inference_provider_requests"))
+        - _coerce_int(baseline.get("inference_provider_requests")),
+    )
+    delta["total_usd"] = round(
+        delta["inference_providers_usd"] + delta["hf_jobs_usd"],
+        6,
+    )
+    return delta
+
+
+async def capture_hf_account_usage_baseline(
+    hf_token: str | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if not hf_token:
+        return None
+    windows = resolve_usage_windows("UTC", now=now)
+    now_utc = windows["now_utc"]
+    month_start = windows["month_start_utc"]
+    payload = await _fetch_hf_billing_usage_v2(
+        hf_token,
+        start=month_start,
+        end=now_utc,
+    )
+    if payload is None:
+        return None
+    bucket = _account_bucket_from_billing_usage(
+        payload,
+        window_start=month_start,
+        window_end=now_utc,
+        timezone="UTC",
+    )
+    return _baseline_from_account_bucket(
+        bucket,
+        captured_at=now_utc,
+        month_start=month_start,
+    )
+
+
 def _inference_credits_from_billing_usage(
     payload: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -334,6 +418,17 @@ def _session_usage_window_started_at(
     return None
 
 
+def _session_usage_window_baseline(
+    manager: Any,
+    session_id: str | None,
+) -> dict[str, Any] | None:
+    if not session_id:
+        return None
+    agent_session = getattr(manager, "sessions", {}).get(session_id)
+    baseline = getattr(agent_session, "usage_window_baseline", None)
+    return baseline if isinstance(baseline, dict) else None
+
+
 async def _load_persisted_session_usage_window_started_at(
     manager: Any,
     session_id: str | None,
@@ -341,7 +436,7 @@ async def _load_persisted_session_usage_window_started_at(
     if not session_id:
         return None
     store = manager._store()
-    if not getattr(store, "enabled", False):
+    if not getattr(store, "enabled", False) or not hasattr(store, "load_session"):
         return None
     loaded = await store.load_session(session_id)
     metadata = loaded.get("metadata") if isinstance(loaded, dict) else None
@@ -354,6 +449,23 @@ async def _load_persisted_session_usage_window_started_at(
         return _utc(started_at)
     parsed = _parse_timestamp(started_at)
     return _utc(parsed) if parsed is not None else None
+
+
+async def _load_persisted_session_usage_window_baseline(
+    manager: Any,
+    session_id: str | None,
+) -> dict[str, Any] | None:
+    if not session_id:
+        return None
+    store = manager._store()
+    if not getattr(store, "enabled", False) or not hasattr(store, "load_session"):
+        return None
+    loaded = await store.load_session(session_id)
+    metadata = loaded.get("metadata") if isinstance(loaded, dict) else None
+    if not isinstance(metadata, dict):
+        return None
+    baseline = metadata.get("usage_window_baseline")
+    return baseline if isinstance(baseline, dict) else None
 
 
 async def _build_hf_account_usage(
@@ -384,6 +496,15 @@ async def _build_hf_account_usage(
         session_start = await _load_persisted_session_usage_window_started_at(
             manager, session_id
         )
+    session_baseline = _session_usage_window_baseline(manager, session_id)
+    if session_baseline is None:
+        session_baseline = await _load_persisted_session_usage_window_baseline(
+            manager,
+            session_id,
+        )
+    baseline_month_start = None
+    if session_baseline is not None:
+        baseline_month_start = _baseline_datetime(session_baseline.get("month_start"))
 
     window_tasks: dict[str, tuple[datetime, asyncio.Task[dict[str, Any] | None]]] = {
         "month": (
@@ -401,12 +522,28 @@ async def _build_hf_account_usage(
             ),
         )
     if session_start is not None:
-        window_tasks["current_session"] = (
-            session_start,
-            asyncio.create_task(
-                _fetch_hf_billing_usage_v2(hf_token, start=session_start, end=now_utc)
-            ),
-        )
+        if baseline_month_start is not None:
+            window_tasks["current_session_baseline"] = (
+                baseline_month_start,
+                asyncio.create_task(
+                    _fetch_hf_billing_usage_v2(
+                        hf_token,
+                        start=baseline_month_start,
+                        end=now_utc,
+                    )
+                ),
+            )
+        else:
+            window_tasks["current_session"] = (
+                session_start,
+                asyncio.create_task(
+                    _fetch_hf_billing_usage_v2(
+                        hf_token,
+                        start=session_start,
+                        end=now_utc,
+                    )
+                ),
+            )
 
     payloads: dict[str, dict[str, Any] | None] = {}
     for name, (_, task) in window_tasks.items():
@@ -419,12 +556,34 @@ async def _build_hf_account_usage(
         return account_usage
 
     for name, (start, _) in window_tasks.items():
+        if name == "current_session_baseline":
+            continue
         payload = payloads.get(name)
         if payload is None:
             continue
         account_usage[name] = _account_bucket_from_billing_usage(
             payload,
             window_start=start,
+            window_end=now_utc,
+            timezone=timezone,
+        )
+
+    if (
+        session_start is not None
+        and session_baseline is not None
+        and baseline_month_start is not None
+        and payloads.get("current_session_baseline") is not None
+    ):
+        baseline_bucket = _account_bucket_from_billing_usage(
+            payloads.get("current_session_baseline"),
+            window_start=baseline_month_start,
+            window_end=now_utc,
+            timezone=timezone,
+        )
+        account_usage["current_session"] = _baseline_delta_bucket(
+            baseline_bucket,
+            session_baseline,
+            window_start=session_start,
             window_end=now_utc,
             timezone=timezone,
         )

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAgentChat } from '@/hooks/useAgentChat';
 import { useAgentStore } from '@/store/agentStore';
 import { useSessionStore } from '@/store/sessionStore';
-import { useUsageStore } from '@/store/usageStore';
 import MessageList from '@/components/Chat/MessageList';
 import ChatInput from '@/components/Chat/ChatInput';
 import ExpiredBanner from '@/components/Chat/ExpiredBanner';
@@ -25,8 +24,7 @@ interface SessionChatProps {
 
 export default function SessionChat({ sessionId, isActive, onSessionDead }: SessionChatProps) {
   const { isConnected, isProcessing, activityStatus, updateSession } = useAgentStore();
-  const { updateSessionTitle, sessions, setSessionProcessing, mergeServerSessions } =
-    useSessionStore();
+  const { updateSessionTitle, sessions, setSessionProcessing } = useSessionStore();
   const sessionMeta = sessions.find((s) => s.id === sessionId);
   const isExpired = sessionMeta?.expired === true;
   const [chatError, setChatError] = useState<string | null>(null);
@@ -64,29 +62,6 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
       useAgentStore.getState().setConnected(true);
     }
   }, [isActive, sessionId]);
-
-  useEffect(() => {
-    if (!isActive || isExpired) return;
-    let cancelled = false;
-
-    (async () => {
-      try {
-        const response = await apiFetch(`/api/session/${sessionId}/activate`, {
-          method: 'POST',
-        });
-        if (cancelled || !response.ok) return;
-        const info = await response.json();
-        mergeServerSessions([info]);
-        void useUsageStore.getState().fetchUsage(sessionId);
-      } catch {
-        /* best effort: usage falls back to the previously persisted window */
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isActive, isExpired, mergeServerSessions, sessionId]);
 
   // Re-sync state when the browser tab regains focus (Chrome throttles
   // timers in background tabs which can stall the AI SDK's update flushing).

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useAgentChat } from '@/hooks/useAgentChat';
 import { useAgentStore } from '@/store/agentStore';
 import { useSessionStore } from '@/store/sessionStore';
+import { useUsageStore } from '@/store/usageStore';
 import MessageList from '@/components/Chat/MessageList';
 import ChatInput from '@/components/Chat/ChatInput';
 import ExpiredBanner from '@/components/Chat/ExpiredBanner';
@@ -24,7 +25,8 @@ interface SessionChatProps {
 
 export default function SessionChat({ sessionId, isActive, onSessionDead }: SessionChatProps) {
   const { isConnected, isProcessing, activityStatus, updateSession } = useAgentStore();
-  const { updateSessionTitle, sessions, setSessionProcessing } = useSessionStore();
+  const { updateSessionTitle, sessions, setSessionProcessing, mergeServerSessions } =
+    useSessionStore();
   const sessionMeta = sessions.find((s) => s.id === sessionId);
   const isExpired = sessionMeta?.expired === true;
   const [chatError, setChatError] = useState<string | null>(null);
@@ -62,6 +64,29 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
       useAgentStore.getState().setConnected(true);
     }
   }, [isActive, sessionId]);
+
+  useEffect(() => {
+    if (!isActive || isExpired) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const response = await apiFetch(`/api/session/${sessionId}/activate`, {
+          method: 'POST',
+        });
+        if (cancelled || !response.ok) return;
+        const info = await response.json();
+        mergeServerSessions([info]);
+        void useUsageStore.getState().fetchUsage(sessionId);
+      } catch {
+        /* best effort: usage falls back to the previously persisted window */
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isActive, isExpired, mergeServerSessions, sessionId]);
 
   // Re-sync state when the browser tab regains focus (Chrome throttles
   // timers in background tabs which can stall the AI SDK's update flushing).

--- a/frontend/src/components/SessionSidebar/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar/SessionSidebar.tsx
@@ -18,6 +18,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import { useSessionStore } from '@/store/sessionStore';
 import { useAgentStore } from '@/store/agentStore';
+import { useUsageStore } from '@/store/usageStore';
 import { apiFetch } from '@/utils/api';
 
 interface SessionSidebarProps {
@@ -122,12 +123,28 @@ export default function SessionSidebar({ onClose }: SessionSidebarProps) {
 
   const handleSelect = useCallback(
     (sessionId: string) => {
+      const shouldResetUsageWindow = sessionId !== activeSessionId;
       switchSession(sessionId);
+      if (shouldResetUsageWindow) {
+        void (async () => {
+          try {
+            const response = await apiFetch(`/api/session/${sessionId}/activate`, {
+              method: 'POST',
+            });
+            if (!response.ok) return;
+            const info = await response.json();
+            mergeServerSessions([info]);
+            void useUsageStore.getState().fetchUsage(sessionId);
+          } catch {
+            /* best effort: usage falls back to the previously persisted window */
+          }
+        })();
+      }
       // Per-session state (plan, panel, activity) is restored automatically
       // by SessionChat's useEffect when isActive flips to true.
       onClose?.();
     },
-    [switchSession, onClose],
+    [activeSessionId, mergeServerSessions, switchSession, onClose],
   );
 
   const formatTime = (d: string) =>

--- a/frontend/src/components/SessionSidebar/SessionSidebar.tsx
+++ b/frontend/src/components/SessionSidebar/SessionSidebar.tsx
@@ -65,6 +65,7 @@ export default function SessionSidebar({ onClose }: SessionSidebarProps) {
       }
       const data = await response.json();
       createSession(data.session_id, data.model);
+      void useUsageStore.getState().fetchUsage(data.session_id);
       setPlan([]);
       clearPanel();
       onClose?.();
@@ -109,6 +110,7 @@ export default function SessionSidebar({ onClose }: SessionSidebarProps) {
         if (response.ok) {
           const data = await response.json();
           createSession(data.session_id, data.model);
+          void useUsageStore.getState().fetchUsage(data.session_id);
           setPlan([]);
           clearPanel();
         }

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -214,7 +214,7 @@ export default function UsageMeter() {
           Usage
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          Billing window resets when this task is opened.
+          Billing window resets when you switch back to a task.
         </Typography>
 
         {error ? (

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -214,7 +214,7 @@ export default function UsageMeter() {
           Usage
         </Typography>
         <Typography variant="caption" color="text.secondary">
-          Session billing uses HF account usage since session start.
+          Billing window resets when this task is opened.
         </Typography>
 
         {error ? (

--- a/frontend/src/components/WelcomeScreen/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen/WelcomeScreen.tsx
@@ -12,6 +12,7 @@ import LoginIcon from '@mui/icons-material/Login';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import { useSessionStore } from '@/store/sessionStore';
 import { useAgentStore } from '@/store/agentStore';
+import { useUsageStore } from '@/store/usageStore';
 import { apiFetch } from '@/utils/api';
 import { isInIframe, triggerLogin } from '@/hooks/useAuth';
 
@@ -210,6 +211,7 @@ export default function WelcomeScreen() {
       }
       const data = await response.json();
       createSession(data.session_id, data.model);
+      void useUsageStore.getState().fetchUsage(data.session_id);
       setPlan([]);
       clearPanel();
     } catch {

--- a/frontend/src/store/sessionStore.ts
+++ b/frontend/src/store/sessionStore.ts
@@ -30,6 +30,7 @@ interface SessionStore {
     session_id: string;
     title?: string | null;
     created_at: string;
+    usage_window_started_at?: string | null;
     is_active?: boolean;
     is_processing?: boolean;
     model?: string | null;
@@ -60,10 +61,12 @@ export const useSessionStore = create<SessionStore>()(
       activeSessionId: null,
 
       createSession: (id: string, model?: string | null) => {
+        const now = new Date().toISOString();
         const newSession: SessionMeta = {
           id,
           title: `Chat ${get().sessions.length + 1}`,
-          createdAt: new Date().toISOString(),
+          createdAt: now,
+          usageWindowStartedAt: now,
           isActive: true,
           needsAttention: false,
           model: model ?? null,
@@ -124,6 +127,8 @@ export const useSessionStore = create<SessionStore>()(
                 isActive: server.is_active ?? existing.isActive,
                 isProcessing: Boolean(server.is_processing),
                 model: server.model ?? existing.model ?? null,
+                usageWindowStartedAt:
+                  server.usage_window_started_at ?? existing.usageWindowStartedAt ?? null,
                 needsAttention: Boolean(server.pending_approval?.length) || existing.needsAttention,
                 expired: false,
                 ...(auto
@@ -144,6 +149,7 @@ export const useSessionStore = create<SessionStore>()(
               id,
               title: server.title || `Chat ${merged.length + 1}`,
               createdAt: server.created_at || new Date().toISOString(),
+              usageWindowStartedAt: server.usage_window_started_at ?? null,
               isActive: server.is_active ?? true,
               isProcessing: Boolean(server.is_processing),
               needsAttention: Boolean(server.pending_approval?.length),

--- a/frontend/src/store/usageStore.ts
+++ b/frontend/src/store/usageStore.ts
@@ -139,7 +139,13 @@ export const useUsageStore = create<UsageStore>()((set, get) => ({
   error: null,
 
   fetchUsage: async (sessionId?: string | null) => {
-    set({ isLoading: true, error: null });
+    const current = get().usage;
+    set({
+      usage:
+        sessionId && current?.session?.session_id !== sessionId ? null : current,
+      isLoading: true,
+      error: null,
+    });
     try {
       let response = await apiFetch(usageUrl(sessionId));
       if (response.status === 404 && sessionId) {

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -14,6 +14,7 @@ export interface SessionMeta {
   id: string;
   title: string;
   createdAt: string;
+  usageWindowStartedAt?: string | null;
   isActive: boolean;
   needsAttention: boolean;
   model?: string | null;

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -128,6 +128,28 @@ def _runtime_agent_session(
     )
 
 
+@pytest.mark.asyncio
+async def test_reset_session_usage_window_updates_runtime_and_store():
+    store = RestoreStore()
+    manager = _manager_with_store(store)
+    agent_session = _runtime_agent_session("s1")
+    manager.sessions["s1"] = agent_session
+    started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
+
+    info = await manager.reset_session_usage_window("s1", started_at=started_at)
+
+    assert agent_session.usage_window_started_at == started_at
+    assert info is not None
+    assert info["usage_window_started_at"] == started_at.isoformat()
+    assert store.updated_fields[-1] == (
+        "s1",
+        {
+            "usage_window_started_at": started_at,
+            "last_active_at": agent_session.last_active_at,
+        },
+    )
+
+
 def test_unknown_saved_model_defaults_to_kimi():
     model = SessionManager._model_from_saved_metadata("unsupported/model")
 

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -135,16 +135,23 @@ async def test_reset_session_usage_window_updates_runtime_and_store():
     agent_session = _runtime_agent_session("s1")
     manager.sessions["s1"] = agent_session
     started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
+    baseline = {"captured_at": started_at, "total_usd": 1.25}
 
-    info = await manager.reset_session_usage_window("s1", started_at=started_at)
+    info = await manager.reset_session_usage_window(
+        "s1",
+        started_at=started_at,
+        baseline=baseline,
+    )
 
     assert agent_session.usage_window_started_at == started_at
+    assert agent_session.usage_window_baseline == baseline
     assert info is not None
     assert info["usage_window_started_at"] == started_at.isoformat()
     assert store.updated_fields[-1] == (
         "s1",
         {
             "usage_window_started_at": started_at,
+            "usage_window_baseline": baseline,
             "last_active_at": agent_session.last_active_at,
         },
     )

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -360,6 +360,70 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_hf_account_usage_uses_baseline_for_current_delta(monkeypatch):
+    usage_window_started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
+    month_start = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+    manager = _Manager(
+        {
+            "s1": SimpleNamespace(
+                session_id="s1",
+                user_id="owner",
+                created_at=datetime(2026, 6, 5, 12, 0, tzinfo=UTC),
+                usage_window_started_at=usage_window_started_at,
+                usage_window_baseline={
+                    "captured_at": usage_window_started_at,
+                    "month_start": month_start,
+                    "total_usd": 2.5,
+                    "inference_providers_usd": 2.0,
+                    "hf_jobs_usd": 0.5,
+                    "inference_provider_requests": 10,
+                    "hf_jobs_minutes": 4.0,
+                },
+                session=SimpleNamespace(logged_events=[]),
+            )
+        }
+    )
+    calls = []
+
+    async def fake_fetch(_token, *, start, end):
+        calls.append((start, end))
+        if start == month_start:
+            return {
+                "usage": {
+                    "inferenceProviders": {
+                        "usedNanoUsd": 2_000_000_000,
+                        "numRequests": 10,
+                    },
+                    "jobs": {"usedMicroUsd": 500_000, "totalMinutes": 4.0},
+                }
+            }
+        return {
+            "usage": {
+                "inferenceProviders": {
+                    "usedNanoUsd": 5_000_000_000,
+                    "numRequests": 99,
+                },
+                "jobs": {"usedMicroUsd": 0, "totalMinutes": 0},
+            }
+        }
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+
+    usage = await build_usage_response(
+        manager,
+        user_id="owner",
+        hf_token="hf_fake",
+        session_id="s1",
+        timezone_name="UTC",
+        now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+    )
+
+    assert usage["hf_account"]["current_session"]["total_usd"] == 0.0
+    assert usage["hf_account"]["current_session"]["inference_provider_requests"] == 0
+    assert usage_window_started_at not in {start for start, _ in calls}
+
+
+@pytest.mark.asyncio
 async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
     store = _MetadataStore({"created_at": session_created_at})

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -140,6 +140,19 @@ class _Manager:
         return self.store
 
 
+class _MetadataStore(_NoopStore):
+    enabled = True
+
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+    async def load_session(self, session_id):
+        return {"metadata": {"session_id": session_id, **self.metadata}, "messages": []}
+
+    async def load_usage_events(self, user_id, **kwargs):
+        return []
+
+
 def _agent_session(session_id, user_id, events):
     return SimpleNamespace(
         session_id=session_id,
@@ -278,14 +291,16 @@ async def test_hf_account_usage_reports_billing_unavailable_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_hf_account_usage_uses_session_start_for_current_delta(monkeypatch):
+async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
+    usage_window_started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
     manager = _Manager(
         {
             "s1": SimpleNamespace(
                 session_id="s1",
                 user_id="owner",
                 created_at=session_created_at,
+                usage_window_started_at=usage_window_started_at,
                 session=SimpleNamespace(logged_events=[]),
             )
         }
@@ -294,7 +309,7 @@ async def test_hf_account_usage_uses_session_start_for_current_delta(monkeypatch
 
     async def fake_fetch(_token, *, start, end):
         calls.append((start, end))
-        if start == session_created_at:
+        if start == usage_window_started_at:
             used_nano = 500_000_000
         elif start == datetime(2026, 6, 5, 0, 0, tzinfo=UTC):
             used_nano = 1_000_000_000
@@ -339,6 +354,47 @@ async def test_hf_account_usage_uses_session_start_for_current_delta(monkeypatch
     }
     assert {start for start, _ in calls} == {
         datetime(2026, 6, 5, 0, 0, tzinfo=UTC),
+        datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+        usage_window_started_at,
+    }
+
+
+@pytest.mark.asyncio
+async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
+    session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
+    store = _MetadataStore({"created_at": session_created_at})
+    manager = _Manager({}, store=store)
+    calls = []
+
+    async def fake_fetch(_token, *, start, end):
+        calls.append((start, end))
+        return {
+            "usage": {
+                "inferenceProviders": {
+                    "usedNanoUsd": 0,
+                    "includedNanoUsd": 0,
+                    "limitNanoUsd": 0,
+                },
+                "jobs": {"usedMicroUsd": 0, "totalMinutes": 0},
+            }
+        }
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+
+    usage = await build_usage_response(
+        manager,
+        user_id="owner",
+        hf_token="hf_fake",
+        session_id="s1",
+        timezone_name="UTC",
+        now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+        include_rollups=False,
+    )
+
+    assert usage["hf_account"]["current_session"]["window_start"] == (
+        "2026-06-05T12:00:00Z"
+    )
+    assert {start for start, _ in calls} == {
         datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
         session_created_at,
     }


### PR DESCRIPTION
## Summary
- add a persisted usage_window_started_at timestamp for sessions
- reset the usage billing window when a session is activated or revisited
- use the usage window for Hugging Face account usage deltas, with created_at fallback for old sessions

## Verification
- uv run --with pytest --with pytest-asyncio pytest tests/unit/test_usage.py tests/unit/test_session_manager_persistence.py
- uv run ruff check .
- uv run ruff format --check .
- npm run build
- npm run lint