### PR TITLE
Add plan-aware CLI billing CTA

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -26,6 +26,11 @@ from agent.core.cost_estimation import CostEstimate, estimate_tool_cost
 from agent.messaging.gateway import NotificationGateway
 from agent.core import telemetry
 from agent.core.doom_loop import check_for_doom_loop
+from agent.core.hf_access import (
+    HF_BILLING_URL,
+    HF_PRO_SUBSCRIBE_URL,
+    is_inference_billing_error,
+)
 from agent.core.llm_params import _resolve_llm_params
 from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_caching
 from agent.core.session import DEFAULT_SESSION_LOG_DIR, Event, OpType, Session
@@ -543,7 +548,33 @@ async def _heal_effort_and_rebuild_params(
     )
 
 
-def _friendly_error_message(error: Exception) -> str | None:
+def _inference_credit_error_message(user_plan: str | None = None) -> str:
+    plan = (user_plan or "unknown").lower()
+    if plan == "pro":
+        return (
+            "Hugging Face Inference Providers credits are exhausted for this "
+            "account.\n\n"
+            f"Add credits to continue: {HF_BILLING_URL}"
+        )
+    if plan == "free":
+        return (
+            "Your monthly Hugging Face Inference Providers credits are exhausted.\n\n"
+            f"Subscribe to HF PRO for more monthly usage: {HF_PRO_SUBSCRIBE_URL}\n"
+            f"Or add pay-as-you-go credits: {HF_BILLING_URL}"
+        )
+    return (
+        "Hugging Face Inference Providers credits appear to be exhausted for "
+        "this account.\n\n"
+        f"Add pay-as-you-go credits: {HF_BILLING_URL}\n"
+        f"If this is a free account, HF PRO adds more monthly usage: {HF_PRO_SUBSCRIBE_URL}"
+    )
+
+
+def _friendly_error_message(
+    error: Exception,
+    *,
+    user_plan: str | None = None,
+) -> str | None:
     """Return a user-friendly message for known error types, or None to fall back to traceback."""
     err_str = str(error).lower()
 
@@ -559,11 +590,8 @@ def _friendly_error_message(error: Exception) -> str | None:
             "To switch models, use the /model command."
         )
 
