### PR TITLE
Document Codex gh auth retry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Notes:
 - Always use the `gh` CLI for GitHub operations such as opening, editing, inspecting, or commenting on PRs and issues.
 - For multiline PR descriptions, prefer `gh pr edit <number> --body-file <file>` over inline `--body` so shell quoting, `$` env-var names, backticks, and newlines are preserved correctly.
 - If `gh` reports an invalid token or auth failure, retry the command with `GH_TOKEN` and `GITHUB_TOKEN` unset, for example `env -u GH_TOKEN -u GITHUB_TOKEN gh pr create ...`, so `gh` can use the stored login token instead of a stale environment token.
+- In Codex, sandboxed `gh` auth checks can report a valid keyring login as invalid when GitHub network access is restricted. Before telling the user to re-authenticate, retry with both env tokens unset and GitHub network access enabled.
 
 ## GitHub PRs
 


### PR DESCRIPTION
## Summary

- document that sandboxed Codex `gh` auth checks can falsely report a valid keyring login as invalid when GitHub network access is restricted
- tell future agents to retry with `GH_TOKEN` and `GITHUB_TOKEN` unset and GitHub network access enabled before asking the user to re-authenticate

## Checks

- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check .`
