### PR TITLE
Pin open web models to Novita

### DIFF
--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -5,10 +5,10 @@ HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 # Keep these as verbatim HF Router ids; version punctuation differs by model.
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
 GPT_55_MODEL_ID = "openai/gpt-5.5:fal-ai"
-KIMI_K26_MODEL_ID = "moonshotai/Kimi-K2.6"
-MINIMAX_M27_MODEL_ID = "MiniMaxAI/MiniMax-M2.7"
-GLM_51_MODEL_ID = "zai-org/GLM-5.1"
-DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:deepinfra"
+KIMI_K26_MODEL_ID = "moonshotai/Kimi-K2.6:novita"
+MINIMAX_M27_MODEL_ID = "MiniMaxAI/MiniMax-M2.7:novita"
+GLM_51_MODEL_ID = "zai-org/GLM-5.1:novita"
+DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:novita"
 
 DEFAULT_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -28,8 +28,11 @@ from agent.core.local_models import (
 )
 from agent.core.model_ids import (
     CLAUDE_OPUS_48_MODEL_ID,
+    DEEPSEEK_V4_PRO_MODEL_ID,
+    GLM_51_MODEL_ID,
     GPT_55_MODEL_ID,
     KIMI_K26_MODEL_ID,
+    MINIMAX_M27_MODEL_ID,
     strip_huggingface_model_prefix,
 )
 
@@ -41,10 +44,10 @@ from agent.core.model_ids import (
 SUGGESTED_MODELS = [
     {"id": CLAUDE_OPUS_48_MODEL_ID, "label": "Claude Opus 4.8"},
     {"id": GPT_55_MODEL_ID, "label": "GPT-5.5"},
-    {"id": "MiniMaxAI/MiniMax-M2.7", "label": "MiniMax M2.7"},
+    {"id": MINIMAX_M27_MODEL_ID, "label": "MiniMax M2.7"},
     {"id": KIMI_K26_MODEL_ID, "label": "Kimi K2.6"},
-    {"id": "zai-org/GLM-5.1", "label": "GLM 5.1"},
-    {"id": "deepseek-ai/DeepSeek-V4-Pro:deepinfra", "label": "DeepSeek V4 Pro"},
+    {"id": GLM_51_MODEL_ID, "label": "GLM 5.1"},
+    {"id": DEEPSEEK_V4_PRO_MODEL_ID, "label": "DeepSeek V4 Pro"},
 ]
 
 

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -25,8 +25,11 @@ import { useAgentStore } from '@/store/agentStore';
 import { useSessionStore } from '@/store/sessionStore';
 import {
   CLAUDE_OPUS_48_MODEL_PATH,
+  DEEPSEEK_V4_PRO_MODEL_PATH,
+  GLM_51_MODEL_PATH,
   GPT_55_MODEL_PATH,
   KIMI_K26_MODEL_PATH,
+  MINIMAX_M27_MODEL_PATH,
   isClaudePath,
 } from '@/utils/model';
 
@@ -67,19 +70,19 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   {
     id: 'minimax-m2.7',
     name: 'MiniMax M2.7',
-    modelPath: 'MiniMaxAI/MiniMax-M2.7',
+    modelPath: MINIMAX_M27_MODEL_PATH,
     avatarUrl: getHfAvatarUrl('MiniMaxAI/MiniMax-M2.7'),
   },
   {
     id: 'glm-5.1',
     name: 'GLM 5.1',
-    modelPath: 'zai-org/GLM-5.1',
+    modelPath: GLM_51_MODEL_PATH,
     avatarUrl: getHfAvatarUrl('zai-org/GLM-5.1'),
   },
   {
     id: 'deepseek-v4-pro',
     name: 'DeepSeek V4 Pro',
-    modelPath: 'deepseek-ai/DeepSeek-V4-Pro:deepinfra',
+    modelPath: DEEPSEEK_V4_PRO_MODEL_PATH,
     avatarUrl: getHfAvatarUrl('deepseek-ai/DeepSeek-V4-Pro'),
   },
 ];

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -8,7 +8,10 @@
 
 export const CLAUDE_OPUS_48_MODEL_PATH = 'anthropic/claude-opus-4.8:fal-ai';
 export const GPT_55_MODEL_PATH = 'openai/gpt-5.5:fal-ai';
-export const KIMI_K26_MODEL_PATH = 'moonshotai/Kimi-K2.6';
+export const KIMI_K26_MODEL_PATH = 'moonshotai/Kimi-K2.6:novita';
+export const MINIMAX_M27_MODEL_PATH = 'MiniMaxAI/MiniMax-M2.7:novita';
+export const GLM_51_MODEL_PATH = 'zai-org/GLM-5.1:novita';
+export const DEEPSEEK_V4_PRO_MODEL_PATH = 'deepseek-ai/DeepSeek-V4-Pro:novita';
 
 export function isClaudePath(modelPath: string | undefined): boolean {
   return !!modelPath && modelPath.includes('anthropic');


### PR DESCRIPTION
Pins Kimi, MiniMax, GLM, and DeepSeek to the Novita HF Router provider in backend and frontend model lists. Verified with focused pytest, Ruff, and frontend build.