### PR TITLE
Add session usage threshold approvals

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -30,6 +30,11 @@ from agent.core.llm_params import _resolve_llm_params
 from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_caching
 from agent.core.session import DEFAULT_SESSION_LOG_DIR, Event, OpType, Session
 from agent.core.tools import ToolRouter
+from agent.core.usage_thresholds import (
+    USAGE_THRESHOLD_TOOL_NAME,
+    is_usage_threshold_pending,
+    next_usage_warning_threshold,
+)
 from agent.tools.jobs_tool import CPU_FLAVORS
 from agent.tools.sandbox_tool import (
     DEFAULT_CPU_SANDBOX_HARDWARE,
@@ -133,6 +138,46 @@ def _detect_repeated_malformed(
             return streak_tool
 
     return None
+
+
+def _coerce_float(value: Any) -> float:
+    if isinstance(value, bool) or value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _usage_output_message(pending: dict[str, Any]) -> str:
+    current = _coerce_float(pending.get("current_spend_usd"))
+    next_threshold = _coerce_float(pending.get("next_threshold_usd"))
+    return (
+        f"Current-session usage warning acknowledged at ${current:.2f}. "
+        f"The next warning is at ${next_threshold:.2f}."
+    )
+
+
+async def _maybe_pause_for_usage_threshold(
+    session: Session,
+    *,
+    continuation: str,
+    final_response: str | None = None,
+) -> bool:
+    checker = getattr(session, "usage_threshold_checker", None)
+    if checker is None or session.pending_approval:
+        return False
+    payload: dict[str, Any] = {
+        "continuation": continuation,
+        "history_size": len(session.context_manager.items),
+    }
+    if final_response is not None:
+        payload["final_response"] = final_response
+    try:
+        return bool(await checker(payload))
+    except Exception as e:
+        logger.debug("Usage threshold check failed: %s", e)
+        return False
 
 
 def _validate_tool_args(tool_args: dict) -> tuple[bool, str | None]:
@@ -1082,6 +1127,22 @@ class Handlers:
         history stays valid) and notifies the frontend that those tools were
         abandoned.
         """
+        if is_usage_threshold_pending(session.pending_approval):
+            tool_call_id = str(session.pending_approval.get("tool_call_id") or "")
+            session.pending_approval = None
+            if tool_call_id:
+                await session.send_event(
+                    Event(
+                        event_type="tool_state_change",
+                        data={
+                            "tool_call_id": tool_call_id,
+                            "tool": USAGE_THRESHOLD_TOOL_NAME,
+                            "state": "abandoned",
+                        },
+                    )
+                )
+            return
+
         tool_calls = session.pending_approval.get("tool_calls", [])
         for tc in tool_calls:
             tool_name = tc.function.name
@@ -1160,6 +1221,12 @@ class Handlers:
             await _compact_and_notify(session)
             if not session.is_running:
                 break
+
+            if await _maybe_pause_for_usage_threshold(
+                session,
+                continuation="continue_agent",
+            ):
+                return final_response
 
             # Doom-loop detection: break out of repeated tool call patterns
             doom_prompt = check_for_doom_loop(session.context_manager.items)
@@ -1670,6 +1737,14 @@ class Handlers:
             await _cleanup_on_cancel(session)
             await session.send_event(Event(event_type="interrupted"))
         elif not errored:
+            if await _maybe_pause_for_usage_threshold(
+                session,
+                continuation="complete_turn",
+                final_response=final_response
+                if isinstance(final_response, str)
+                else None,
+            ):
+                return final_response
             await session.send_event(
                 Event(
                     event_type="turn_complete",
@@ -1724,6 +1799,113 @@ class Handlers:
         await session.send_event(Event(event_type="resume_complete", data=result))
 
     @staticmethod
+    async def _exec_usage_threshold_approval(
+        session: Session, approvals: list[dict]
+    ) -> None:
+        pending = (
+            session.pending_approval
+            if isinstance(session.pending_approval, dict)
+            else {}
+        )
+        tool_call_id = str(pending.get("tool_call_id") or "")
+        approval = next(
+            (item for item in approvals if item.get("tool_call_id") == tool_call_id),
+            {"approved": False},
+        )
+        approved = bool(approval.get("approved"))
+
+        session.pending_approval = None
+        if not tool_call_id:
+            await session.send_event(
+                Event(
+                    event_type="error",
+                    data={"error": "Usage approval is missing its approval id"},
+                )
+            )
+            return
+
+        if not approved:
+            feedback = str(approval.get("feedback") or "Stopped by user").strip()
+            await session.send_event(
+                Event(
+                    event_type="tool_state_change",
+                    data={
+                        "tool_call_id": tool_call_id,
+                        "tool": USAGE_THRESHOLD_TOOL_NAME,
+                        "state": "rejected",
+                    },
+                )
+            )
+            await session.send_event(
+                Event(
+                    event_type="tool_output",
+                    data={
+                        "tool": USAGE_THRESHOLD_TOOL_NAME,
+                        "tool_call_id": tool_call_id,
+                        "output": feedback,
+                        "success": False,
+                    },
+                )
+            )
+            await session.send_event(Event(event_type="interrupted"))
+            session.increment_turn()
+            await session.auto_save_if_needed()
+            return
+
+        current_spend = _coerce_float(pending.get("current_spend_usd"))
+        acknowledged_threshold = _coerce_float(pending.get("threshold_usd"))
+        next_threshold = next_usage_warning_threshold(
+            current_spend,
+            acknowledged_threshold,
+        )
+        session.usage_warning_next_threshold_usd = next_threshold
+        pending["next_threshold_usd"] = next_threshold
+
+        await session.send_event(
+            Event(
+                event_type="tool_state_change",
+                data={
+                    "tool_call_id": tool_call_id,
+                    "tool": USAGE_THRESHOLD_TOOL_NAME,
+                    "state": "approved",
+                },
+            )
+        )
+        await session.send_event(
+            Event(
+                event_type="tool_output",
+                data={
+                    "tool": USAGE_THRESHOLD_TOOL_NAME,
+                    "tool_call_id": tool_call_id,
+                    "output": _usage_output_message(pending),
+                    "success": True,
+                },
+            )
+        )
+
+        if pending.get("continuation") == "complete_turn":
+            final_response = pending.get("final_response")
+            await session.send_event(
+                Event(
+                    event_type="turn_complete",
+                    data={
+                        "history_size": int(
+                            pending.get("history_size")
+                            or len(session.context_manager.items)
+                        ),
+                        "final_response": final_response
+                        if isinstance(final_response, str)
+                        else None,
+                    },
+                )
+            )
+            session.increment_turn()
+            await session.auto_save_if_needed()
+            return
+
+        await Handlers.run_agent(session, "")
+
+    @staticmethod
     async def exec_approval(session: Session, approvals: list[dict]) -> None:
         """Handle batch job execution approval"""
         if not session.pending_approval:
@@ -1733,6 +1915,10 @@ class Handlers:
                     data={"error": "No pending approval to process"},
                 )
             )
+            return
+
+        if is_usage_threshold_pending(session.pending_approval):
+            await Handlers._exec_usage_threshold_approval(session, approvals)
             return
 
         tool_calls = session.pending_approval.get("tool_calls", [])

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -169,6 +169,7 @@ async def _maybe_pause_for_usage_threshold(
         return False
     payload: dict[str, Any] = {
         "continuation": continuation,
+        "force_check": continuation == "complete_turn",
         "history_size": len(session.context_manager.items),
     }
     if final_response is not None:
@@ -1128,7 +1129,8 @@ class Handlers:
         abandoned.
         """
         if is_usage_threshold_pending(session.pending_approval):
-            tool_call_id = str(session.pending_approval.get("tool_call_id") or "")
+            pending = session.pending_approval
+            tool_call_id = str(pending.get("tool_call_id") or "")
             session.pending_approval = None
             if tool_call_id:
                 await session.send_event(
@@ -1141,6 +1143,24 @@ class Handlers:
                         },
                     )
                 )
