### PR TITLE
Remove inference usage link from usage popover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Notes:
 
 ## GitHub CLI
 
+- Always use the `gh` CLI for GitHub operations such as opening, editing, inspecting, or commenting on PRs and issues.
 - For multiline PR descriptions, prefer `gh pr edit <number> --body-file <file>` over inline `--body` so shell quoting, `$` env-var names, backticks, and newlines are preserved correctly.
 - If `gh` reports an invalid token or auth failure, retry the command with `GH_TOKEN` and `GITHUB_TOKEN` unset, for example `env -u GH_TOKEN -u GITHUB_TOKEN gh pr create ...`, so `gh` can use the stored login token instead of a stale environment token.
 

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 HF_BILLING_USAGE_V2_URL = "https://huggingface.co/api/settings/billing/usage-v2"
 HF_BILLING_URL = "https://huggingface.co/settings/billing"
-HF_INFERENCE_PROVIDERS_USAGE_URL = "https://huggingface.co/settings/billing/usage"
 HF_INFERENCE_PROVIDERS_PRICING_URL = (
     "https://huggingface.co/docs/inference-providers/en/pricing"
 )
@@ -746,7 +745,6 @@ async def build_usage_response(
         "hf_account": hf_account,
         "links": {
             "hf_billing": HF_BILLING_URL,
-            "inference_providers_usage": HF_INFERENCE_PROVIDERS_USAGE_URL,
             "inference_providers_pricing": HF_INFERENCE_PROVIDERS_PRICING_URL,
             "jobs_pricing": HF_JOBS_PRICING_URL,
         },

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -243,11 +243,6 @@ export default function UsageMeter() {
               HF billing <OpenInNewIcon sx={{ fontSize: 12 }} />
             </Link>
           )}
-          {links.inference_providers_usage && (
-            <Link href={links.inference_providers_usage} target="_blank" rel="noopener noreferrer" underline="hover" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, fontSize: '0.75rem' }}>
-              Inference usage <OpenInNewIcon sx={{ fontSize: 12 }} />
-            </Link>
-          )}
           {links.jobs_pricing && (
             <Link href={links.jobs_pricing} target="_blank" rel="noopener noreferrer" underline="hover" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, fontSize: '0.75rem' }}>
               Jobs pricing <OpenInNewIcon sx={{ fontSize: 12 }} />


### PR DESCRIPTION
Summary:
- Remove the Inference usage footer link from the usage popover.
- Keep HF billing and Jobs pricing links visible.

Checks:
- uv run --frozen --extra dev ruff check .
- uv run --frozen --extra dev ruff format --check .
- npm run build
- npm run lint (passes with existing warnings in frontend/src/main.tsx and frontend/src/utils/logger.ts)