### PR TITLE
Add sandbox costs to usage meter

### DIFF
--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -20,7 +20,12 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
 MAX_BSON_BYTES = 15 * 1024 * 1024
-USAGE_EVENT_TYPES = ("llm_call", "hf_job_complete")
+USAGE_EVENT_TYPES = (
+    "llm_call",
+    "hf_job_complete",
+    "sandbox_create",
+    "sandbox_destroy",
+)
 
 
 def _now() -> datetime:
@@ -415,7 +420,7 @@ class MongoSessionStore(NoopSessionStore):
                 created_at["$lt"] = end
             event_query["created_at"] = created_at
 
-        event_cursor = self.db.session_events.find(event_query)
+        event_cursor = self.db.session_events.find(event_query).sort("created_at", 1)
         return [row async for row in event_cursor]
 
     async def append_trace_message(

--- a/backend/models.py
+++ b/backend/models.py
@@ -131,14 +131,17 @@ class UsageBucket(BaseModel):
     total_usd: float = 0.0
     inference_usd: float = 0.0
     hf_jobs_estimated_usd: float = 0.0
+    sandbox_estimated_usd: float = 0.0
     llm_calls: int = 0
     hf_jobs_count: int = 0
+    sandbox_count: int = 0
     prompt_tokens: int = 0
     completion_tokens: int = 0
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
     total_tokens: int = 0
     hf_jobs_billable_seconds_estimate: int = 0
+    sandbox_billable_seconds_estimate: int = 0
 
 
 class HfAccountUsageBucket(BaseModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -177,7 +177,6 @@ class HfAccountUsage(BaseModel):
     available: bool = False
     error: str | None = None
     current_session: HfAccountUsageBucket | None = None
-    today: HfAccountUsageBucket | None = None
     month: HfAccountUsageBucket | None = None
     inference_providers_credits: HfInferenceProvidersCredits | None = None
 
@@ -190,8 +189,6 @@ class UsageResponse(BaseModel):
     generated_at: str
     timezone: str
     session: UsageBucket | None = None
-    today: UsageBucket
-    month: UsageBucket
     hf_account: HfAccountUsage | None = None
     links: dict[str, str] = Field(default_factory=dict)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -122,12 +122,9 @@ class SessionYoloRequest(BaseModel):
 
 
 class UsageBucket(BaseModel):
-    """App-attributed usage totals for a session or time window."""
+    """App-attributed usage totals for a session."""
 
     session_id: str | None = None
-    window_start: str | None = None
-    window_end: str | None = None
-    timezone: str | None = None
     total_usd: float = 0.0
     inference_usd: float = 0.0
     hf_jobs_estimated_usd: float = 0.0

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -718,7 +718,6 @@ async def get_usage(
     request: Request,
     session_id: str | None = None,
     tz: str | None = None,
-    include_rollups: bool = True,
     user: dict = Depends(get_current_user),
 ) -> dict:
     """Return app-attributed usage for the current user."""
@@ -739,7 +738,6 @@ async def get_usage(
         ),
         session_id=session_id,
         timezone_name=tz,
-        include_rollups=include_rollups,
     )
 
 

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -481,7 +481,6 @@ class SessionManager:
             hf_token=agent_session.hf_token,
             session_id=agent_session.session_id,
             timezone_name="UTC",
-            include_rollups=False,
         )
         spend, billing_source = self._usage_spend_from_response(response)
         agent_session.usage_warning_spend_cache = {

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -119,7 +119,7 @@ def resolve_usage_windows(
     *,
     now: datetime | None = None,
 ) -> dict[str, datetime | str]:
-    """Return UTC day/month windows for a browser timezone."""
+    """Return UTC month window for a browser timezone."""
     try:
         tz = ZoneInfo(timezone_name or "UTC")
     except (ZoneInfoNotFoundError, ValueError):
@@ -127,12 +127,10 @@ def resolve_usage_windows(
 
     now_utc = _utc(now or datetime.now(UTC))
     local_now = now_utc.astimezone(tz)
-    today_local = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
-    month_local = today_local.replace(day=1)
+    month_local = local_now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     return {
         "timezone": tz.key,
         "now_utc": now_utc,
-        "today_start_utc": today_local.astimezone(UTC),
         "month_start_utc": month_local.astimezone(UTC),
     }
 
@@ -615,15 +613,12 @@ async def _build_hf_account_usage(
     session_id: str | None,
     timezone: str,
     now_utc: datetime,
-    today_start: datetime,
     month_start: datetime,
-    include_rollups: bool = True,
 ) -> dict[str, Any]:
     account_usage: dict[str, Any] = {
         "source": "hf_billing_usage_v2",
         "available": False,
         "current_session": None,
-        "today": None,
         "month": None,
         "inference_providers_credits": None,
     }
@@ -654,13 +649,6 @@ async def _build_hf_account_usage(
             ),
         ),
     }