+            if pending.get("continuation") == "complete_turn":
+                final_response = pending.get("final_response")
+                await session.send_event(
+                    Event(
+                        event_type="turn_complete",
+                        data={
+                            "history_size": int(
+                                pending.get("history_size")
+                                or len(session.context_manager.items)
+                            ),
+                            "final_response": final_response
+                            if isinstance(final_response, str)
+                            else None,
+                        },
+                    )
+                )
+                session.increment_turn()
+                await session.auto_save_if_needed()
             return
 
         tool_calls = session.pending_approval.get("tool_calls", [])

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -17,6 +17,10 @@ from agent.config import Config
 from agent.context_manager.manager import ContextManager
 from agent.messaging.gateway import NotificationGateway
 from agent.messaging.models import NotificationRequest
+from agent.core.usage_thresholds import (
+    USAGE_THRESHOLD_TOOL_NAME,
+    USAGE_WARNING_FIRST_THRESHOLD_USD,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +28,23 @@ _DEFAULT_MAX_TOKENS = 200_000
 _TURN_COMPLETE_NOTIFICATION_CHARS = 39000
 
 DEFAULT_SESSION_LOG_DIR = Path("session_logs")
+
+
+def _format_usd(value: Any) -> str:
+    if isinstance(value, bool):
+        return "$0.00"
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        amount = 0.0
+    return f"${amount:.2f}"
+
+
+def _approval_tools_are_usage_thresholds(tools: Any) -> bool:
+    if not isinstance(tools, list) or len(tools) != 1:
+        return False
+    tool = tools[0]
+    return isinstance(tool, dict) and tool.get("tool") == USAGE_THRESHOLD_TOOL_NAME
 
 
 def _get_max_tokens_safe(model_name: str) -> int:
@@ -134,6 +155,8 @@ class Session:
         self.auto_approval_enabled: bool = False
         self.auto_approval_cost_cap_usd: float | None = None
         self.auto_approval_estimated_spend_usd: float = 0.0
+        self.usage_warning_next_threshold_usd: float = USAGE_WARNING_FIRST_THRESHOLD_USD
+        self.usage_threshold_checker: Any | None = None
 
         # Session trajectory logging
         self.logged_events: list[dict] = []
@@ -258,21 +281,38 @@ class Session:
         data = event.data or {}
         if event.event_type == "approval_required":
             tools = data.get("tools", [])
-            tool_names = []
-            for tool in tools if isinstance(tools, list) else []:
-                if isinstance(tool, dict):
-                    tool_name = str(tool.get("tool") or "").strip()
-                    if tool_name and tool_name not in tool_names:
-                        tool_names.append(tool_name)
-            count = len(tools) if isinstance(tools, list) else 0
-            title = "Agent approval required"
-            message = (
-                f"Session {self.session_id} is waiting for approval "
-                f"for {count} tool call(s)."
-            )
-            if tool_names:
-                message += " Tools: " + ", ".join(tool_names)
-            severity = "warning"
+            if _approval_tools_are_usage_thresholds(tools):
+                tool = tools[0]
+                args = tool.get("arguments") if isinstance(tool, dict) else {}
+                args = args if isinstance(args, dict) else {}
+                current = _format_usd(args.get("current_spend_usd"))
+                threshold = _format_usd(args.get("threshold_usd"))
+                next_threshold = _format_usd(args.get("next_threshold_usd"))
+                title = "Usage approval required"
+                message = (
+                    f"Session {self.session_id} reached {current} in current-session "
+                    f"usage, crossing the {threshold} warning threshold."
+                )
+                if next_threshold:
+                    message += f" The next warning is at {next_threshold}."
+                severity = "warning"
+            else:
+                tools = data.get("tools", [])
+                tool_names = []
+                for tool in tools if isinstance(tools, list) else []:
+                    if isinstance(tool, dict):
+                        tool_name = str(tool.get("tool") or "").strip()
+                        if tool_name and tool_name not in tool_names:
+                            tool_names.append(tool_name)
+                count = len(tools) if isinstance(tools, list) else 0
+                title = "Agent approval required"
+                message = (
+                    f"Session {self.session_id} is waiting for approval "
+                    f"for {count} tool call(s)."
+                )
+                if tool_names:
+                    message += " Tools: " + ", ".join(tool_names)
+                severity = "warning"
         elif event.event_type == "error":
             title = "Agent error"
             error = str(data.get("error") or "Unknown error")

--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -178,6 +178,7 @@ class MongoSessionStore(NoopSessionStore):
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
         auto_approval_estimated_spend_usd: float = 0.0,
+        usage_warning_next_threshold_usd: float = 5.0,
     ) -> None:
         if not self._ready():
             return
@@ -212,6 +213,7 @@ class MongoSessionStore(NoopSessionStore):
                     "auto_approval_enabled": auto_approval_enabled,
                     "auto_approval_cost_cap_usd": auto_approval_cost_cap_usd,
                     "auto_approval_estimated_spend_usd": auto_approval_estimated_spend_usd,
+                    "usage_warning_next_threshold_usd": usage_warning_next_threshold_usd,
                 },
             },
             upsert=True,
@@ -236,6 +238,7 @@ class MongoSessionStore(NoopSessionStore):
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
         auto_approval_estimated_spend_usd: float = 0.0,
+        usage_warning_next_threshold_usd: float = 5.0,
         raise_on_error: bool = False,
     ) -> None:
         if not self._ready():
@@ -260,6 +263,7 @@ class MongoSessionStore(NoopSessionStore):
             auto_approval_enabled=auto_approval_enabled,
             auto_approval_cost_cap_usd=auto_approval_cost_cap_usd,
             auto_approval_estimated_spend_usd=auto_approval_estimated_spend_usd,
+            usage_warning_next_threshold_usd=usage_warning_next_threshold_usd,
         )
         ops: list[Any] = []
         for idx, raw in enumerate(messages):