-    if "insufficient" in err_str and "credit" in err_str:
-        return (
-            "Insufficient Hugging Face Inference Providers credits. Add credits "
-            "or upgrade your HF account to continue."
-        )
+    if is_inference_billing_error(error):
+        return _inference_credit_error_message(user_plan)
 
     if "not supported by provider" in err_str or "no provider supports" in err_str:
         return (
@@ -1653,7 +1681,10 @@ class Handlers:
             except Exception as e:
                 import traceback
 
-                error_msg = _friendly_error_message(e)
+                error_msg = _friendly_error_message(
+                    e,
+                    user_plan=getattr(session, "user_plan", None),
+                )
                 if error_msg is None:
                     error_msg = str(e) + "\n" + traceback.format_exc()
 
@@ -2051,6 +2082,7 @@ async def submission_loop(
     notification_gateway: NotificationGateway | None = None,
     notification_destinations: list[str] | None = None,
     defer_turn_complete_notification: bool = False,
+    user_plan: str | None = None,
 ) -> None:
     """
     Main agent loop - processes submissions and dispatches to handlers.
@@ -2064,6 +2096,7 @@ async def submission_loop(
         tool_router=tool_router,
         hf_token=hf_token,
         user_id=user_id,
+        user_plan=user_plan,
         local_mode=local_mode,
         stream=stream,
         notification_gateway=notification_gateway,

--- a/agent/core/hf_access.py
+++ b/agent/core/hf_access.py
@@ -182,11 +182,17 @@ async def resolve_jobs_namespace(
 
 
 _BILLING_PATTERNS = re.compile(
-    r"\b(insufficient[_\s-]?(?:credits?|quota)|out\s+of\s+(?:monthly\s+)?credits?|"
+    r"\b(insufficient[_\s-]?credits?|out\s+of\s+credits?|"
     r"payment\s+required|billing|no\s+credits?|add\s+credits?|requires?\s+credits?|"
-    r"exhausted\s+(?:monthly\s+)?credits?|"
+    r"credits?\s+(?:exhausted|used\s+up|limit))\b",
+    re.IGNORECASE,
+)
+
+_INFERENCE_BILLING_PATTERNS = re.compile(
+    r"\b(insufficient[_\s-]?quota|out\s+of\s+monthly\s+credits?|"
+    r"exhausted\s+monthly\s+credits?|"
     r"quota[_\s-]?(?:exceeded|exhausted|limit|insufficient)|"
-    r"(?:monthly\s+)?credits?\s+(?:exhausted|used\s+up|limit))\b",
+    r"monthly\s+credits?\s+(?:exhausted|used\s+up|limit))\b",
     re.IGNORECASE,
 )
 
@@ -202,4 +208,7 @@ def is_billing_error(message: str) -> bool:
 
 def is_inference_billing_error(error: Exception | str) -> bool:
     """True if an Inference Providers error looks like exhausted credits."""
-    return is_billing_error(str(error))
+    message = str(error)
+    return is_billing_error(message) or bool(
+        _INFERENCE_BILLING_PATTERNS.search(message)
+    )

--- a/agent/core/hf_access.py
+++ b/agent/core/hf_access.py
@@ -12,11 +12,16 @@ import asyncio
 import os
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
 OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL", "https://huggingface.co")
+HF_BILLING_URL = "https://huggingface.co/settings/billing"
+HF_PRO_SUBSCRIBE_URL = "https://huggingface.co/subscribe/pro"
+
+HfUserPlan = Literal["free", "pro"]
+HfUserPlanStatus = Literal["free", "pro", "unknown"]
 
 
 @dataclass(frozen=True)
@@ -95,6 +100,15 @@ def jobs_access_from_whoami(whoami: dict[str, Any]) -> JobsAccess:
     )
 
 
+def normalize_hf_user_plan(whoami: Any) -> HfUserPlan | None:
+    """Normalize a whoami-v2 payload to the supported HF account plan tiers."""
+    if not isinstance(whoami, dict):
+        return None
+    if whoami.get("isPro") is True:
+        return "pro"
+    return "free"
+
+
 async def fetch_whoami_v2(token: str, timeout: float = 5.0) -> dict[str, Any] | None:
     if not token:
         return None
@@ -110,6 +124,17 @@ async def fetch_whoami_v2(token: str, timeout: float = 5.0) -> dict[str, Any] | 
             return payload if isinstance(payload, dict) else None
         except (httpx.HTTPError, ValueError):
             return None
+
+
+async def fetch_hf_user_plan(
+    token: str | None,
+    timeout: float = 5.0,
+) -> HfUserPlanStatus:
+    """Return the token owner's HF plan, or ``unknown`` if lookup fails."""
+    if not token:
+        return "unknown"
+    whoami = await fetch_whoami_v2(token, timeout=timeout)
+    return normalize_hf_user_plan(whoami) or "unknown"
 
 
 async def get_jobs_access(token: str) -> JobsAccess | None:
@@ -157,8 +182,11 @@ async def resolve_jobs_namespace(
 
 
 _BILLING_PATTERNS = re.compile(
-    r"\b(insufficient[_\s-]?credits?|out\s+of\s+credits?|payment\s+required|"
-    r"billing|no\s+credits?|add\s+credits?|requires?\s+credits?)\b",
+    r"\b(insufficient[_\s-]?(?:credits?|quota)|out\s+of\s+(?:monthly\s+)?credits?|"
+    r"payment\s+required|billing|no\s+credits?|add\s+credits?|requires?\s+credits?|"
+    r"exhausted\s+(?:monthly\s+)?credits?|"
+    r"quota[_\s-]?(?:exceeded|exhausted|limit|insufficient)|"
+    r"(?:monthly\s+)?credits?\s+(?:exhausted|used\s+up|limit))\b",
     re.IGNORECASE,
 )
 
@@ -170,3 +198,8 @@ def is_billing_error(message: str) -> bool:
     if "402" in message:
         return True
     return bool(_BILLING_PATTERNS.search(message))
+
+
+def is_inference_billing_error(error: Exception | str) -> bool:
+    """True if an Inference Providers error looks like exhausted credits."""
+    return is_billing_error(str(error))

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -95,11 +95,13 @@ class Session:
         session_id: str | None = None,
         user_id: str | None = None,
         hf_username: str | None = None,
+        user_plan: str | None = None,
         persistence_store: Any | None = None,
     ):
         self.hf_token: Optional[str] = hf_token
         self.user_id: Optional[str] = user_id
         self.hf_username: Optional[str] = hf_username
+        self.user_plan: str | None = user_plan
         self.local_mode = local_mode
         self.persistence_store = persistence_store
         self.tool_router = tool_router

--- a/agent/main.py
+++ b/agent/main.py
@@ -26,6 +26,7 @@ from agent.config import load_config
 from agent.core.approval_policy import is_scheduled_operation
 from agent.core.agent_loop import submission_loop
 from agent.core import model_switcher
+from agent.core.hf_access import fetch_hf_user_plan
 from agent.core.hf_tokens import resolve_hf_token
 from agent.core.local_models import is_local_model_id
 from agent.core.model_ids import strip_huggingface_model_prefix
@@ -1180,6 +1181,7 @@ async def main(model: str | None = None, sandbox_tools: bool = False):
 
     # Resolve username for banner
     hf_user = _get_hf_user(hf_token)
+    hf_user_plan = await fetch_hf_user_plan(hf_token)
 
     print_banner(
         model=config.model_name,
@@ -1221,6 +1223,7 @@ async def main(model: str | None = None, sandbox_tools: bool = False):
             session_holder=session_holder,
             hf_token=hf_token,
             user_id=hf_user,
+            user_plan=hf_user_plan,
             local_mode=local_mode,
             stream=True,
             notification_gateway=notification_gateway,
@@ -1437,6 +1440,7 @@ async def headless_main(
     notification_gateway = NotificationGateway(config.messaging)
     await notification_gateway.start()
     hf_user = _get_hf_user(hf_token)
+    hf_user_plan = await fetch_hf_user_plan(hf_token)
 
     if max_iterations is not None:
         config.max_iterations = max_iterations
@@ -1464,6 +1468,7 @@ async def headless_main(
             session_holder=session_holder,
             hf_token=hf_token,
             user_id=hf_user,
+            user_plan=hf_user_plan,
             local_mode=local_mode,
             stream=stream,
             notification_gateway=notification_gateway,

--- a/agent/main.py
+++ b/agent/main.py
@@ -26,7 +26,7 @@ from agent.config import load_config
 from agent.core.approval_policy import is_scheduled_operation
 from agent.core.agent_loop import submission_loop
 from agent.core import model_switcher
-from agent.core.hf_access import fetch_hf_user_plan
+from agent.core.hf_access import fetch_whoami_v2, normalize_hf_user_plan
 from agent.core.hf_tokens import resolve_hf_token
 from agent.core.local_models import is_local_model_id
 from agent.core.model_ids import strip_huggingface_model_prefix
@@ -146,6 +146,25 @@ def _get_hf_user(token: str | None) -> str | None:
         return HfApi(token=token).whoami().get("name")
     except Exception:
         return None
+
+
+def _get_hf_user_from_whoami(whoami: dict[str, Any] | None) -> str | None:
+    if not isinstance(whoami, dict):
+        return None
+    for key in ("name", "user", "preferred_username"):
+        value = whoami.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+async def _get_hf_identity(token: str | None) -> tuple[str | None, str]:
+    if not token:
+        return None, "unknown"
+    whoami = await fetch_whoami_v2(token)
+    if whoami is None:
+        return _get_hf_user(token), "unknown"
+    return _get_hf_user_from_whoami(whoami), normalize_hf_user_plan(whoami) or "unknown"
 
 
 async def _prompt_and_save_hf_token(prompt_session: PromptSession) -> str:
@@ -1179,9 +1198,8 @@ async def main(model: str | None = None, sandbox_tools: bool = False):
     if not hf_token and (not is_local_model_id(config.model_name) or not local_mode):
         hf_token = await _prompt_and_save_hf_token(prompt_session)
 
-    # Resolve username for banner
-    hf_user = _get_hf_user(hf_token)
-    hf_user_plan = await fetch_hf_user_plan(hf_token)
+    # Resolve username and plan from one whoami-v2 request for banner and CTAs.
+    hf_user, hf_user_plan = await _get_hf_identity(hf_token)
 
     print_banner(
         model=config.model_name,
@@ -1439,8 +1457,7 @@ async def headless_main(
 
     notification_gateway = NotificationGateway(config.messaging)
     await notification_gateway.start()
-    hf_user = _get_hf_user(hf_token)
-    hf_user_plan = await fetch_hf_user_plan(hf_token)
+    hf_user, hf_user_plan = await _get_hf_identity(hf_token)
 
     if max_iterations is not None:
         config.max_iterations = max_iterations

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -16,7 +16,7 @@ from fastapi import HTTPException, Request, status
 
 from agent.core.hf_tokens import bearer_token_from_header, clean_hf_token
 
-from agent.core.hf_access import fetch_whoami_v2
+from agent.core.hf_access import fetch_whoami_v2, normalize_hf_user_plan
 
 logger = logging.getLogger(__name__)
 
@@ -139,13 +139,7 @@ def _user_from_info(user_info: dict[str, Any]) -> dict[str, Any]:
 
 def _normalize_user_plan(whoami: Any) -> str:
     """Normalize a whoami-v2 payload to the app's supported plan tiers."""
-    if not isinstance(whoami, dict):
-        return "free"
-
-    if whoami.get("isPro") is True:
-        return "pro"
-
-    return "free"
+    return normalize_hf_user_plan(whoami) or "free"
 
 
 async def _fetch_user_plan(token: str) -> str:

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -242,6 +242,7 @@ async def _check_session_access(
         user["user_id"],
         hf_token=hf_token,
         hf_username=user.get("username"),
+        user_plan=user.get("plan"),
         preload_sandbox=preload_sandbox,
     )
     if not agent_session:
@@ -440,6 +441,7 @@ async def create_session(
             user_id=user["user_id"],
             hf_username=user.get("username"),
             hf_token=hf_token,
+            user_plan=user.get("plan"),
             model=model,
             is_pro=user.get("plan") == "pro",
         )
@@ -483,6 +485,7 @@ async def restore_session_summary(
             user_id=user["user_id"],
             hf_username=user.get("username"),
             hf_token=hf_token,
+            user_plan=user.get("plan"),
             model=model,
             is_pro=user.get("plan") == "pro",
         )

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -99,6 +99,7 @@ class AgentSession:
     user_id: str = "dev"  # Owner of this session
     hf_username: str | None = None  # HF namespace used for personal trace uploads
     hf_token: str | None = None  # User's HF OAuth token for tool execution
+    user_plan: str | None = None  # Active HF account plan for plan-aware agent CTAs
     task: asyncio.Task | None = None
     created_at: datetime = field(default_factory=datetime.utcnow)
     # Last genuine activity (submit/turn-start/turn-finish/direct user write).
@@ -234,6 +235,7 @@ class SessionManager:
         user_id: str,
         hf_username: str | None,
         hf_token: str | None,
+        user_plan: str | None,
         model: str | None,
         event_queue: asyncio.Queue,
         notification_destinations: list[str] | None = None,
@@ -256,6 +258,7 @@ class SessionManager:
             hf_token=hf_token,
             user_id=user_id,
             hf_username=hf_username,
+            user_plan=user_plan,
             notification_gateway=self.messaging_gateway,
             notification_destinations=notification_destinations or [],
             session_id=session_id,
@@ -437,6 +440,7 @@ class SessionManager:
         *,
         hf_token: str | None,
         hf_username: str | None,
+        user_plan: str | None = None,
     ) -> None:
         if hf_token:
             agent_session.hf_token = hf_token
@@ -444,6 +448,9 @@ class SessionManager:
         if hf_username:
             agent_session.hf_username = hf_username
             agent_session.session.hf_username = hf_username
+        if user_plan is not None:
+            agent_session.user_plan = user_plan
+            agent_session.session.user_plan = user_plan
 
     @staticmethod
     def _has_active_sandbox_preload(agent_session: AgentSession) -> bool:
@@ -633,6 +640,7 @@ class SessionManager:
         user_id: str,
         hf_token: str | None = None,
         hf_username: str | None = None,
+        user_plan: str | None = None,
         preload_sandbox: bool = True,
     ) -> AgentSession | None:
         """Return a live runtime session, lazily restoring it from Mongo."""
@@ -644,6 +652,7 @@ class SessionManager:
                     existing,
                     hf_token=hf_token,
                     hf_username=hf_username,
+                    user_plan=user_plan,
                 )
                 self._restart_cpu_preload_if_token_recovered(
                     existing,
@@ -665,6 +674,7 @@ class SessionManager:
                     existing,
                     hf_token=hf_token,
                     hf_username=hf_username,
+                    user_plan=user_plan,
                 )
                 self._restart_cpu_preload_if_token_recovered(
                     existing,
@@ -697,6 +707,7 @@ class SessionManager:
             user_id=owner or user_id,
             hf_username=hf_username,
             hf_token=hf_token,
+            user_plan=user_plan,
             model=model,
             event_queue=event_queue,
             notification_destinations=meta.get("notification_destinations") or [],
@@ -773,6 +784,7 @@ class SessionManager:
             user_id=owner or user_id,
             hf_username=hf_username,
             hf_token=hf_token,
+            user_plan=user_plan,
             created_at=created_at,
             usage_window_started_at=usage_window_started_at,
             usage_window_baseline=usage_window_baseline,
@@ -790,6 +802,7 @@ class SessionManager:
                 started,
                 hf_token=hf_token,
                 hf_username=hf_username,
+                user_plan=user_plan,
             )
             return started
         if preload_sandbox:
@@ -802,6 +815,7 @@ class SessionManager:
         user_id: str = "dev",
         hf_username: str | None = None,
         hf_token: str | None = None,
+        user_plan: str | None = None,
         model: str | None = None,
         is_pro: bool | None = None,
     ) -> str:
@@ -815,6 +829,7 @@ class SessionManager:
             user_id: The ID of the user who owns this session.
             hf_username: The HF username/namespace used for personal trace uploads.
             hf_token: The user's HF OAuth token, stored for tool execution.
+            user_plan: The active HF account plan used for plan-aware agent CTAs.
             model: Optional model override. When set, replaces ``model_name``
                 on the per-session config clone. None falls back to the
                 config default.
@@ -865,6 +880,7 @@ class SessionManager:
                 user_id=user_id,
                 hf_username=hf_username,
                 hf_token=hf_token,
+                user_plan=user_plan,
                 model=model,
                 event_queue=event_queue,
             )
@@ -878,6 +894,7 @@ class SessionManager:
                 user_id=user_id,
                 hf_username=hf_username,
                 hf_token=hf_token,
+                user_plan=user_plan,
             )
 
             await self._start_agent_session(

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -209,7 +209,7 @@ async def test_restore_summary_uses_default_model_without_quota_gate(monkeypatch
         cookies = {}
 
     async def fake_create_session(**kwargs):
-        events.append(("create", kwargs["model"]))
+        events.append(("create", kwargs["model"], kwargs.get("user_plan")))
         return "s1"
 
     async def fake_check_session_access(
@@ -235,7 +235,45 @@ async def test_restore_summary_uses_default_model_without_quota_gate(monkeypatch
     assert response.session_id == "s1"
     assert response.model == agent.DEFAULT_FREE_MODEL_ID
     assert events == [
-        ("create", agent.DEFAULT_FREE_MODEL_ID),
+        ("create", agent.DEFAULT_FREE_MODEL_ID, "free"),
         ("check", "s1", False),
         ("seed", "s1"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_check_session_access_passes_user_plan(monkeypatch):
+    seen = {}
+    expected_session = SimpleNamespace(user_id="u1")
+
+    class Request:
+        headers = {"Authorization": "Bearer user-token"}
+        cookies = {}
+
+    async def fake_ensure_session_loaded(session_id, user_id, **kwargs):
+        seen["session_id"] = session_id
+        seen["user_id"] = user_id
+        seen.update(kwargs)
+        return expected_session
+
+    monkeypatch.setattr(
+        agent.session_manager,
+        "ensure_session_loaded",
+        fake_ensure_session_loaded,
+    )
+
+    result = await agent._check_session_access(
+        "s1",
+        {"user_id": "u1", "username": "tester", "plan": "pro"},
+        Request(),
+    )
+
+    assert result is expected_session
+    assert seen == {
+        "session_id": "s1",
+        "user_id": "u1",
+        "hf_token": "user-token",
+        "hf_username": "tester",
+        "user_plan": "pro",
+        "preload_sandbox": True,
+    }

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -9,8 +9,13 @@ import pytest
 from rich.console import Console
 
 import agent.main as main_mod
+from agent.core.session import Event
 from agent.tools.research_tool import _get_research_model
 from agent.utils import terminal_display
+
+
+async def _fake_hf_user_plan(_token):
+    return "pro"
 
 
 def test_router_anthropic_research_model_is_unchanged():
@@ -189,6 +194,7 @@ async def test_interactive_main_applies_model_override_before_banner(monkeypatch
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
     monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
+    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
     monkeypatch.setattr(
         main_mod,
         "load_config",
@@ -223,6 +229,7 @@ async def test_local_model_local_runtime_skips_hf_token_prompt(monkeypatch):
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: None)
     monkeypatch.setattr(main_mod, "_prompt_and_save_hf_token", fail_prompt)
     monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: None)
+    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
     monkeypatch.setattr(
         main_mod,
         "load_config",
@@ -261,6 +268,7 @@ async def test_local_model_sandbox_runtime_prompts_for_hf_token(monkeypatch):
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: None)
     monkeypatch.setattr(main_mod, "_prompt_and_save_hf_token", fake_prompt)
     monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
+    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
     monkeypatch.setattr(
         main_mod,
         "load_config",
@@ -305,6 +313,7 @@ async def test_interactive_main_passes_sandbox_runtime_to_tool_router(monkeypatc
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
     monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
+    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
     monkeypatch.setattr(main_mod, "print_banner", lambda **_kwargs: None)
     monkeypatch.setattr(hf_router_catalog, "prewarm", lambda: None)
     monkeypatch.setattr(
@@ -325,6 +334,160 @@ async def test_interactive_main_passes_sandbox_runtime_to_tool_router(monkeypatc
 
     assert seen["hf_token"] == "hf-token"
     assert seen["local_mode"] is False
+
+
+@pytest.mark.asyncio
+async def test_interactive_main_passes_user_plan_to_submission_loop(monkeypatch):
+    seen: dict[str, object] = {}
+
+    async def fake_fetch_hf_user_plan(token):
+        seen["plan_token"] = token
+        return "free"
+
+    class FakeGateway:
+        def __init__(self, _config):
+            pass
+
+        async def start(self):
+            pass
+
+        async def close(self):
+            pass
+
+    class FakeToolRouter:
+        def __init__(self, _mcp_servers, *, hf_token=None, local_mode=True):
+            self.hf_token = hf_token
+            self.local_mode = local_mode
+
+        async def __aexit__(self, *_args):
+            pass
+
+    async def fake_submission_loop(submission_queue, _event_queue, **kwargs):
+        seen["user_plan"] = kwargs.get("user_plan")
+        seen["hf_token"] = kwargs.get("hf_token")
+        while True:
+            submission = await submission_queue.get()
+            if submission.operation.op_type == main_mod.OpType.SHUTDOWN:
+                return
+
+    async def fake_event_listener(
+        _event_queue,
+        _submission_queue,
+        _turn_complete_event,
+        ready_event,
+        _prompt_session,
+        _config,
+        *,
+        session_holder=None,
+    ):
+        ready_event.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            return
+
+    async def fake_get_user_input(_prompt_session):
+        return "/quit"
+
+    from agent.core import hf_router_catalog
+
+    monkeypatch.setattr(main_mod, "_clear_terminal", lambda: None)
+    monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
+    monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
+    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
+    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", fake_fetch_hf_user_plan)
+    monkeypatch.setattr(main_mod, "print_banner", lambda **_kwargs: None)
+    monkeypatch.setattr(main_mod, "NotificationGateway", FakeGateway)
+    monkeypatch.setattr(main_mod, "ToolRouter", FakeToolRouter)
+    monkeypatch.setattr(main_mod, "submission_loop", fake_submission_loop)
+    monkeypatch.setattr(main_mod, "event_listener", fake_event_listener)
+    monkeypatch.setattr(main_mod, "get_user_input", fake_get_user_input)
+    monkeypatch.setattr(hf_router_catalog, "prewarm", lambda: None)
+    monkeypatch.setattr(
+        main_mod,
+        "load_config",
+        lambda _path, **_kwargs: SimpleNamespace(
+            model_name="anthropic/claude-opus-4.8:fal-ai",
+            mcpServers={},
+            messaging=SimpleNamespace(default_auto_destinations=lambda: []),
+            tool_runtime="local",
+        ),
+    )
+
+    await main_mod.main()
+
+    assert seen == {
+        "plan_token": "hf-token",
+        "user_plan": "free",
+        "hf_token": "hf-token",
+    }
+
+
+@pytest.mark.asyncio
+async def test_headless_main_passes_user_plan_to_submission_loop(monkeypatch):
+    seen: dict[str, object] = {}
+
+    async def fake_fetch_hf_user_plan(token):
+        seen["plan_token"] = token
+        return "pro"
+
+    class FakeGateway:
+        def __init__(self, _config):
+            pass
+
+        async def start(self):
+            pass
+
+        async def close(self):
+            pass
+
+    class FakeToolRouter:
+        def __init__(self, _mcp_servers, *, hf_token=None, local_mode=True):
+            self.hf_token = hf_token
+            self.local_mode = local_mode
+
+        async def __aexit__(self, *_args):
+            pass
+
+    async def fake_submission_loop(submission_queue, event_queue, **kwargs):
+        seen["user_plan"] = kwargs.get("user_plan")
+        seen["hf_token"] = kwargs.get("hf_token")
+        await event_queue.put(Event(event_type="ready"))
+        submission = await submission_queue.get()
+        seen["prompt"] = submission.operation.data["text"]
+        await event_queue.put(
+            Event(event_type="turn_complete", data={"history_size": 0})
+        )
+        shutdown = await submission_queue.get()
+        assert shutdown.operation.op_type == main_mod.OpType.SHUTDOWN
+
+    monkeypatch.setattr(main_mod, "_clear_terminal", lambda: None)
+    monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
+    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
+    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", fake_fetch_hf_user_plan)
+    monkeypatch.setattr(main_mod, "NotificationGateway", FakeGateway)
+    monkeypatch.setattr(main_mod, "ToolRouter", FakeToolRouter)
+    monkeypatch.setattr(main_mod, "submission_loop", fake_submission_loop)
+    monkeypatch.setattr(
+        main_mod,
+        "load_config",
+        lambda _path, **_kwargs: SimpleNamespace(
+            model_name="anthropic/claude-opus-4.8:fal-ai",
+            mcpServers={},
+            messaging=SimpleNamespace(default_auto_destinations=lambda: []),
+            tool_runtime="local",
+            max_iterations=3,
+        ),
+    )
+
+    await main_mod.headless_main("train a model")
+
+    assert seen == {
+        "plan_token": "hf-token",
+        "user_plan": "pro",
+        "hf_token": "hf-token",
+        "prompt": "train a model",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -14,8 +14,8 @@ from agent.tools.research_tool import _get_research_model
 from agent.utils import terminal_display
 
 
-async def _fake_hf_user_plan(_token):
-    return "pro"
+async def _fake_hf_identity(_token):
+    return "tester", "pro"
 
 
 def test_router_anthropic_research_model_is_unchanged():
@@ -109,6 +109,24 @@ def test_subagent_display_does_not_spawn_background_redraw(monkeypatch):
     assert calls == []
 
 
+@pytest.mark.asyncio
+async def test_hf_identity_uses_single_whoami_v2_payload(monkeypatch):
+    calls: list[tuple[str, float]] = []
+
+    async def fake_fetch_whoami_v2(token, timeout=5.0):
+        calls.append((token, timeout))
+        return {"name": "tester", "isPro": True}
+
+    def fail_get_hf_user(_token):
+        raise AssertionError("fallback whoami should not run when whoami-v2 succeeds")
+
+    monkeypatch.setattr(main_mod, "fetch_whoami_v2", fake_fetch_whoami_v2)
+    monkeypatch.setattr(main_mod, "_get_hf_user", fail_get_hf_user)
+
+    assert await main_mod._get_hf_identity("hf-token") == ("tester", "pro")
+    assert calls == [("hf-token", 5.0)]
+
+
 def test_cli_forwards_model_flag_to_interactive_main(monkeypatch):
     seen: dict[str, object] = {}
 
@@ -193,8 +211,7 @@ async def test_interactive_main_applies_model_override_before_banner(monkeypatch
     monkeypatch.setattr(main_mod.os, "system", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
-    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
-    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
+    monkeypatch.setattr(main_mod, "_get_hf_identity", _fake_hf_identity)
     monkeypatch.setattr(
         main_mod,
         "load_config",
@@ -228,8 +245,6 @@ async def test_local_model_local_runtime_skips_hf_token_prompt(monkeypatch):
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: None)
     monkeypatch.setattr(main_mod, "_prompt_and_save_hf_token", fail_prompt)
-    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: None)
-    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
     monkeypatch.setattr(
         main_mod,
         "load_config",
@@ -267,8 +282,7 @@ async def test_local_model_sandbox_runtime_prompts_for_hf_token(monkeypatch):
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: None)
     monkeypatch.setattr(main_mod, "_prompt_and_save_hf_token", fake_prompt)
-    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
-    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
+    monkeypatch.setattr(main_mod, "_get_hf_identity", _fake_hf_identity)
     monkeypatch.setattr(
         main_mod,
         "load_config",
@@ -312,8 +326,7 @@ async def test_interactive_main_passes_sandbox_runtime_to_tool_router(monkeypatc
     monkeypatch.setattr(main_mod.os, "system", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
-    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
-    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", _fake_hf_user_plan)
+    monkeypatch.setattr(main_mod, "_get_hf_identity", _fake_hf_identity)
     monkeypatch.setattr(main_mod, "print_banner", lambda **_kwargs: None)
     monkeypatch.setattr(hf_router_catalog, "prewarm", lambda: None)
     monkeypatch.setattr(
@@ -340,9 +353,9 @@ async def test_interactive_main_passes_sandbox_runtime_to_tool_router(monkeypatc
 async def test_interactive_main_passes_user_plan_to_submission_loop(monkeypatch):
     seen: dict[str, object] = {}
 
-    async def fake_fetch_hf_user_plan(token):
+    async def fake_get_hf_identity(token):
         seen["plan_token"] = token
-        return "free"
+        return "tester", "free"
 
     class FakeGateway:
         def __init__(self, _config):
@@ -394,8 +407,7 @@ async def test_interactive_main_passes_user_plan_to_submission_loop(monkeypatch)
     monkeypatch.setattr(main_mod, "_clear_terminal", lambda: None)
     monkeypatch.setattr(main_mod, "PromptSession", lambda: object())
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
-    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
-    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", fake_fetch_hf_user_plan)
+    monkeypatch.setattr(main_mod, "_get_hf_identity", fake_get_hf_identity)
     monkeypatch.setattr(main_mod, "print_banner", lambda **_kwargs: None)
     monkeypatch.setattr(main_mod, "NotificationGateway", FakeGateway)
     monkeypatch.setattr(main_mod, "ToolRouter", FakeToolRouter)
@@ -427,9 +439,9 @@ async def test_interactive_main_passes_user_plan_to_submission_loop(monkeypatch)
 async def test_headless_main_passes_user_plan_to_submission_loop(monkeypatch):
     seen: dict[str, object] = {}
 
-    async def fake_fetch_hf_user_plan(token):
+    async def fake_get_hf_identity(token):
         seen["plan_token"] = token
-        return "pro"
+        return "tester", "pro"
 
     class FakeGateway:
         def __init__(self, _config):
@@ -463,8 +475,7 @@ async def test_headless_main_passes_user_plan_to_submission_loop(monkeypatch):
 
     monkeypatch.setattr(main_mod, "_clear_terminal", lambda: None)
     monkeypatch.setattr(main_mod, "resolve_hf_token", lambda: "hf-token")
-    monkeypatch.setattr(main_mod, "_get_hf_user", lambda _token: "tester")
-    monkeypatch.setattr(main_mod, "fetch_hf_user_plan", fake_fetch_hf_user_plan)
+    monkeypatch.setattr(main_mod, "_get_hf_identity", fake_get_hf_identity)
     monkeypatch.setattr(main_mod, "NotificationGateway", FakeGateway)
     monkeypatch.setattr(main_mod, "ToolRouter", FakeToolRouter)
     monkeypatch.setattr(main_mod, "submission_loop", fake_submission_loop)

--- a/tests/unit/test_hf_access.py
+++ b/tests/unit/test_hf_access.py
@@ -77,10 +77,17 @@ def test_is_billing_error_detects_402_and_credit_phrasing():
     assert not is_billing_error("")
 
 
+def test_jobs_billing_classifier_ignores_non_credit_quota_errors():
+    assert not is_billing_error("quota exceeded")
+    assert not is_billing_error("insufficient_quota")
+    assert not is_billing_error("flavor quota exceeded")
+
+
 def test_is_inference_billing_error_detects_credit_and_quota_phrasing():
     assert is_inference_billing_error("402 Payment Required")
     assert is_inference_billing_error("exhausted monthly credits")
     assert is_inference_billing_error("insufficient_quota")
+    assert is_inference_billing_error("quota exceeded")
     assert is_inference_billing_error("monthly credits exhausted")
     assert not is_inference_billing_error("503 service unavailable")
 

--- a/tests/unit/test_hf_access.py
+++ b/tests/unit/test_hf_access.py
@@ -1,4 +1,12 @@
-from agent.core.hf_access import is_billing_error, jobs_access_from_whoami
+import pytest
+
+from agent.core.hf_access import (
+    fetch_hf_user_plan,
+    is_billing_error,
+    is_inference_billing_error,
+    jobs_access_from_whoami,
+    normalize_hf_user_plan,
+)
 
 
 def test_personal_user_lists_username_namespace():
@@ -67,3 +75,43 @@ def test_is_billing_error_detects_402_and_credit_phrasing():
     assert is_billing_error("Out of credit, please add billing")
     assert not is_billing_error("Internal server error")
     assert not is_billing_error("")
+
+
+def test_is_inference_billing_error_detects_credit_and_quota_phrasing():
+    assert is_inference_billing_error("402 Payment Required")
+    assert is_inference_billing_error("exhausted monthly credits")
+    assert is_inference_billing_error("insufficient_quota")
+    assert is_inference_billing_error("monthly credits exhausted")
+    assert not is_inference_billing_error("503 service unavailable")
+
+
+def test_normalize_hf_user_plan_uses_ispro_only():
+    assert normalize_hf_user_plan({"isPro": True}) == "pro"
+    assert normalize_hf_user_plan({"isPro": False}) == "free"
+    assert normalize_hf_user_plan({"plan": "HF Pro"}) == "free"
+    assert normalize_hf_user_plan(None) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_hf_user_plan_returns_unknown_without_token():
+    assert await fetch_hf_user_plan(None) == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_fetch_hf_user_plan_returns_unknown_when_whoami_unavailable(monkeypatch):
+    async def fake_fetch_whoami_v2(_token, timeout=5.0):
+        return None
+
+    monkeypatch.setattr("agent.core.hf_access.fetch_whoami_v2", fake_fetch_whoami_v2)
+
+    assert await fetch_hf_user_plan("hf-token") == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_fetch_hf_user_plan_normalizes_whoami(monkeypatch):
+    async def fake_fetch_whoami_v2(_token, timeout=5.0):
+        return {"isPro": True}
+
+    monkeypatch.setattr("agent.core.hf_access.fetch_whoami_v2", fake_fetch_whoami_v2)
+
+    assert await fetch_hf_user_plan("hf-token") == "pro"

--- a/tests/unit/test_llm_error_classification.py
+++ b/tests/unit/test_llm_error_classification.py
@@ -16,6 +16,7 @@ from agent.core.agent_loop import (
     _MAX_LLM_RETRIES,
     _LLM_RATE_LIMIT_RETRY_DELAYS,
     _LLM_RETRY_DELAYS,
+    _friendly_error_message,
     _is_context_overflow_error,
     _is_rate_limit_error,
     _is_transient_error,
@@ -100,3 +101,38 @@ def test_rate_limit_total_budget_covers_token_bucket_recovery():
     exceed a typical ~60s provider token-bucket recovery window."""
     assert len(_LLM_RATE_LIMIT_RETRY_DELAYS) == _MAX_LLM_RETRIES - 1
     assert sum(_LLM_RATE_LIMIT_RETRY_DELAYS) > 60
+
+
+def test_free_user_credit_error_mentions_pro_and_billing_links():
+    msg = _friendly_error_message(
+        Exception("402 Payment Required: monthly credits exhausted"),
+        user_plan="free",
+    )
+
+    assert msg is not None
+    assert "https://huggingface.co/subscribe/pro" in msg
+    assert "https://huggingface.co/settings/billing" in msg
+
+
+def test_pro_user_credit_error_mentions_billing_only():
+    msg = _friendly_error_message(
+        Exception("insufficient_quota"),
+        user_plan="pro",
+    )
+
+    assert msg is not None
+    assert "https://huggingface.co/settings/billing" in msg
+    assert "https://huggingface.co/subscribe/pro" not in msg
+
+
+def test_unknown_plan_credit_error_uses_fallback_wording():
+    msg = _friendly_error_message(
+        Exception("exhausted monthly credits"),
+        user_plan="unknown",
+    )
+
+    assert msg is not None
+    assert "appear to be exhausted" in msg
+    assert "If this is a free account" in msg
+    assert "https://huggingface.co/settings/billing" in msg
+    assert "https://huggingface.co/subscribe/pro" in msg

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -22,8 +22,15 @@ from session_manager import AgentSession, SessionManager  # noqa: E402
 
 
 class FakeRuntimeSession:
-    def __init__(self, *, hf_token: str | None = None, model: str = "test-model"):
+    def __init__(
+        self,
+        *,
+        hf_token: str | None = None,
+        user_plan: str | None = None,
+        model: str = "test-model",
+    ):
         self.hf_token = hf_token
+        self.user_plan = user_plan
         self.context_manager = SimpleNamespace(items=[])
         self.pending_approval = None
         self.turn_count = 0
@@ -116,8 +123,9 @@ def _runtime_agent_session(
     *,
     user_id: str = "owner",
     hf_token: str | None = "owner-token",
+    user_plan: str | None = None,
 ) -> AgentSession:
-    runtime_session = FakeRuntimeSession(hf_token=hf_token)
+    runtime_session = FakeRuntimeSession(hf_token=hf_token, user_plan=user_plan)
     return AgentSession(
         session_id=session_id,
         session=runtime_session,  # type: ignore[arg-type]
@@ -125,6 +133,7 @@ def _runtime_agent_session(
         submission_queue=asyncio.Queue(),
         user_id=user_id,
         hf_token=hf_token,
+        user_plan=user_plan,
     )
 
 
@@ -188,6 +197,7 @@ def _install_fake_runtime(manager: SessionManager) -> asyncio.Event:
     def fake_create_session_sync(**kwargs: Any):
         return object(), FakeRuntimeSession(
             hf_token=kwargs.get("hf_token"),
+            user_plan=kwargs.get("user_plan"),
             model=kwargs.get("model") or "test-model",
         )
 
@@ -321,6 +331,19 @@ async def test_existing_session_updates_token_after_access_check():
     assert result is existing
     assert existing.hf_token == "new-token"
     assert existing.session.hf_token == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_existing_session_updates_plan_after_access_check():
+    manager = _manager_with_store(NoopSessionStore())
+    existing = _runtime_agent_session("s1", user_id="owner", user_plan="free")
+    manager.sessions["s1"] = existing
+
+    result = await manager.ensure_session_loaded("s1", user_id="owner", user_plan="pro")
+
+    assert result is existing
+    assert existing.user_plan == "pro"
+    assert existing.session.user_plan == "pro"
 
 
 @pytest.mark.asyncio
@@ -459,11 +482,17 @@ async def test_create_session_schedules_cpu_sandbox_preload():
     manager._start_cpu_sandbox_preload = fake_start_cpu_sandbox_preload  # type: ignore[method-assign]
 
     try:
-        session_id = await manager.create_session(user_id="owner", hf_token="token")
+        session_id = await manager.create_session(
+            user_id="owner",
+            hf_token="token",
+            user_plan="pro",
+        )
 
         assert scheduled == [session_id]
         assert session_id in manager.sessions
+        assert manager.sessions[session_id].user_plan == "pro"
         runtime_session = manager.sessions[session_id].session
+        assert runtime_session.user_plan == "pro"
         assert not hasattr(runtime_session, "_ml_intern_artifact_collection_task")
         assert not hasattr(runtime_session, "_ml_intern_artifact_collection_slug")
     finally:
@@ -484,12 +513,16 @@ async def test_lazy_restore_schedules_cpu_sandbox_preload():
 
     try:
         restored = await manager.ensure_session_loaded(
-            "persisted-session", user_id="owner"
+            "persisted-session",
+            user_id="owner",
+            user_plan="free",
         )
 
         assert restored is not None
         assert scheduled == ["persisted-session"]
         assert "persisted-session" in manager.sessions
+        assert restored.user_plan == "free"
+        assert restored.session.user_plan == "free"
         assert not hasattr(restored.session, "_ml_intern_artifact_collection_task")
         assert not hasattr(restored.session, "_ml_intern_artifact_collection_slug")
     finally:

--- a/tests/unit/test_session_reaper.py
+++ b/tests/unit/test_session_reaper.py
@@ -54,8 +54,14 @@ class RecordingStore(NoopSessionStore):
 class FakeSession:
     """Minimal Session stand-in supporting both persistence and _run_session."""
 
-    def __init__(self, *, hf_token: str | None = "token") -> None:
+    def __init__(
+        self,
+        *,
+        hf_token: str | None = "token",
+        user_plan: str | None = None,
+    ) -> None:
         self.hf_token = hf_token
+        self.user_plan = user_plan
         self.context_manager = SimpleNamespace(items=[])
         self.pending_approval: Any = None
         self.turn_count = 0
@@ -140,7 +146,10 @@ def _install_fake_create(manager: SessionManager) -> asyncio.Event:
     stop = asyncio.Event()
 
     def fake_create_session_sync(**kwargs: Any):
-        return object(), FakeSession(hf_token=kwargs.get("hf_token"))
+        return object(), FakeSession(
+            hf_token=kwargs.get("hf_token"),
+            user_plan=kwargs.get("user_plan"),
+        )
 
     async def fake_run_session(*_: Any) -> None:
         await stop.wait()


### PR DESCRIPTION
## Summary
- add shared HF plan lookup and inference billing error helpers
- thread the active user plan through CLI sessions
- show free/pro/unknown-specific CLI CTAs when Inference Providers credits are exhausted

## Tests
- uv run pytest tests/unit/test_llm_error_classification.py tests/unit/test_hf_access.py tests/unit/test_plan_normalization.py tests/unit/test_cli_rendering.py
- uv run ruff check .
- uv run ruff format --check .