### PR TITLE
Rename idle reaper timeout to minutes

### DIFF
--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -140,14 +140,14 @@ SANDBOX_SHUTDOWN_CLEANUP_CONCURRENCY: int = 10
 SANDBOX_SHUTDOWN_CLEANUP_TIMEOUT_S: float = 60.0
 
 # ── Idle-session reaper ─────────────────────────────────────────────
-# A live session idle ≥ REAPER_IDLE_HOURS with no in-flight work has its
+# A live session idle ≥ REAPER_IDLE_MINUTES with no in-flight work has its
 # sandbox + RAM released and is evicted from the live pool, while staying
 # fully resumable from Mongo (it reappears as a normal chat, never "ended").
 # This frees both the global pool and the user's concurrent slots.
-REAPER_IDLE_HOURS: float = float(os.environ.get("REAPER_IDLE_HOURS", "2"))
+REAPER_IDLE_MINUTES: float = float(os.environ.get("REAPER_IDLE_MINUTES", "15"))
 REAPER_INTERVAL_S: float = float(os.environ.get("REAPER_INTERVAL_S", "300"))
 REAP_TEARDOWN_TIMEOUT_S: float = float(os.environ.get("REAP_TEARDOWN_TIMEOUT_S", "30"))
-REAPER_IDLE = timedelta(hours=REAPER_IDLE_HOURS)
+REAPER_IDLE = timedelta(minutes=REAPER_IDLE_MINUTES)
 
 
 class SessionManager:
@@ -821,7 +821,7 @@ class SessionManager:
 
         Raises:
             SessionCapacityError: If the server or user has reached the
-                maximum number of concurrent sessions.
+                maximum number of live sessions.
         """
         # ── Capacity checks ──────────────────────────────────────────
         # Reserve a global slot under the lock so concurrent creates can't all
@@ -843,7 +843,9 @@ class SessionManager:
                 if user_count >= MAX_SESSIONS_PER_USER:
                     raise SessionCapacityError(
                         f"You have reached the maximum of {MAX_SESSIONS_PER_USER} "
-                        "concurrent sessions. Please close an existing session first.",
+                        f"live sessions. Close an existing session, or wait "
+                        f"{REAPER_IDLE_MINUTES:g} minutes after your last activity "
+                        "for an idle session to be released.",
                         error_type="per_user",
                     )
             self._pending_creates += 1

--- a/tests/unit/test_session_reaper.py
+++ b/tests/unit/test_session_reaper.py
@@ -31,6 +31,11 @@ from session_manager import (  # noqa: E402
 from agent.core.session import OpType  # noqa: E402
 
 
+def test_reaper_idle_default_is_fifteen_minutes():
+    assert sm.REAPER_IDLE_MINUTES == 15
+    assert sm.REAPER_IDLE == timedelta(minutes=15)
+
+
 class RecordingStore(NoopSessionStore):
     """Captures every save_snapshot call so tests can assert persistence."""
 
@@ -371,6 +376,12 @@ async def test_per_user_cap_frees_up_after_slot_reclaimed():
         with pytest.raises(SessionCapacityError) as exc:
             await manager.create_session(user_id="owner")
         assert exc.value.error_type == "per_user"
+        message = str(exc.value)
+        assert f"maximum of {sm.MAX_SESSIONS_PER_USER} live sessions" in message
+        assert "Close an existing session" in message
+        assert f"wait {sm.REAPER_IDLE_MINUTES:g} minutes" in message
+        assert "after your last activity" in message
+        assert "idle session to be released" in message
 
         # Reclaiming a slot (the reaper evicts an idle session) frees capacity.
         manager.sessions.pop("owner-0")


### PR DESCRIPTION
## Summary
- replace REAPER_IDLE_HOURS with REAPER_IDLE_MINUTES defaulting to 15
- update per-user capacity errors to refer to live sessions and idle release timing
- add tests for the default timeout and capacity message wording

## Tests
- uv run pytest tests/unit/test_session_reaper.py
- uv run ruff check .
- uv run ruff format --check .