--- a/agent/core/usage_thresholds.py
+++ b/agent/core/usage_thresholds.py
@@ -1,0 +1,57 @@
+"""Helpers for session usage-threshold approval warnings."""
+
+from typing import Any, Literal
+
+USAGE_THRESHOLD_TOOL_NAME = "usage_threshold"
+USAGE_WARNING_FIRST_THRESHOLD_USD = 5.0
+USAGE_WARNING_MULTIPLIER = 2.0
+
+UsageApprovalContinuation = Literal["continue_agent", "complete_turn"]
+
+
+def normalize_usage_threshold(value: Any) -> float:
+    """Return a usable positive threshold, defaulting to the first warning."""
+    if isinstance(value, bool):
+        return USAGE_WARNING_FIRST_THRESHOLD_USD
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError):
+        return USAGE_WARNING_FIRST_THRESHOLD_USD
+    if threshold <= 0:
+        return USAGE_WARNING_FIRST_THRESHOLD_USD
+    return threshold
+
+
+def next_usage_warning_threshold(
+    current_spend_usd: float,
+    acknowledged_threshold_usd: float,
+) -> float:
+    """Advance the next threshold until it is above the current spend."""
+    threshold = normalize_usage_threshold(acknowledged_threshold_usd)
+    current = max(0.0, float(current_spend_usd or 0.0))
+    while threshold <= current:
+        threshold *= USAGE_WARNING_MULTIPLIER
+    return round(threshold, 4)
+
+
+def is_usage_threshold_pending(pending_approval: Any) -> bool:
+    return (
+        isinstance(pending_approval, dict)
+        and pending_approval.get("kind") == USAGE_THRESHOLD_TOOL_NAME
+    )
+
+
+def usage_threshold_pending_to_tool(pending_approval: dict[str, Any]) -> dict[str, Any]:
+    """Represent a synthetic usage approval as the existing pending-tool shape."""
+    tool_call_id = str(pending_approval.get("tool_call_id") or "")
+    arguments = {
+        "threshold_usd": pending_approval.get("threshold_usd"),
+        "current_spend_usd": pending_approval.get("current_spend_usd"),
+        "next_threshold_usd": pending_approval.get("next_threshold_usd"),
+        "billing_source": pending_approval.get("billing_source"),
+    }
+    return {
+        "tool": USAGE_THRESHOLD_TOOL_NAME,
+        "tool_call_id": tool_call_id,
+        "arguments": arguments,
+    }

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -610,7 +610,7 @@ async def upload_session_dataset(
         if agent_session.session.pending_approval:
             raise HTTPException(
                 status_code=409,
-                detail="Approve or reject pending tools before uploading a dataset.",
+                detail="Resolve pending approvals before uploading a dataset.",
             )
 
         hf_token = (

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -6,7 +6,7 @@ import logging
 import os
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -33,6 +33,7 @@ from agent.messaging.gateway import NotificationGateway
 # Get project root (parent of backend directory)
 PROJECT_ROOT = Path(__file__).parent.parent
 DEFAULT_CONFIG_PATH = str(PROJECT_ROOT / "configs" / "frontend_agent_config.json")
+USAGE_WARNING_SPEND_CACHE_TTL_SECONDS = 30.0
 
 
 # These dataclasses match agent/main.py structure
@@ -123,6 +124,7 @@ class AgentSession:
     usage_window_started_at: datetime | None = None
     usage_window_baseline: dict[str, Any] | None = None
     usage_warning_next_threshold_usd: float = USAGE_WARNING_FIRST_THRESHOLD_USD
+    usage_warning_spend_cache: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.usage_window_started_at is None:
@@ -452,7 +454,22 @@ class SessionManager:
     async def _current_session_usage_spend(
         self,
         agent_session: AgentSession,
+        *,
+        use_cache: bool = True,
     ) -> tuple[float, str]:
+        now = datetime.now(UTC)
+        cache = agent_session.usage_warning_spend_cache
+        cache_expires_at = cache.get("expires_at")
+        if (
+            use_cache
+            and isinstance(cache_expires_at, datetime)
+            and cache_expires_at > now
+        ):
+            return (
+                float(cache.get("spend_usd") or 0.0),
+                str(cache.get("billing_source") or "app_telemetry_session"),
+            )
+
         from usage import build_usage_response
 
         response = await build_usage_response(
@@ -463,7 +480,39 @@ class SessionManager:
             timezone_name="UTC",
             include_rollups=False,
         )
-        return self._usage_spend_from_response(response)
+        spend, billing_source = self._usage_spend_from_response(response)
+        agent_session.usage_warning_spend_cache = {
+            "spend_usd": spend,
+            "billing_source": billing_source,
+            "expires_at": now
+            + timedelta(seconds=USAGE_WARNING_SPEND_CACHE_TTL_SECONDS),
+        }
+        return spend, billing_source
+
+    @staticmethod
+    def _runtime_session_usage_spend(agent_session: AgentSession) -> float:
+        from usage import aggregate_usage_events, event_created_at
+
+        window_start = agent_session.usage_window_started_at
+        if isinstance(window_start, datetime):
+            if window_start.tzinfo is None:
+                window_start = window_start.replace(tzinfo=UTC)
+            else:
+                window_start = window_start.astimezone(UTC)
+        events = []
+        for raw_event in getattr(agent_session.session, "logged_events", []) or []:
+            if raw_event.get("event_type") not in {"llm_call", "hf_job_complete"}:
+                continue
+            if isinstance(window_start, datetime):
+                created_at = event_created_at(raw_event, timezone_name="UTC")
+                if created_at is not None and created_at < window_start:
+                    continue
+            events.append(raw_event)
+        bucket = aggregate_usage_events(
+            events,
+            session_id=agent_session.session_id,
+        )
+        return float(bucket.get("total_usd") or 0.0)
 
     async def _maybe_request_usage_threshold_approval(
         self,
@@ -485,8 +534,14 @@ class SessionManager:
                 agent_session.usage_warning_next_threshold_usd,
             )
         )
+        force_check = bool(continuation_payload.get("force_check"))
+        local_spend = self._runtime_session_usage_spend(agent_session)
+        if not force_check and local_spend < threshold:
+            return False
+
         current_spend, billing_source = await self._current_session_usage_spend(
-            agent_session
+            agent_session,
+            use_cache=not force_check,
         )
         if current_spend < threshold:
             return False

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -20,6 +20,14 @@ from agent.core.model_ids import (
 from agent.core.session import Event, OpType, Session
 from agent.core.session_persistence import get_session_store
 from agent.core.tools import ToolRouter
+from agent.core.usage_thresholds import (
+    USAGE_THRESHOLD_TOOL_NAME,
+    USAGE_WARNING_FIRST_THRESHOLD_USD,
+    is_usage_threshold_pending,
+    next_usage_warning_threshold,
+    normalize_usage_threshold,
+    usage_threshold_pending_to_tool,
+)
 from agent.messaging.gateway import NotificationGateway
 
 # Get project root (parent of backend directory)
@@ -114,6 +122,7 @@ class AgentSession:
     title: str | None = None
     usage_window_started_at: datetime | None = None
     usage_window_baseline: dict[str, Any] | None = None
+    usage_warning_next_threshold_usd: float = USAGE_WARNING_FIRST_THRESHOLD_USD
 
     def __post_init__(self) -> None:
         if self.usage_window_started_at is None:
@@ -270,6 +279,8 @@ class SessionManager:
 
     def _serialize_pending_approval(self, session: Session) -> list[dict[str, Any]]:
         pending = session.pending_approval or {}
+        if is_usage_threshold_pending(pending):
+            return [dict(pending)]
         tool_calls = pending.get("tool_calls") or []
         serialized: list[dict[str, Any]] = []
         for tc in tool_calls:
@@ -282,6 +293,8 @@ class SessionManager:
     @staticmethod
     def _pending_tools_for_api(session: Session) -> list[dict[str, Any]] | None:
         pending = session.pending_approval or {}
+        if is_usage_threshold_pending(pending):
+            return [usage_threshold_pending_to_tool(pending)]
         tool_calls = pending.get("tool_calls") or []
         if not tool_calls:
             return None
@@ -305,6 +318,10 @@ class SessionManager:
     ) -> None:
         if not pending_approval:
             session.pending_approval = None
+            return
+        first = pending_approval[0]
+        if isinstance(first, dict) and first.get("kind") == USAGE_THRESHOLD_TOOL_NAME:
+            session.pending_approval = dict(first)
             return
         from litellm import ChatCompletionMessageToolCall as ToolCall
 
@@ -334,6 +351,9 @@ class SessionManager:
     ) -> list[dict[str, Any]] | None:
         if not pending_approval:
             return None
+        first = pending_approval[0]
+        if isinstance(first, dict) and first.get("kind") == USAGE_THRESHOLD_TOOL_NAME:
+            return [usage_threshold_pending_to_tool(first)]
         result: list[dict[str, Any]] = []
         for raw in pending_approval:
             if "function" in raw:
@@ -384,6 +404,126 @@ class SessionManager:
             "estimated_spend_usd": round(estimated, 4),
             "remaining_usd": remaining,
         }