-    if include_rollups:
-        window_tasks["today"] = (
-            today_start,
-            asyncio.create_task(
-                _fetch_hf_billing_usage_v2(hf_token, start=today_start, end=now_utc)
-            ),
-        )
     if session_start is not None:
         if baseline_month_start is not None:
             window_tasks["current_session_baseline"] = (
@@ -817,12 +805,10 @@ async def build_usage_response(
     session_id: str | None = None,
     timezone_name: str | None = None,
     now: datetime | None = None,
-    include_rollups: bool = True,
 ) -> dict[str, Any]:
     windows = resolve_usage_windows(timezone_name, now=now)
     timezone = str(windows["timezone"])
     now_utc = windows["now_utc"]
-    today_start = windows["today_start_utc"]
     month_start = windows["month_start_utc"]
 
     session_events: list[dict[str, Any]] = []
@@ -833,32 +819,13 @@ async def build_usage_response(
             session_id=session_id,
         )
 
-    today_events: list[dict[str, Any]] = []
-    month_events: list[dict[str, Any]] = []
-    if include_rollups:
-        today_events = await _load_usage_events(
-            manager,
-            user_id=user_id,
-            start=today_start,
-            end=now_utc,
-            timezone_name=timezone,
-        )
-        month_events = await _load_usage_events(
-            manager,
-            user_id=user_id,
-            start=month_start,
-            end=now_utc,
-            timezone_name=timezone,
-        )
     hf_account = await _build_hf_account_usage(
         manager,
         hf_token=hf_token,
         session_id=session_id,
         timezone=timezone,
         now_utc=now_utc,
-        today_start=today_start,
         month_start=month_start,
-        include_rollups=include_rollups,
     )
 
     return {
@@ -870,18 +837,6 @@ async def build_usage_response(
             aggregate_usage_events(session_events, session_id=session_id)
             if session_id
             else None
-        ),
-        "today": aggregate_usage_events(
-            today_events,
-            window_start=today_start,
-            window_end=now_utc,
-            timezone=timezone,
-        ),
-        "month": aggregate_usage_events(
-            month_events,
-            window_start=month_start,
-            window_end=now_utc,
-            timezone=timezone,
         ),
         "hf_account": hf_account,
         "links": {

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -2,13 +2,20 @@
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
 
-USAGE_EVENT_TYPES = ("llm_call", "hf_job_complete")
+from agent.core.cost_estimation import SPACE_PRICE_USD_PER_HOUR
+
+USAGE_EVENT_TYPES = (
+    "llm_call",
+    "hf_job_complete",
+    "sandbox_create",
+    "sandbox_destroy",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,14 +152,17 @@ def _empty_bucket(
         "total_usd": 0.0,
         "inference_usd": 0.0,
         "hf_jobs_estimated_usd": 0.0,
+        "sandbox_estimated_usd": 0.0,
         "llm_calls": 0,
         "hf_jobs_count": 0,
+        "sandbox_count": 0,
         "prompt_tokens": 0,
         "completion_tokens": 0,
         "cache_read_tokens": 0,
         "cache_creation_tokens": 0,
         "total_tokens": 0,
         "hf_jobs_billable_seconds_estimate": 0,
+        "sandbox_billable_seconds_estimate": 0,
     }
 
 
@@ -217,14 +227,145 @@ def aggregate_usage_events(
             bucket["hf_jobs_billable_seconds_estimate"] += _coerce_int(
                 data.get("billable_seconds_estimate") or data.get("wall_time_s")
             )
+        elif event_type == "sandbox_destroy":
+            # Sandbox costs are paired and added after the main pass so the
+            # create event can provide hardware pricing metadata.
+            continue
+
+    _aggregate_sandbox_usage(
+        events,
+        bucket,
+        window_start=window_start,
+        window_end=window_end,
+        timezone=timezone,
+    )
 
     bucket["inference_usd"] = round(bucket["inference_usd"], 6)
     bucket["hf_jobs_estimated_usd"] = round(bucket["hf_jobs_estimated_usd"], 6)
+    bucket["sandbox_estimated_usd"] = round(bucket["sandbox_estimated_usd"], 6)
     bucket["total_usd"] = round(
-        bucket["inference_usd"] + bucket["hf_jobs_estimated_usd"],
+        (
+            bucket["inference_usd"]
+            + bucket["hf_jobs_estimated_usd"]
+            + bucket["sandbox_estimated_usd"]
+        ),
         6,
     )
     return bucket
+
+
+def _event_sort_key(
+    indexed_event: tuple[int, dict[str, Any]],
+    *,
+    timezone_name: str | None,
+) -> tuple[bool, datetime, int]:
+    index, event = indexed_event
+    created_at = event_created_at(event, timezone_name=timezone_name)
+    return (
+        created_at is None,
+        created_at or datetime.min.replace(tzinfo=UTC),
+        index,
+    )
+
+
+def _sandbox_id(event: dict[str, Any]) -> str | None:
+    data = event.get("data") or {}
+    sandbox_id = data.get("sandbox_id")
+    return sandbox_id if isinstance(sandbox_id, str) and sandbox_id else None
+
+
+def _sandbox_duration_seconds(
+    create_event: dict[str, Any],
+    destroy_event: dict[str, Any],
+    *,
+    window_start: datetime | None,
+    window_end: datetime | None,
+    timezone_name: str | None,
+) -> int:
+    create_data = create_event.get("data") or {}
+    destroy_data = destroy_event.get("data") or {}
+    lifetime_s = _coerce_int(destroy_data.get("lifetime_s"))
+    create_at = event_created_at(create_event, timezone_name=timezone_name)
+    destroy_at = event_created_at(destroy_event, timezone_name=timezone_name)
+
+    if lifetime_s > 0:
+        if destroy_at is None or (window_start is None and window_end is None):
+            return lifetime_s
+        interval_start = destroy_at - timedelta(seconds=lifetime_s)
+        interval_end = destroy_at
+    else:
+        if create_at is None or destroy_at is None:
+            return 0
+        create_latency_s = max(0, _coerce_int(create_data.get("create_latency_s")))
+        interval_start = create_at - timedelta(seconds=create_latency_s)
+        interval_end = destroy_at
+
+    if interval_end <= interval_start:
+        return 0
+
+    clamp_start = _utc(window_start) if window_start is not None else interval_start
+    clamp_end = _utc(window_end) if window_end is not None else interval_end
+    clamped_start = max(interval_start, clamp_start)
+    clamped_end = min(interval_end, clamp_end)
+    if clamped_end <= clamped_start:
+        return 0
+    return int((clamped_end - clamped_start).total_seconds())
+
+
+def _aggregate_sandbox_usage(
+    events: list[dict[str, Any]],
+    bucket: dict[str, Any],
+    *,
+    window_start: datetime | None,
+    window_end: datetime | None,
+    timezone: str | None,
+) -> None:
+    lifecycle_events = [
+        (index, event)
+        for index, event in enumerate(events)
+        if event.get("event_type") in {"sandbox_create", "sandbox_destroy"}
+    ]
+    ordered_events = [
+        event
+        for _, event in sorted(
+            lifecycle_events,
+            key=lambda item: _event_sort_key(item, timezone_name=timezone),
+        )
+    ]
+    active_creates: dict[str, dict[str, Any]] = {}
+
+    for event in ordered_events:
+        event_type = event.get("event_type")
+        sandbox_id = _sandbox_id(event)
+        if sandbox_id is None:
+            continue
+
+        if event_type == "sandbox_create":
+            active_creates[sandbox_id] = event
+            continue
+
+        if event_type != "sandbox_destroy":
+            continue
+
+        create_event = active_creates.pop(sandbox_id, None)
+        if create_event is None:
+            continue
+
+        create_data = create_event.get("data") or {}
+        hardware = str(create_data.get("hardware") or "cpu-basic")
+        price_usd_per_hour = SPACE_PRICE_USD_PER_HOUR.get(hardware, 0.0)
+        seconds = _sandbox_duration_seconds(
+            create_event,
+            event,
+            window_start=window_start,
+            window_end=window_end,
+            timezone_name=timezone,
+        )
+
+        bucket["sandbox_count"] += 1
+        if price_usd_per_hour > 0:
+            bucket["sandbox_billable_seconds_estimate"] += seconds
+        bucket["sandbox_estimated_usd"] += price_usd_per_hour * (seconds / 3600)
 
 
 def _account_bucket_from_billing_usage(

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -138,15 +138,9 @@ def resolve_usage_windows(
 def _empty_bucket(
     *,
     session_id: str | None = None,
-    window_start: datetime | None = None,
-    window_end: datetime | None = None,
-    timezone: str | None = None,
 ) -> dict[str, Any]:
     return {
         "session_id": session_id,
-        "window_start": _iso(window_start),
-        "window_end": _iso(window_end),
-        "timezone": timezone,
         "total_usd": 0.0,
         "inference_usd": 0.0,
         "hf_jobs_estimated_usd": 0.0,
@@ -186,16 +180,8 @@ def aggregate_usage_events(
     events: list[dict[str, Any]],
     *,
     session_id: str | None = None,
-    window_start: datetime | None = None,
-    window_end: datetime | None = None,
-    timezone: str | None = None,
 ) -> dict[str, Any]:
-    bucket = _empty_bucket(
-        session_id=session_id,
-        window_start=window_start,
-        window_end=window_end,
-        timezone=timezone,
-    )
+    bucket = _empty_bucket(session_id=session_id)
     for event in events:
         event_type = event.get("event_type")
         data = event.get("data") or {}
@@ -230,13 +216,7 @@ def aggregate_usage_events(
             # create event can provide hardware pricing metadata.
             continue
 
-    _aggregate_sandbox_usage(
-        events,
-        bucket,
-        window_start=window_start,
-        window_end=window_end,
-        timezone=timezone,
-    )
+    _aggregate_sandbox_usage(events, bucket)
 
     bucket["inference_usd"] = round(bucket["inference_usd"], 6)
     bucket["hf_jobs_estimated_usd"] = round(bucket["hf_jobs_estimated_usd"], 6)
@@ -254,11 +234,9 @@ def aggregate_usage_events(
 
 def _event_sort_key(
     indexed_event: tuple[int, dict[str, Any]],
-    *,
-    timezone_name: str | None,
 ) -> tuple[bool, datetime, int]:
     index, event = indexed_event
-    created_at = event_created_at(event, timezone_name=timezone_name)
+    created_at = event_created_at(event)
     return (
         created_at is None,
         created_at or datetime.min.replace(tzinfo=UTC),
@@ -275,48 +253,29 @@ def _sandbox_id(event: dict[str, Any]) -> str | None:
 def _sandbox_duration_seconds(
     create_event: dict[str, Any],
     destroy_event: dict[str, Any],
-    *,
-    window_start: datetime | None,
-    window_end: datetime | None,
-    timezone_name: str | None,
 ) -> int:
     create_data = create_event.get("data") or {}
     destroy_data = destroy_event.get("data") or {}
     lifetime_s = _coerce_int(destroy_data.get("lifetime_s"))
-    create_at = event_created_at(create_event, timezone_name=timezone_name)
-    destroy_at = event_created_at(destroy_event, timezone_name=timezone_name)
 
     if lifetime_s > 0:
-        if destroy_at is None or (window_start is None and window_end is None):
-            return lifetime_s
-        interval_start = destroy_at - timedelta(seconds=lifetime_s)
-        interval_end = destroy_at
-    else:
-        if create_at is None or destroy_at is None:
-            return 0
-        create_latency_s = max(0, _coerce_int(create_data.get("create_latency_s")))
-        interval_start = create_at - timedelta(seconds=create_latency_s)
-        interval_end = destroy_at
+        # Telemetry starts the lifetime clock before create latency elapses.
+        return lifetime_s
 
-    if interval_end <= interval_start:
+    create_at = event_created_at(create_event)
+    destroy_at = event_created_at(destroy_event)
+    if create_at is None or destroy_at is None:
         return 0
-
-    clamp_start = _utc(window_start) if window_start is not None else interval_start
-    clamp_end = _utc(window_end) if window_end is not None else interval_end
-    clamped_start = max(interval_start, clamp_start)
-    clamped_end = min(interval_end, clamp_end)
-    if clamped_end <= clamped_start:
+    create_latency_s = max(0, _coerce_int(create_data.get("create_latency_s")))
+    interval_start = create_at - timedelta(seconds=create_latency_s)
+    if destroy_at <= interval_start:
         return 0
-    return int((clamped_end - clamped_start).total_seconds())
+    return int((destroy_at - interval_start).total_seconds())
 
 
 def _aggregate_sandbox_usage(
     events: list[dict[str, Any]],
     bucket: dict[str, Any],
-    *,
-    window_start: datetime | None,
-    window_end: datetime | None,
-    timezone: str | None,
 ) -> None:
     lifecycle_events = [
         (index, event)
@@ -327,7 +286,7 @@ def _aggregate_sandbox_usage(
         event
         for _, event in sorted(
             lifecycle_events,
-            key=lambda item: _event_sort_key(item, timezone_name=timezone),
+            key=_event_sort_key,
         )
     ]
     active_creates: dict[str, dict[str, Any]] = {}
@@ -352,13 +311,7 @@ def _aggregate_sandbox_usage(
         create_data = create_event.get("data") or {}
         hardware = str(create_data.get("hardware") or "cpu-basic")
         price_usd_per_hour = SPACE_PRICE_USD_PER_HOUR.get(hardware, 0.0)
-        seconds = _sandbox_duration_seconds(
-            create_event,
-            event,
-            window_start=window_start,
-            window_end=window_end,
-            timezone_name=timezone,
-        )
+        seconds = _sandbox_duration_seconds(create_event, event)
 
         bucket["sandbox_count"] += 1
         if price_usd_per_hour > 0:

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -125,6 +125,10 @@ function AccountUsageSection({
             useJobEstimate ? telemetry?.hf_jobs_estimated_usd : account?.hf_jobs_usd,
           )}
         />
+        <UsageRow
+          label="HF Sandboxes"
+          value={formatUsd(telemetry?.sandbox_estimated_usd)}
+        />
         <UsageRow label="LLM calls" value={formatCount(telemetry?.llm_calls)} />
         <UsageRow
           label="Input tokens"
@@ -179,7 +183,11 @@ export default function UsageMeter() {
     void fetchUsage(activeSessionId);
   }, [activeSessionId, fetchUsage]);
 
-  const sessionTotal = usage?.hf_account?.current_session?.total_usd;
+  const accountSessionTotal = usage?.hf_account?.current_session?.total_usd;
+  const sessionTotal =
+    accountSessionTotal == null
+      ? usage?.session?.total_usd
+      : accountSessionTotal + (usage?.session?.sandbox_estimated_usd ?? 0);
   const links = useMemo(() => usage?.links ?? {}, [usage?.links]);
   const billingMessage = billingUnavailableMessage(usage?.hf_account?.error);
   const open = Boolean(anchorEl);

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -702,7 +702,7 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
             const state = event.data?.state as string;
             const toolName = event.data?.tool as string;
             if (state === 'running' && toolName) sideChannel.onToolRunning(toolName);
-          } else if (et === 'llm_call' || et === 'hf_job_complete') {
+          } else if (et === 'llm_call' || et === 'hf_job_complete' || et === 'sandbox_destroy') {
             sideChannel.onUsageEvent(et, (event.data || {}) as Record<string, unknown>);
           } else if (et === 'turn_complete' || et === 'error' || et === 'interrupted') {
             sideChannel.onProcessingDone();

--- a/frontend/src/lib/sse-chat-transport.ts
+++ b/frontend/src/lib/sse-chat-transport.ts
@@ -39,7 +39,7 @@ export interface SideChannelCallbacks {
   onToolOutputPanel: (tool: string, toolCallId: string, output: string, success: boolean) => void;
   onStreaming: () => void;
   onToolRunning: (toolName: string, description?: string) => void;
-  onUsageEvent: (eventType: 'llm_call' | 'hf_job_complete', data: Record<string, unknown>) => void;
+  onUsageEvent: (eventType: 'llm_call' | 'hf_job_complete' | 'sandbox_destroy', data: Record<string, unknown>) => void;
   onInterrupted: () => void;
   onRecoverMessages: (context: MessageRecoveryContext) => Promise<boolean>;
 }
@@ -375,6 +375,7 @@ function createEventToChunkStream(sideChannel: SideChannelCallbacks): TransformS
 
         case 'llm_call':
         case 'hf_job_complete':
+        case 'sandbox_destroy':
           sideChannel.onUsageEvent(event.event_type, event.data || {});
           break;
 

--- a/frontend/src/store/usageStore.ts
+++ b/frontend/src/store/usageStore.ts
@@ -49,7 +49,6 @@ export interface HfAccountUsage {
   available: boolean;
   error?: string | null;
   current_session: HfAccountUsageBucket | null;
-  today: HfAccountUsageBucket | null;
   month: HfAccountUsageBucket | null;
   inference_providers_credits: HfInferenceProvidersCredits | null;
 }
@@ -60,8 +59,6 @@ export interface UsageResponse {
   generated_at: string;
   timezone: string;
   session: UsageBucket | null;
-  today: UsageBucket;
-  month: UsageBucket;
   hf_account?: HfAccountUsage | null;
   links: Record<string, string>;
 }
@@ -96,7 +93,6 @@ function usageUrl(sessionId?: string | null): string {
   const params = new URLSearchParams();
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
   params.set('tz', timezone);
-  params.set('include_rollups', 'false');
   if (sessionId) params.set('session_id', sessionId);
   return `/api/usage?${params.toString()}`;
 }
@@ -186,8 +182,6 @@ export const useUsageStore = create<UsageStore>()((set, get) => ({
           current.session?.session_id === sessionId
             ? applyEventToBucket(current.session, eventType, data)
             : current.session,
-        today: applyEventToBucket(current.today, eventType, data) ?? current.today,
-        month: applyEventToBucket(current.month, eventType, data) ?? current.month,
       },
     });
   },

--- a/frontend/src/store/usageStore.ts
+++ b/frontend/src/store/usageStore.ts
@@ -3,9 +3,6 @@ import { apiFetch } from '@/utils/api';
 
 export interface UsageBucket {
   session_id?: string | null;
-  window_start?: string | null;
-  window_end?: string | null;
-  timezone?: string | null;
   total_usd: number;
   inference_usd: number;
   hf_jobs_estimated_usd: number;

--- a/frontend/src/store/usageStore.ts
+++ b/frontend/src/store/usageStore.ts
@@ -9,14 +9,17 @@ export interface UsageBucket {
   total_usd: number;
   inference_usd: number;
   hf_jobs_estimated_usd: number;
+  sandbox_estimated_usd: number;
   llm_calls: number;
   hf_jobs_count: number;
+  sandbox_count: number;
   prompt_tokens: number;
   completion_tokens: number;
   cache_read_tokens: number;
   cache_creation_tokens: number;
   total_tokens: number;
   hf_jobs_billable_seconds_estimate: number;
+  sandbox_billable_seconds_estimate: number;
 }
 
 export interface HfAccountUsageBucket {
@@ -63,7 +66,7 @@ export interface UsageResponse {
   links: Record<string, string>;
 }
 
-type UsageEventType = 'llm_call' | 'hf_job_complete';
+type UsageEventType = 'llm_call' | 'hf_job_complete' | 'sandbox_destroy';
 
 interface UsageStore {
   usage: UsageResponse | null;
@@ -129,7 +132,11 @@ function applyEventToBucket(
       intValue(data.billable_seconds_estimate) || intValue(data.wall_time_s);
   }
 
-  next.total_usd = roundUsd(next.inference_usd + next.hf_jobs_estimated_usd);
+  next.total_usd = roundUsd(
+    next.inference_usd +
+      next.hf_jobs_estimated_usd +
+      (next.sandbox_estimated_usd ?? 0),
+  );
   return next;
 }
 
@@ -165,6 +172,11 @@ export const useUsageStore = create<UsageStore>()((set, get) => ({
   },
 
   applyUsageEvent: (sessionId, eventType, data) => {
+    if (eventType === 'sandbox_destroy') {
+      void get().fetchUsage(sessionId);
+      return;
+    }
+
     const current = get().usage;
     if (!current) return;
     set({

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -15,6 +15,8 @@ export type EventType =
   | 'tool_state_change'
   | 'llm_call'
   | 'hf_job_complete'
+  | 'sandbox_create'
+  | 'sandbox_destroy'
   | 'turn_complete'
   | 'compacted'
   | 'error'

--- a/tests/unit/test_session_persistence.py
+++ b/tests/unit/test_session_persistence.py
@@ -212,7 +212,7 @@ async def test_load_usage_events_scopes_mongo_queries_to_current_user_and_window
             None,
         )
     ]
-    assert store.db.session_events.cursors[0].sort_calls == []
+    assert store.db.session_events.cursors[0].sort_calls == [(("created_at", 1), {})]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -285,8 +285,6 @@ async def test_usage_response_omits_app_rollups_without_session():
     )
 
     assert usage["session"] is None
-    assert "today" not in usage
-    assert "month" not in usage
 
 
 @pytest.mark.asyncio
@@ -317,8 +315,6 @@ async def test_runtime_usage_includes_requested_session_total():
 
     assert usage["session"]["session_id"] == "s1"
     assert usage["session"]["inference_usd"] == 0.25
-    assert "today" not in usage
-    assert "month" not in usage
 
 
 @pytest.mark.asyncio
@@ -349,8 +345,6 @@ async def test_runtime_usage_includes_requested_session_tokens():
 
     assert usage["session"]["llm_calls"] == 1
     assert usage["session"]["total_tokens"] == 42
-    assert "today" not in usage
-    assert "month" not in usage
 
 
 @pytest.mark.asyncio
@@ -437,7 +431,6 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
 
     assert usage["hf_account"]["available"] is True
     assert usage["hf_account"]["current_session"]["inference_providers_usd"] == 0.5
-    assert "today" not in usage["hf_account"]
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 2.0
     assert usage["hf_account"]["inference_providers_credits"] == {
         "included_usd": 2.0,
@@ -606,7 +599,4 @@ async def test_usage_response_loads_only_session_events(monkeypatch):
         session_created_at,
     }
     assert datetime(2026, 6, 5, 0, 0, tzinfo=UTC) not in billing_starts
-    assert "today" not in usage
-    assert "month" not in usage
-    assert "today" not in usage["hf_account"]
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 0.0

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -211,7 +211,6 @@ def test_usage_windows_respect_browser_timezone():
     )
 
     assert windows["timezone"] == "America/Los_Angeles"
-    assert windows["today_start_utc"] == datetime(2026, 6, 1, 7, 0, tzinfo=UTC)
     assert windows["month_start_utc"] == datetime(2026, 6, 1, 7, 0, tzinfo=UTC)
 
 
@@ -261,7 +260,7 @@ def _agent_session(session_id, user_id, events):
 
 
 @pytest.mark.asyncio
-async def test_runtime_usage_excludes_other_users():
+async def test_usage_response_omits_app_rollups_without_session():
     manager = _Manager(
         {
             "owner-session": _agent_session(
@@ -285,9 +284,9 @@ async def test_runtime_usage_excludes_other_users():
         now=datetime(2026, 6, 1, 13, 0, tzinfo=UTC),
     )
 
-    assert usage["today"]["llm_calls"] == 1
-    assert usage["today"]["inference_usd"] == 0.5
-    assert usage["month"]["inference_usd"] == 0.5
+    assert usage["session"] is None
+    assert "today" not in usage
+    assert "month" not in usage
 
 
 @pytest.mark.asyncio
@@ -318,11 +317,12 @@ async def test_runtime_usage_includes_requested_session_total():
 
     assert usage["session"]["session_id"] == "s1"
     assert usage["session"]["inference_usd"] == 0.25
-    assert usage["today"]["inference_usd"] == 0.0
+    assert "today" not in usage
+    assert "month" not in usage
 
 
 @pytest.mark.asyncio
-async def test_runtime_usage_interprets_naive_timestamps_in_browser_timezone():
+async def test_runtime_usage_includes_requested_session_tokens():
     manager = _Manager(
         {
             "s1": _agent_session(
@@ -348,9 +348,9 @@ async def test_runtime_usage_interprets_naive_timestamps_in_browser_timezone():
     )
 
     assert usage["session"]["llm_calls"] == 1
-    assert usage["today"]["llm_calls"] == 1
-    assert usage["month"]["llm_calls"] == 1
-    assert usage["today"]["total_tokens"] == 42
+    assert usage["session"]["total_tokens"] == 42
+    assert "today" not in usage
+    assert "month" not in usage
 
 
 @pytest.mark.asyncio
@@ -410,8 +410,6 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
         calls.append((start, end))
         if start == usage_window_started_at:
             used_nano = 500_000_000
-        elif start == datetime(2026, 6, 5, 0, 0, tzinfo=UTC):
-            used_nano = 1_000_000_000
         else:
             used_nano = 2_000_000_000
         return {
@@ -439,7 +437,7 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
 
     assert usage["hf_account"]["available"] is True
     assert usage["hf_account"]["current_session"]["inference_providers_usd"] == 0.5
-    assert usage["hf_account"]["today"]["inference_providers_usd"] == 1.0
+    assert "today" not in usage["hf_account"]
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 2.0
     assert usage["hf_account"]["inference_providers_credits"] == {
         "included_usd": 2.0,
@@ -452,7 +450,6 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
         "period_end": None,
     }
     assert {start for start, _ in calls} == {
-        datetime(2026, 6, 5, 0, 0, tzinfo=UTC),
         datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
         usage_window_started_at,
     }
@@ -551,7 +548,6 @@ async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
         session_id="s1",
         timezone_name="UTC",
         now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
-        include_rollups=False,
     )
 
     assert usage["hf_account"]["current_session"]["window_start"] == (
@@ -564,7 +560,7 @@ async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_compact_usage_skips_unused_rollup_loads(monkeypatch):
+async def test_usage_response_loads_only_session_events(monkeypatch):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
     store = _RecordingStore()
     manager = _Manager(
@@ -602,7 +598,6 @@ async def test_compact_usage_skips_unused_rollup_loads(monkeypatch):
         session_id="s1",
         timezone_name="UTC",
         now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
-        include_rollups=False,
     )
 
     assert store.calls == [("owner", {"session_id": "s1", "start": None, "end": None})]
@@ -611,7 +606,7 @@ async def test_compact_usage_skips_unused_rollup_loads(monkeypatch):
         session_created_at,
     }
     assert datetime(2026, 6, 5, 0, 0, tzinfo=UTC) not in billing_starts
-    assert usage["today"]["llm_calls"] == 0
-    assert usage["month"]["llm_calls"] == 0
-    assert usage["hf_account"]["today"] is None
+    assert "today" not in usage
+    assert "month" not in usage
+    assert "today" not in usage["hf_account"]
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 0.0

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -10,11 +10,13 @@ if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
 from usage import (  # noqa: E402
+    USAGE_EVENT_TYPES,
     _account_bucket_from_billing_usage,
     aggregate_usage_events,
     build_usage_response,
     resolve_usage_windows,
 )
+from agent.core import session_persistence  # noqa: E402
 
 
 def _event(event_type, data=None, created_at="2026-06-01T12:00:00+00:00"):
@@ -25,7 +27,7 @@ def _event(event_type, data=None, created_at="2026-06-01T12:00:00+00:00"):
     }
 
 
-def test_aggregate_usage_events_sums_inference_and_jobs():
+def test_aggregate_usage_events_sums_inference_jobs_and_sandboxes():
     events = [
         _event(
             "llm_call",
@@ -46,6 +48,22 @@ def test_aggregate_usage_events_sums_inference_and_jobs():
                 "billable_seconds_estimate": 1800,
             },
         ),
+        _event(
+            "sandbox_create",
+            {
+                "sandbox_id": "alice/sandbox-12345678",
+                "hardware": "cpu-upgrade",
+            },
+            created_at="2026-06-01T12:30:00+00:00",
+        ),
+        _event(
+            "sandbox_destroy",
+            {
+                "sandbox_id": "alice/sandbox-12345678",
+                "lifetime_s": 3600,
+            },
+            created_at="2026-06-01T13:30:00+00:00",
+        ),
     ]
 
     usage = aggregate_usage_events(events, session_id="s1")
@@ -53,15 +71,18 @@ def test_aggregate_usage_events_sums_inference_and_jobs():
     assert usage["session_id"] == "s1"
     assert usage["llm_calls"] == 2
     assert usage["hf_jobs_count"] == 1
+    assert usage["sandbox_count"] == 1
     assert usage["prompt_tokens"] == 110
     assert usage["completion_tokens"] == 50
     assert usage["cache_read_tokens"] == 25
     assert usage["cache_creation_tokens"] == 5
     assert usage["total_tokens"] == 190
     assert usage["hf_jobs_billable_seconds_estimate"] == 1800
+    assert usage["sandbox_billable_seconds_estimate"] == 3600
     assert usage["inference_usd"] == 0.375
     assert usage["hf_jobs_estimated_usd"] == 1.5
-    assert usage["total_usd"] == 1.875
+    assert usage["sandbox_estimated_usd"] == 0.05
+    assert usage["total_usd"] == 1.925
 
 
 def test_aggregate_usage_events_treats_missing_costs_as_zero():
@@ -77,6 +98,84 @@ def test_aggregate_usage_events_treats_missing_costs_as_zero():
     assert usage["prompt_tokens"] == 7
     assert usage["hf_jobs_billable_seconds_estimate"] == 60
     assert usage["total_usd"] == 0.0
+
+
+def test_aggregate_usage_events_ignores_active_sandbox_before_destroy():
+    usage = aggregate_usage_events(
+        [
+            _event(
+                "sandbox_create",
+                {
+                    "sandbox_id": "alice/sandbox-12345678",
+                    "hardware": "a100-large",
+                },
+            )
+        ]
+    )
+
+    assert usage["sandbox_count"] == 0
+    assert usage["sandbox_estimated_usd"] == 0.0
+    assert usage["sandbox_billable_seconds_estimate"] == 0
+    assert usage["total_usd"] == 0.0
+
+
+def test_aggregate_usage_events_counts_cpu_basic_sandbox_as_free():
+    usage = aggregate_usage_events(
+        [
+            _event(
+                "sandbox_create",
+                {
+                    "sandbox_id": "alice/sandbox-12345678",
+                    "hardware": "cpu-basic",
+                },
+            ),
+            _event(
+                "sandbox_destroy",
+                {
+                    "sandbox_id": "alice/sandbox-12345678",
+                    "lifetime_s": 3600,
+                },
+            ),
+        ]
+    )
+
+    assert usage["sandbox_count"] == 1
+    assert usage["sandbox_estimated_usd"] == 0.0
+    assert usage["sandbox_billable_seconds_estimate"] == 0
+    assert usage["total_usd"] == 0.0
+
+
+def test_aggregate_usage_events_falls_back_to_sandbox_timestamps():
+    usage = aggregate_usage_events(
+        [
+            _event(
+                "sandbox_create",
+                {
+                    "sandbox_id": "alice/sandbox-12345678",
+                    "hardware": "t4-small",
+                },
+                created_at="2026-06-01T12:00:00+00:00",
+            ),
+            _event(
+                "sandbox_destroy",
+                {"sandbox_id": "alice/sandbox-12345678"},
+                created_at="2026-06-01T12:30:00+00:00",
+            ),
+        ]
+    )
+
+    assert usage["sandbox_count"] == 1
+    assert usage["sandbox_billable_seconds_estimate"] == 1800
+    assert usage["sandbox_estimated_usd"] == 0.3
+    assert usage["total_usd"] == 0.3
+
+
+def test_usage_event_type_allowlists_include_sandbox_lifecycle():
+    assert set(USAGE_EVENT_TYPES) >= {"sandbox_create", "sandbox_destroy"}
+    assert set(session_persistence.USAGE_EVENT_TYPES) >= {
+        "sandbox_create",
+        "sandbox_destroy",
+    }
 
 
 def test_account_bucket_from_hf_billing_usage_v2():


### PR DESCRIPTION
## Summary

- include completed HF sandbox spend in app usage aggregation
- show the usage popover row as `HF Sandboxes`
- refresh usage when a sandbox destroy event arrives

## Tests

- `uv run --with pytest --with pytest-asyncio pytest tests/unit/test_usage.py`
- `uv run --frozen --with ruff ruff check .`
- `uv run --frozen --with ruff ruff format --check .`
- `npm run build`
- `npm run lint` (passes with existing warnings in `src/main.tsx` and `src/utils/logger.ts`)
