### PR TITLE
Split usage token rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Notes:
 ## GitHub CLI
 
 - For multiline PR descriptions, prefer `gh pr edit <number> --body-file <file>` over inline `--body` so shell quoting, `$` env-var names, backticks, and newlines are preserved correctly.
+- If `gh` reports an invalid token or auth failure, retry the command with `GH_TOKEN` and `GITHUB_TOKEN` unset, for example `env -u GH_TOKEN -u GITHUB_TOKEN gh pr create ...`, so `gh` can use the stored login token instead of a stale environment token.
 
 ## GitHub PRs
 

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -35,6 +35,18 @@ function formatCount(value: number | undefined): string {
   return new Intl.NumberFormat('en-US').format(value ?? 0);
 }
 
+function contextTokenCount(telemetry: UsageBucket | null | undefined): number | undefined {
+  if (!telemetry) return undefined;
+  if (telemetry.total_tokens > 0) {
+    return Math.max(0, telemetry.total_tokens - telemetry.completion_tokens);
+  }
+  return (
+    telemetry.prompt_tokens +
+    telemetry.cache_read_tokens +
+    telemetry.cache_creation_tokens
+  );
+}
+
 function billingUnavailableMessage(error: string | null | undefined): string | null {
   if (!error) return null;
   if (error === 'missing_hf_token') return 'Sign in to view HF account billing usage.';
@@ -115,8 +127,12 @@ function AccountUsageSection({
         />
         <UsageRow label="LLM calls" value={formatCount(telemetry?.llm_calls)} />
         <UsageRow
-          label="Tokens"
-          value={formatCount(telemetry?.total_tokens)}
+          label="Context tokens"
+          value={formatCount(contextTokenCount(telemetry))}
+        />
+        <UsageRow
+          label="Output tokens"
+          value={formatCount(telemetry?.completion_tokens)}
         />
       </UsageGrid>
     </Box>


### PR DESCRIPTION
Summary: split the Usage popup into Context tokens and Output tokens. Validation: npm run lint; npm run build; uv run --extra dev ruff check .; uv run --extra dev ruff format --check .