+
+    def _install_usage_threshold_checker(self, agent_session: AgentSession) -> None:
+        threshold = normalize_usage_threshold(
+            getattr(
+                agent_session.session,
+                "usage_warning_next_threshold_usd",
+                agent_session.usage_warning_next_threshold_usd,
+            )
+        )
+        agent_session.usage_warning_next_threshold_usd = threshold
+        agent_session.session.usage_warning_next_threshold_usd = threshold
+
+        async def _checker(payload: dict[str, Any]) -> bool:
+            return await self._maybe_request_usage_threshold_approval(
+                agent_session.session_id,
+                payload,
+            )
+
+        agent_session.session.usage_threshold_checker = _checker
+
+    @staticmethod
+    def _usage_spend_from_response(response: dict[str, Any]) -> tuple[float, str]:
+        def coerce_spend(value: Any) -> float | None:
+            if isinstance(value, bool) or value is None:
+                return None
+            try:
+                return max(0.0, float(value))
+            except (TypeError, ValueError):
+                return None
+
+        hf_account = response.get("hf_account")
+        if isinstance(hf_account, dict):
+            current_session = hf_account.get("current_session")
+            if isinstance(current_session, dict):
+                spend = coerce_spend(current_session.get("total_usd"))
+                if spend is not None:
+                    return spend, "hf_billing_current_session"
+
+        session_bucket = response.get("session")
+        if isinstance(session_bucket, dict):
+            spend = coerce_spend(session_bucket.get("total_usd"))
+            if spend is not None:
+                return spend, "app_telemetry_session"
+        return 0.0, "app_telemetry_session"
+
+    async def _current_session_usage_spend(
+        self,
+        agent_session: AgentSession,
+    ) -> tuple[float, str]:
+        from usage import build_usage_response
+
+        response = await build_usage_response(
+            self,
+            user_id=agent_session.user_id,
+            hf_token=agent_session.hf_token,
+            session_id=agent_session.session_id,
+            timezone_name="UTC",
+            include_rollups=False,
+        )
+        return self._usage_spend_from_response(response)
+
+    async def _maybe_request_usage_threshold_approval(
+        self,
+        session_id: str,
+        continuation_payload: dict[str, Any],
+    ) -> bool:
+        agent_session = self.sessions.get(session_id)
+        if not agent_session or not agent_session.is_active:
+            return False
+
+        session = agent_session.session
+        if session.pending_approval:
+            return False
+
+        threshold = normalize_usage_threshold(
+            getattr(
+                session,
+                "usage_warning_next_threshold_usd",
+                agent_session.usage_warning_next_threshold_usd,
+            )
+        )
+        current_spend, billing_source = await self._current_session_usage_spend(
+            agent_session
+        )
+        if current_spend < threshold:
+            return False
+
+        next_threshold = next_usage_warning_threshold(current_spend, threshold)
+        tool_call_id = f"usage-threshold-{uuid.uuid4().hex[:10]}"
+        pending: dict[str, Any] = {
+            "kind": USAGE_THRESHOLD_TOOL_NAME,
+            "tool_call_id": tool_call_id,
+            "threshold_usd": round(threshold, 4),
+            "current_spend_usd": round(current_spend, 6),
+            "next_threshold_usd": next_threshold,
+            "billing_source": billing_source,
+            "continuation": continuation_payload.get("continuation")
+            or "continue_agent",
+            "history_size": int(
+                continuation_payload.get("history_size")
+                or len(session.context_manager.items)
+            ),
+        }
+        final_response = continuation_payload.get("final_response")
+        if isinstance(final_response, str):
+            pending["final_response"] = final_response
+
+        session.pending_approval = pending
+        self._touch(agent_session)
+        await session.send_event(
+            Event(
+                event_type="approval_required",
+                data={
+                    "tools": [usage_threshold_pending_to_tool(pending)],
+                    "count": 1,
+                    "usage_threshold": True,
+                },
+            )
+        )
+        return True
 
     async def _start_agent_session(
         self,
@@ -616,6 +756,13 @@ class SessionManager:
                     )
                     or 0.0
                 ),
+                usage_warning_next_threshold_usd=normalize_usage_threshold(
+                    getattr(
+                        agent_session.session,
+                        "usage_warning_next_threshold_usd",
+                        agent_session.usage_warning_next_threshold_usd,
+                    )
+                ),
                 raise_on_error=raise_on_error,
             )
         except Exception as e:
@@ -645,6 +792,7 @@ class SessionManager:
                     hf_token=hf_token,
                     hf_username=hf_username,
                 )
+                self._install_usage_threshold_checker(existing)
                 self._restart_cpu_preload_if_token_recovered(
                     existing,
                     preload_sandbox=preload_sandbox,
@@ -666,6 +814,7 @@ class SessionManager:
                     hf_token=hf_token,
                     hf_username=hf_username,
                 )
+                self._install_usage_threshold_checker(existing)
                 self._restart_cpu_preload_if_token_recovered(
                     existing,
                     preload_sandbox=preload_sandbox,
@@ -754,6 +903,9 @@ class SessionManager:
         session.auto_approval_estimated_spend_usd = float(
             meta.get("auto_approval_estimated_spend_usd") or 0.0
         )
+        session.usage_warning_next_threshold_usd = normalize_usage_threshold(
+            meta.get("usage_warning_next_threshold_usd")
+        )
 
         created_at = meta.get("created_at")
         if not isinstance(created_at, datetime):
@@ -776,10 +928,12 @@ class SessionManager:
             created_at=created_at,
             usage_window_started_at=usage_window_started_at,
             usage_window_baseline=usage_window_baseline,
+            usage_warning_next_threshold_usd=session.usage_warning_next_threshold_usd,
             is_active=True,
             is_processing=False,
             title=meta.get("title"),
         )
+        self._install_usage_threshold_checker(agent_session)
         started = await self._start_agent_session(
             agent_session=agent_session,
             event_queue=event_queue,
@@ -879,6 +1033,7 @@ class SessionManager:
                 hf_username=hf_username,
                 hf_token=hf_token,
             )
+            self._install_usage_threshold_checker(agent_session)
 
             await self._start_agent_session(
                 agent_session=agent_session,

--- a/frontend/src/components/Chat/ToolCallGroup.tsx
+++ b/frontend/src/components/Chat/ToolCallGroup.tsx
@@ -20,6 +20,24 @@ type DynamicToolPart = Extract<UIMessage['parts'][number], { type: 'dynamic-tool
 
 type ToolPartState = DynamicToolPart['state'];
 
+const USAGE_THRESHOLD_TOOL_NAME = 'usage_threshold';
+
+function formatApprovalUsd(value: unknown): string {
+  const amount = typeof value === 'number' && Number.isFinite(value) ? value : Number(value || 0);
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(amount) ? amount : 0);
+}
+
+function usageSourceLabel(source: unknown): string {
+  return source === 'hf_billing_current_session'
+    ? 'HF billing'
+    : 'app telemetry';
+}
+
 /** Check if a tool part was cancelled (output-error with cancellation message). */
 function isCancelledTool(tool: DynamicToolPart): boolean {
   return tool.state === 'output-error' &&
@@ -506,6 +524,7 @@ function InlineApproval({
   const { setPanel, getEditedScript } = useAgentStore();
   const { setRightPanelOpen, setLeftSidebarOpen } = useLayoutStore();
   const hasEditedScript = !!getEditedScript(toolCallId);
+  const isUsageThreshold = toolName === USAGE_THRESHOLD_TOOL_NAME;
 
   const handleScriptClick = useCallback(() => {
     if (toolName === 'hf_jobs' && args?.script) {
@@ -519,6 +538,87 @@ function InlineApproval({
       setLeftSidebarOpen(false);
     }
   }, [toolCallId, toolName, args, scriptLabel, setPanel, getEditedScript, setRightPanelOpen, setLeftSidebarOpen]);
+
+  if (isUsageThreshold) {
+    return (
+      <Box sx={{ px: 1.5, py: 1.5, borderTop: '1px solid var(--tool-border)' }}>
+        <Alert
+          severity="warning"
+          sx={{
+            mb: 1.5,
+            py: 0.5,
+            bgcolor: 'rgba(245,158,11,0.08)',
+            border: '1px solid rgba(245,158,11,0.18)',
+            color: 'var(--text)',
+            '& .MuiAlert-icon': { color: 'var(--accent-yellow)' },
+          }}
+        >
+          <Typography variant="body2" sx={{ fontSize: '0.74rem' }}>
+            Current session usage is {formatApprovalUsd(args?.current_spend_usd)} and crossed the{' '}
+            {formatApprovalUsd(args?.threshold_usd)} warning threshold.
+          </Typography>
+        </Alert>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr auto',
+            gap: 0.75,
+            mb: 1.5,
+            fontSize: '0.72rem',
+          }}
+        >
+          <Typography variant="body2" sx={{ color: 'var(--muted-text)', fontSize: '0.72rem' }}>
+            Next warning
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text)', fontSize: '0.72rem', fontVariantNumeric: 'tabular-nums' }}>
+            {formatApprovalUsd(args?.next_threshold_usd)}
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--muted-text)', fontSize: '0.72rem' }}>
+            Source
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text)', fontSize: '0.72rem' }}>
+            {usageSourceLabel(args?.billing_source)}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            size="small"
+            onClick={() => onResolve(toolCallId, false, 'Stopped at usage warning')}
+            sx={{
+              flex: 1,
+              textTransform: 'none',
+              border: '1px solid rgba(255,255,255,0.05)',
+              color: 'var(--accent-red)',
+              fontSize: '0.75rem',
+              py: 0.75,
+              borderRadius: '8px',
+              '&:hover': { bgcolor: 'rgba(224,90,79,0.05)', borderColor: 'var(--accent-red)' },
+            }}
+          >
+            Stop here
+          </Button>
+          <Button
+            size="small"
+            onClick={() => onResolve(toolCallId, true)}
+            sx={{
+              flex: 1,
+              textTransform: 'none',
+              border: '1px solid var(--accent-green)',
+              color: 'var(--accent-green)',
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              py: 0.75,
+              borderRadius: '8px',
+              bgcolor: 'rgba(47,204,113,0.08)',
+              '&:hover': { bgcolor: 'rgba(47,204,113,0.1)' },
+            }}
+          >
+            Continue
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ px: 1.5, py: 1.5, borderTop: '1px solid var(--tool-border)' }}>
@@ -815,6 +915,8 @@ export default function ToolCallGroup({ tools, approveTools }: ToolCallGroupProp
     for (const t of tools) {
       if (t.toolName === 'research') {
         displayMap[t.toolCallId] = 'research';
+      } else if (t.toolName === USAGE_THRESHOLD_TOOL_NAME) {
+        displayMap[t.toolCallId] = 'Usage warning';
       }
     }
     return { scriptLabelMap: scriptMap, toolDisplayMap: displayMap };

--- a/frontend/src/components/SessionChat.tsx
+++ b/frontend/src/components/SessionChat.tsx
@@ -150,7 +150,9 @@ export default function SessionChat({ sessionId, isActive, onSessionDead }: Sess
             disabled={!isConnected || activityStatus.type === 'waiting-approval'}
             placeholder={
               activityStatus.type === 'waiting-approval'
-                ? 'Approve or reject pending tools first...'
+                ? activityStatus.approvalKind === 'usage'
+                  ? 'Review the usage warning to continue...'
+                  : 'Approve or reject pending tools first...'
                 : undefined
             }
           />

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -14,13 +14,15 @@ import { SSEChatTransport, type SideChannelCallbacks } from '@/lib/sse-chat-tran
 import { loadMessages, saveMessages } from '@/lib/chat-message-store';
 import { saveBackendMessages } from '@/lib/backend-message-store';
 import { saveResearch, loadResearch, clearResearch, RESEARCH_MAX_STEPS } from '@/lib/research-store';
-import { llmMessagesToUIMessages } from '@/lib/convert-llm-messages';
+import { llmMessagesToUIMessages, type PendingApprovalItem } from '@/lib/convert-llm-messages';
 import { apiFetch } from '@/utils/api';
 import { useAgentStore } from '@/store/agentStore';
 import { useSessionStore } from '@/store/sessionStore';
 import { useUsageStore } from '@/store/usageStore';
 import { useLayoutStore } from '@/store/layoutStore';
 import { logger } from '@/utils/logger';
+
+const USAGE_THRESHOLD_TOOL_NAME = 'usage_threshold';
 
 interface UseAgentChatOptions {
   sessionId: string;
@@ -37,6 +39,36 @@ function textFromUIMessage(message: UIMessage): string {
     .filter((p): p is Extract<typeof p, { type: 'text' }> => p.type === 'text')
     .map(p => p.text)
     .join('');
+}
+
+function pendingApprovalItemsFromInfo(info: unknown): PendingApprovalItem[] | undefined {
+  const pending = (info as { pending_approval?: unknown } | null)?.pending_approval;
+  if (!Array.isArray(pending)) return undefined;
+  const items = pending.filter((item): item is PendingApprovalItem => {
+    if (!item || typeof item !== 'object') return false;
+    const raw = item as Record<string, unknown>;
+    return (
+      typeof raw.tool === 'string' &&
+      typeof raw.tool_call_id === 'string' &&
+      !!raw.arguments &&
+      typeof raw.arguments === 'object'
+    );
+  });
+  return items.length > 0 ? items : undefined;
+}
+
+function pendingApprovalIds(items: PendingApprovalItem[] | undefined): Set<string> | undefined {
+  if (!items?.length) return undefined;
+  return new Set(items.map((item) => item.tool_call_id));
+}
+
+function waitingApprovalStatus(items: PendingApprovalItem[] | undefined) {
+  return {
+    type: 'waiting-approval' as const,
+    approvalKind: items?.some((item) => item.tool === USAGE_THRESHOLD_TOOL_NAME)
+      ? 'usage' as const
+      : 'tool' as const,
+  };
 }
 
 export function useAgentChat({ sessionId, isActive, isProcessing = false, onReady, onError, onSessionDead }: UseAgentChatOptions) {
@@ -222,6 +254,11 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       onApprovalRequired: (tools) => {
         if (!tools.length) return;
         setNeedsAttention(sessionId, true);
+        const pendingItems = tools.map((tool) => ({
+          tool: tool.tool,
+          tool_call_id: tool.tool_call_id,
+          arguments: tool.arguments,
+        }));
 
         const store = useAgentStore.getState();
         for (const tool of tools) {
@@ -243,7 +280,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         // feeds shouldReactivate) so a backgrounded waiting-approval session
         // doesn't stay "processing" until the next /sessions merge —
         // activityStatus still surfaces the waiting-approval state.
-        setProcessingState(false, { activityStatus: { type: 'waiting-approval' } });
+        setProcessingState(false, { activityStatus: waitingApprovalStatus(pendingItems) });
         refreshUsage();
 
         // Build panel data for this session's pending approval
@@ -393,16 +430,14 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
           if (!Array.isArray(data) || data.length === 0) return false;
           saveBackendMessages(sessionId, data);
 
+          let pendingItems: PendingApprovalItem[] | undefined;
           let pendingIds: Set<string> | undefined;
           let backendIsProcessing = false;
           if (info) {
             backendIsProcessing = !!info.is_processing;
-            if (info.pending_approval && Array.isArray(info.pending_approval)) {
-              pendingIds = new Set(
-                info.pending_approval.map((t: { tool_call_id: string }) => t.tool_call_id)
-              );
-              if (pendingIds.size > 0) setNeedsAttention(sessionId, true);
-            }
+            pendingItems = pendingApprovalItemsFromInfo(info);
+            pendingIds = pendingApprovalIds(pendingItems);
+            if (pendingIds && pendingIds.size > 0) setNeedsAttention(sessionId, true);
             if (info.auto_approval) {
               updateSessionYolo(sessionId, info.auto_approval);
             }
@@ -412,6 +447,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             data,
             pendingIds,
             chatActionsRef.current.messages,
+            pendingItems,
           );
           const backendAdvanced = uiMsgs.length > currentMessageCount;
           let submittedTurnAccepted = false;
@@ -436,7 +472,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             return false;
           }
           if (pendingIds && pendingIds.size > 0) {
-            setProcessingState(false, { activityStatus: { type: 'waiting-approval' } });
+            setProcessingState(false, { activityStatus: waitingApprovalStatus(pendingItems) });
           } else {
             setProcessingState(false);
           }
@@ -536,15 +572,15 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
           return;
         }
 
+        let pendingItems: PendingApprovalItem[] | undefined;
         let pendingIds: Set<string> | undefined;
         let backendIsProcessing = false;
         if (infoRes.ok) {
           const info = await infoRes.json();
           backendIsProcessing = !!info.is_processing;
-          if (info.pending_approval && Array.isArray(info.pending_approval)) {
-            pendingIds = new Set(
-              info.pending_approval.map((t: { tool_call_id: string }) => t.tool_call_id)
-            );
+          pendingItems = pendingApprovalItemsFromInfo(info);
+          pendingIds = pendingApprovalIds(pendingItems);
+          if (pendingIds) {
             if (pendingIds.size > 0) {
               setNeedsAttention(sessionId, true);
             }
@@ -557,7 +593,12 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
           // Cache the raw backend messages so we can restore this session
           // into a fresh backend if the Space restarts.
           saveBackendMessages(sessionId, data);
-          const uiMsgs = llmMessagesToUIMessages(data, pendingIds, chatActionsRef.current.messages);
+          const uiMsgs = llmMessagesToUIMessages(
+            data,
+            pendingIds,
+            chatActionsRef.current.messages,
+            pendingItems,
+          );
           if (uiMsgs.length > 0) {
             chat.setMessages(uiMsgs);
             saveMessages(sessionId, uiMsgs);
@@ -583,7 +624,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             }),
           });
         } else if (pendingIds && pendingIds.size > 0) {
-          setProcessingState(false, { activityStatus: { type: 'waiting-approval' } });
+          setProcessingState(false, { activityStatus: waitingApprovalStatus(pendingItems) });
           clearResearch(sessionId);
         } else {
           setProcessingState(false);
@@ -623,21 +664,19 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         // into a fresh backend if the Space restarts.
         saveBackendMessages(sessionId, data);
 
+        let pendingItems: PendingApprovalItem[] | undefined;
         let pendingIds: Set<string> | undefined;
         if (infoRes.ok) {
           const info = await infoRes.json();
-          if (info.pending_approval && Array.isArray(info.pending_approval)) {
-            pendingIds = new Set(
-              info.pending_approval.map((t: { tool_call_id: string }) => t.tool_call_id)
-            );
-            if (pendingIds.size > 0) setNeedsAttention(sessionId, true);
-          }
+          pendingItems = pendingApprovalItemsFromInfo(info);
+          pendingIds = pendingApprovalIds(pendingItems);
+          if (pendingIds && pendingIds.size > 0) setNeedsAttention(sessionId, true);
           if (info.auto_approval) {
             updateSessionYolo(sessionId, info.auto_approval);
           }
-          return { data, pendingIds, info };
+          return { data, pendingIds, pendingItems, info };
         }
-        return { data, pendingIds, info: null };
+        return { data, pendingIds, pendingItems, info: null };
       } catch {
         return null;
       }
@@ -710,7 +749,12 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             // Final hydration to get the complete message state
             const result = await hydrateMessages();
             if (result) {
-              const uiMsgs = llmMessagesToUIMessages(result.data, result.pendingIds, chatActionsRef.current.messages);
+              const uiMsgs = llmMessagesToUIMessages(
+                result.data,
+                result.pendingIds,
+                chatActionsRef.current.messages,
+                result.pendingItems,
+              );
               if (uiMsgs.length > 0) {
                 chat.setMessages(uiMsgs);
                 saveMessages(sessionId, uiMsgs);
@@ -732,7 +776,12 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             stopReconnect();
             const result = await hydrateMessages();
             if (result) {
-              const uiMsgs = llmMessagesToUIMessages(result.data, result.pendingIds, chatActionsRef.current.messages);
+              const uiMsgs = llmMessagesToUIMessages(
+                result.data,
+                result.pendingIds,
+                chatActionsRef.current.messages,
+                result.pendingItems,
+              );
               if (uiMsgs.length > 0) {
                 chat.setMessages(uiMsgs);
                 saveMessages(sessionId, uiMsgs);
@@ -782,8 +831,13 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       const result = await hydrateMessages();
       if (!result) return;
 
-      const { data, pendingIds, info } = result;
-      const uiMsgs = llmMessagesToUIMessages(data, pendingIds, chatActionsRef.current.messages);
+      const { data, pendingIds, pendingItems, info } = result;
+      const uiMsgs = llmMessagesToUIMessages(
+        data,
+        pendingIds,
+        chatActionsRef.current.messages,
+        pendingItems,
+      );
       if (uiMsgs.length > 0) {
         chat.setMessages(uiMsgs);
         saveMessages(sessionId, uiMsgs);
@@ -806,7 +860,12 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         pollTimerRef.current = setInterval(async () => {
           const fresh = await hydrateMessages();
           if (!fresh) return;
-          const msgs = llmMessagesToUIMessages(fresh.data, fresh.pendingIds, chatActionsRef.current.messages);
+          const msgs = llmMessagesToUIMessages(
+            fresh.data,
+            fresh.pendingIds,
+            chatActionsRef.current.messages,
+            fresh.pendingItems,
+          );
 
           const currentCount = chatActionsRef.current.messages.length;
           if (msgs.length > currentCount || currentCount === 0) {
@@ -965,15 +1024,13 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
       if (!Array.isArray(data) || data.length === 0) return false;
       saveBackendMessages(sessionId, data);
 
+      let pendingItems: PendingApprovalItem[] | undefined;
       let pendingIds: Set<string> | undefined;
       if (infoRes.ok) {
         const info = await infoRes.json();
-        if (info.pending_approval && Array.isArray(info.pending_approval)) {
-          pendingIds = new Set(
-            info.pending_approval.map((t: { tool_call_id: string }) => t.tool_call_id)
-          );
-          if (pendingIds.size > 0) setNeedsAttention(sessionId, true);
-        }
+        pendingItems = pendingApprovalItemsFromInfo(info);
+        pendingIds = pendingApprovalIds(pendingItems);
+        if (pendingIds && pendingIds.size > 0) setNeedsAttention(sessionId, true);
         if (info.auto_approval) {
           updateSessionYolo(sessionId, info.auto_approval);
         }
@@ -983,6 +1040,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
         data,
         pendingIds,
         chatActionsRef.current.messages,
+        pendingItems,
       );
       const setMsgs = chatActionsRef.current.setMessages;
       if (setMsgs && uiMsgs.length > 0) {

--- a/frontend/src/lib/convert-llm-messages.ts
+++ b/frontend/src/lib/convert-llm-messages.ts
@@ -3,6 +3,8 @@
  */
 import type { UIMessage } from 'ai';
 
+const USAGE_THRESHOLD_TOOL_NAME = 'usage_threshold';
+
 interface LLMToolCall {
   id: string;
   function: { name: string; arguments: string };
@@ -14,6 +16,12 @@ interface LLMMessage {
   tool_calls?: LLMToolCall[] | null;
   tool_call_id?: string | null;
   name?: string | null;
+}
+
+export interface PendingApprovalItem {
+  tool: string;
+  tool_call_id: string;
+  arguments: Record<string, unknown>;
 }
 
 // Generate stable IDs based on message position to prevent duplicate renders
@@ -34,9 +42,11 @@ export function llmMessagesToUIMessages(
   messages: LLMMessage[],
   pendingApprovalIds?: Set<string>,
   existingUIMessages?: UIMessage[],
+  pendingApprovalItems?: PendingApprovalItem[],
 ): UIMessage[] {
   // Build a map of tool_call_id -> tool result for pairing
   const toolResults = new Map<string, { output: string; isError: boolean }>();
+  const restoredPendingIds = new Set<string>();
   for (const msg of messages) {
     if (msg.role === 'tool' && msg.tool_call_id) {
       toolResults.set(msg.tool_call_id, {
@@ -53,6 +63,18 @@ export function llmMessagesToUIMessages(
     if (!existingUIMessages || index >= existingUIMessages.length) return null;
     const existing = existingUIMessages[index];
     return existing.role === role ? existing.id : null;
+  };
+  const getExistingPendingToolMessageId = (toolCallId: string): string | null => {
+    for (const existing of existingUIMessages || []) {
+      if (existing.role !== 'assistant') continue;
+      const hasTool = existing.parts.some(
+        (part) =>
+          part.type === 'dynamic-tool' &&
+          part.toolCallId === toolCallId,
+      );
+      if (hasTool) return existing.id;
+    }
+    return null;
   };
 
   for (const msg of messages) {
@@ -101,6 +123,7 @@ export function llmMessagesToUIMessages(
               output: result.output,
             });
           } else if (pendingApprovalIds?.has(tc.id)) {
+            restoredPendingIds.add(tc.id);
             parts.push({
               type: 'dynamic-tool',
               toolCallId: tc.id,
@@ -139,6 +162,30 @@ export function llmMessagesToUIMessages(
         });
       }
     }
+  }
+
+  for (const pending of pendingApprovalItems || []) {
+    if (
+      pending.tool !== USAGE_THRESHOLD_TOOL_NAME ||
+      restoredPendingIds.has(pending.tool_call_id)
+    ) {
+      continue;
+    }
+    const id = getExistingPendingToolMessageId(pending.tool_call_id) || nextId();
+    uiMessages.push({
+      id,
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolCallId: pending.tool_call_id,
+          toolName: pending.tool,
+          state: 'approval-requested',
+          input: pending.arguments || {},
+          approval: { id: `approval-${pending.tool_call_id}` },
+        },
+      ],
+    });
   }
 
   return uiMessages;

--- a/frontend/src/store/agentStore.ts
+++ b/frontend/src/store/agentStore.ts
@@ -60,7 +60,7 @@ export type ActivityStatus =
   | { type: 'idle' }
   | { type: 'thinking' }
   | { type: 'tool'; toolName: string; description?: string }
-  | { type: 'waiting-approval' }
+  | { type: 'waiting-approval'; approvalKind?: 'tool' | 'usage' }
   | { type: 'streaming' }
   | { type: 'cancelled' };
 

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
-from datetime import datetime, UTC
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -35,6 +35,7 @@ class FakeRuntimeSession:
         self.auto_approval_estimated_spend_usd = 0.0
         self.usage_warning_next_threshold_usd = 5.0
         self.usage_threshold_checker = None
+        self.logged_events = []
         self.sandbox = None
         self.sandbox_hardware = None
         self.sandbox_preload_task = None
@@ -256,9 +257,16 @@ def test_usage_spend_falls_back_when_hf_total_is_unavailable():
 async def test_usage_threshold_checker_creates_synthetic_pending_approval(monkeypatch):
     manager = _manager_with_store(NoopSessionStore())
     agent_session = _runtime_agent_session("s1")
+    agent_session.session.logged_events.append(
+        {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "event_type": "llm_call",
+            "data": {"cost_usd": 6.0},
+        }
+    )
     manager.sessions["s1"] = agent_session
 
-    async def fake_current_session_usage_spend(_agent_session):
+    async def fake_current_session_usage_spend(_agent_session, **_kwargs):
         return 12.25, "app_telemetry_session"
 
     monkeypatch.setattr(
@@ -280,6 +288,106 @@ async def test_usage_threshold_checker_creates_synthetic_pending_approval(monkey
     assert pending["next_threshold_usd"] == 20.0
     assert pending["billing_source"] == "app_telemetry_session"
     assert agent_session.session.events[-1].event_type == "approval_required"
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_checker_skips_billing_when_local_spend_below_threshold(
+    monkeypatch,
+):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1")
+    manager.sessions["s1"] = agent_session
+    calls = 0
+
+    async def fake_current_session_usage_spend(_agent_session, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return 12.25, "hf_billing_current_session"
+
+    monkeypatch.setattr(
+        manager,
+        "_current_session_usage_spend",
+        fake_current_session_usage_spend,
+    )
+    manager._install_usage_threshold_checker(agent_session)
+
+    paused = await agent_session.session.usage_threshold_checker(
+        {"continuation": "continue_agent", "history_size": 4}
+    )
+
+    assert paused is False
+    assert calls == 0
+    assert agent_session.session.pending_approval is None
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_checker_forces_billing_at_complete_turn(monkeypatch):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1")
+    manager.sessions["s1"] = agent_session
+    calls = 0
+
+    async def fake_current_session_usage_spend(_agent_session, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return 12.25, "hf_billing_current_session"
+
+    monkeypatch.setattr(
+        manager,
+        "_current_session_usage_spend",
+        fake_current_session_usage_spend,
+    )
+    manager._install_usage_threshold_checker(agent_session)
+
+    paused = await agent_session.session.usage_threshold_checker(
+        {
+            "continuation": "complete_turn",
+            "force_check": True,
+            "history_size": 4,
+        }
+    )
+
+    assert paused is True
+    assert calls == 1
+    assert agent_session.session.pending_approval["continuation"] == "complete_turn"
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_checker_uses_cached_spend_after_local_crossing(
+    monkeypatch,
+):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1")
+    agent_session.session.logged_events.append(
+        {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "event_type": "llm_call",
+            "data": {"cost_usd": 6.0},
+        }
+    )
+    manager.sessions["s1"] = agent_session
+
+    async def fail_build_usage_response(*_args, **_kwargs):
+        raise AssertionError("fresh billing usage should not be fetched")
+
+    monkeypatch.setattr("usage.build_usage_response", fail_build_usage_response)
+    agent_session.usage_warning_spend_cache = {
+        "spend_usd": 4.5,
+        "billing_source": "hf_billing_current_session",
+        "expires_at": datetime.now(UTC) + timedelta(seconds=30),
+    }
+    manager._install_usage_threshold_checker(agent_session)
+
+    first = await agent_session.session.usage_threshold_checker(
+        {"continuation": "continue_agent", "history_size": 4}
+    )
+    second = await agent_session.session.usage_threshold_checker(
+        {"continuation": "continue_agent", "history_size": 4}
+    )
+
+    assert first is False
+    assert second is False
+    assert agent_session.session.pending_approval is None
 
 
 def test_unknown_saved_model_defaults_to_kimi():

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -18,6 +18,7 @@ if str(_BACKEND_DIR) not in sys.path:
 
 from agent.core.model_ids import KIMI_K26_MODEL_ID  # noqa: E402
 from agent.core.session_persistence import NoopSessionStore  # noqa: E402
+from agent.core.usage_thresholds import USAGE_THRESHOLD_TOOL_NAME  # noqa: E402
 from session_manager import AgentSession, SessionManager  # noqa: E402
 
 
@@ -32,10 +33,17 @@ class FakeRuntimeSession:
         self.auto_approval_enabled = False
         self.auto_approval_cost_cap_usd = None
         self.auto_approval_estimated_spend_usd = 0.0
+        self.usage_warning_next_threshold_usd = 5.0
+        self.usage_threshold_checker = None
         self.sandbox = None
         self.sandbox_hardware = None
         self.sandbox_preload_task = None
         self.sandbox_preload_cancel_event = None
+        self.events = []
+        self.session_id = "s1"
+
+    async def send_event(self, event):
+        self.events.append(event)
 
     def auto_approval_policy_summary(self):
         cap = self.auto_approval_cost_cap_usd
@@ -155,6 +163,123 @@ async def test_reset_session_usage_window_updates_runtime_and_store():
             "last_active_at": agent_session.last_active_at,
         },
     )
+
+
+def test_usage_threshold_pending_approval_serializes_and_restores():
+    manager = _manager_with_store(NoopSessionStore())
+    pending = {
+        "kind": USAGE_THRESHOLD_TOOL_NAME,
+        "tool_call_id": "usage-threshold-1",
+        "threshold_usd": 5.0,
+        "current_spend_usd": 5.25,
+        "next_threshold_usd": 10.0,
+        "billing_source": "app_telemetry_session",
+        "continuation": "continue_agent",
+        "history_size": 3,
+    }
+    runtime = FakeRuntimeSession()
+    runtime.pending_approval = pending
+
+    assert manager._serialize_pending_approval(runtime) == [pending]
+    assert manager._pending_tools_for_api(runtime) == [
+        {
+            "tool": USAGE_THRESHOLD_TOOL_NAME,
+            "tool_call_id": "usage-threshold-1",
+            "arguments": {
+                "threshold_usd": 5.0,
+                "current_spend_usd": 5.25,
+                "next_threshold_usd": 10.0,
+                "billing_source": "app_telemetry_session",
+            },
+        }
+    ]
+
+    restored = FakeRuntimeSession()
+    manager._restore_pending_approval(restored, [pending])
+
+    assert restored.pending_approval == pending
+
+
+def test_usage_spend_prefers_hf_current_session_over_telemetry():
+    spend, source = SessionManager._usage_spend_from_response(
+        {
+            "hf_account": {
+                "current_session": {
+                    "total_usd": 7.5,
+                },
+            },
+            "session": {
+                "total_usd": 2.0,
+            },
+        }
+    )
+
+    assert spend == 7.5
+    assert source == "hf_billing_current_session"
+
+
+def test_usage_spend_falls_back_to_app_telemetry():
+    spend, source = SessionManager._usage_spend_from_response(
+        {
+            "hf_account": {
+                "current_session": None,
+            },
+            "session": {
+                "total_usd": 2.0,
+            },
+        }
+    )
+
+    assert spend == 2.0
+    assert source == "app_telemetry_session"
+
+
+def test_usage_spend_falls_back_when_hf_total_is_unavailable():
+    spend, source = SessionManager._usage_spend_from_response(
+        {
+            "hf_account": {
+                "current_session": {
+                    "total_usd": None,
+                },
+            },
+            "session": {
+                "total_usd": 3.5,
+            },
+        }
+    )
+
+    assert spend == 3.5
+    assert source == "app_telemetry_session"
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_checker_creates_synthetic_pending_approval(monkeypatch):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1")
+    manager.sessions["s1"] = agent_session
+
+    async def fake_current_session_usage_spend(_agent_session):
+        return 12.25, "app_telemetry_session"
+
+    monkeypatch.setattr(
+        manager,
+        "_current_session_usage_spend",
+        fake_current_session_usage_spend,
+    )
+    manager._install_usage_threshold_checker(agent_session)
+
+    paused = await agent_session.session.usage_threshold_checker(
+        {"continuation": "continue_agent", "history_size": 4}
+    )
+
+    assert paused is True
+    pending = agent_session.session.pending_approval
+    assert pending["kind"] == USAGE_THRESHOLD_TOOL_NAME
+    assert pending["threshold_usd"] == 5.0
+    assert pending["current_spend_usd"] == 12.25
+    assert pending["next_threshold_usd"] == 20.0
+    assert pending["billing_source"] == "app_telemetry_session"
+    assert agent_session.session.events[-1].event_type == "approval_required"
 
 
 def test_unknown_saved_model_defaults_to_kimi():

--- a/tests/unit/test_usage_threshold_approvals.py
+++ b/tests/unit/test_usage_threshold_approvals.py
@@ -125,3 +125,22 @@ async def test_usage_threshold_rejection_stops_turn(monkeypatch):
     assert session.events[1].data["success"] is False
     assert session.turn_count == 1
     assert session.auto_saved is True
+
+
+@pytest.mark.asyncio
+async def test_abandon_complete_turn_usage_threshold_completes_prior_turn():
+    session = FakeUsageApprovalSession(continuation="complete_turn")
+
+    await Handlers._abandon_pending_approval(session)
+
+    assert session.pending_approval is None
+    assert [event.event_type for event in session.events] == [
+        "tool_state_change",
+        "turn_complete",
+    ]
+    assert session.events[-1].data == {
+        "history_size": 3,
+        "final_response": "done",
+    }
+    assert session.turn_count == 1
+    assert session.auto_saved is True

--- a/tests/unit/test_usage_threshold_approvals.py
+++ b/tests/unit/test_usage_threshold_approvals.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.core.agent_loop import Handlers
+from agent.core.session import Event
+from agent.core.usage_thresholds import (
+    USAGE_THRESHOLD_TOOL_NAME,
+    next_usage_warning_threshold,
+)
+
+
+class FakeUsageApprovalSession:
+    def __init__(self, *, continuation="continue_agent"):
+        self.pending_approval = {
+            "kind": USAGE_THRESHOLD_TOOL_NAME,
+            "tool_call_id": "usage-threshold-1",
+            "threshold_usd": 5.0,
+            "current_spend_usd": 12.25,
+            "next_threshold_usd": 10.0,
+            "billing_source": "app_telemetry_session",
+            "continuation": continuation,
+            "history_size": 3,
+            "final_response": "done",
+        }
+        self.context_manager = SimpleNamespace(items=[])
+        self.usage_warning_next_threshold_usd = 5.0
+        self.events: list[Event] = []
+        self.turn_count = 0
+        self.auto_saved = False
+
+    async def send_event(self, event: Event):
+        self.events.append(event)
+
+    def increment_turn(self):
+        self.turn_count += 1
+
+    async def auto_save_if_needed(self):
+        self.auto_saved = True
+
+
+def test_next_usage_warning_threshold_advances_past_current_spend():
+    assert next_usage_warning_threshold(4.99, 5.0) == 5.0
+    assert next_usage_warning_threshold(5.0, 5.0) == 10.0
+    assert next_usage_warning_threshold(12.25, 5.0) == 20.0
+    assert next_usage_warning_threshold(40.0, 20.0) == 80.0
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_approval_resumes_agent(monkeypatch):
+    session = FakeUsageApprovalSession(continuation="continue_agent")
+    resumed = False
+
+    async def fake_run_agent(run_session, text):
+        nonlocal resumed
+        assert run_session is session
+        assert text == ""
+        resumed = True
+
+    monkeypatch.setattr(Handlers, "run_agent", fake_run_agent)
+
+    await Handlers.exec_approval(
+        session,
+        [{"tool_call_id": "usage-threshold-1", "approved": True}],
+    )
+
+    assert session.pending_approval is None
+    assert resumed is True
+    assert session.usage_warning_next_threshold_usd == 20.0
+    assert [event.event_type for event in session.events] == [
+        "tool_state_change",
+        "tool_output",
+    ]
+    assert session.events[-1].data["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_approval_completes_finished_turn(monkeypatch):
+    session = FakeUsageApprovalSession(continuation="complete_turn")
+
+    async def fail_run_agent(*args, **kwargs):
+        raise AssertionError("complete_turn must not call run_agent")
+
+    monkeypatch.setattr(Handlers, "run_agent", fail_run_agent)
+
+    await Handlers.exec_approval(
+        session,
+        [{"tool_call_id": "usage-threshold-1", "approved": True}],
+    )
+
+    assert session.pending_approval is None
+    assert [event.event_type for event in session.events] == [
+        "tool_state_change",
+        "tool_output",
+        "turn_complete",
+    ]
+    assert session.events[-1].data == {
+        "history_size": 3,
+        "final_response": "done",
+    }
+    assert session.turn_count == 1
+    assert session.auto_saved is True
+
+
+@pytest.mark.asyncio
+async def test_usage_threshold_rejection_stops_turn(monkeypatch):
+    session = FakeUsageApprovalSession()
+
+    async def fail_run_agent(*args, **kwargs):
+        raise AssertionError("rejection must not call run_agent")
+
+    monkeypatch.setattr(Handlers, "run_agent", fail_run_agent)
+
+    await Handlers.exec_approval(
+        session,
+        [{"tool_call_id": "usage-threshold-1", "approved": False}],
+    )
+
+    assert session.pending_approval is None
+    assert [event.event_type for event in session.events] == [
+        "tool_state_change",
+        "tool_output",
+        "interrupted",
+    ]
+    assert session.events[1].data["success"] is False
+    assert session.turn_count == 1
+    assert session.auto_saved is True


### PR DESCRIPTION
## Summary
- add synthetic usage-threshold approvals at $5, $10, $20, $40, and beyond
- pause the agent at safe loop boundaries and reuse the existing approval SSE flow
- persist and hydrate pending usage warnings across session restore and refresh
- render usage warnings with Continue and Stop here actions in the existing approval card UI

## Checks
- uv run --frozen --extra dev pytest tests/unit/test_usage.py tests/unit/test_session_manager_persistence.py tests/unit/test_auto_approval_policy.py tests/unit/test_usage_threshold_approvals.py
- uv run --frozen --extra dev ruff check .
- uv run --frozen --extra dev ruff format --check .
- cd frontend && npm run build
