### PR TITLE
Use session billing endpoint for inference usage

### DIFF
--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -13,7 +13,11 @@ import yaml
 from jinja2 import Template
 from litellm import Message, acompletion
 
-from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_caching
+from agent.core.prompt_caching import (
+    router_session_id_for,
+    with_prompt_cache_params,
+    with_prompt_caching,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +151,8 @@ async def summarize_messages(
         reasoning_effort="high",
     )
     llm_params = with_prompt_cache_params(
-        llm_params, session_id=getattr(session, "session_id", None)
+        llm_params,
+        session_id=router_session_id_for(session),
     )
     prompt_messages, tool_specs = with_prompt_caching(
         prompt_messages, tool_specs, llm_params

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -32,7 +32,11 @@ from agent.core.hf_access import (
     is_inference_billing_error,
 )
 from agent.core.llm_params import _resolve_llm_params
-from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_caching
+from agent.core.prompt_caching import (
+    router_session_id_for,
+    with_prompt_cache_params,
+    with_prompt_caching,
+)
 from agent.core.session import DEFAULT_SESSION_LOG_DIR, Event, OpType, Session
 from agent.core.tools import ToolRouter
 from agent.core.usage_thresholds import (
@@ -894,7 +898,8 @@ async def _call_llm_streaming(
     for _llm_attempt in range(_MAX_LLM_RETRIES):
         try:
             request_llm_params = with_prompt_cache_params(
-                llm_params, session_id=getattr(session, "session_id", None)
+                llm_params,
+                session_id=router_session_id_for(session),
             )
             cached_messages, cached_tools = with_prompt_caching(
                 messages, tools, request_llm_params
@@ -1039,7 +1044,8 @@ async def _call_llm_non_streaming(
     for _llm_attempt in range(_MAX_LLM_RETRIES):
         try:
             request_llm_params = with_prompt_cache_params(
-                llm_params, session_id=getattr(session, "session_id", None)
+                llm_params,
+                session_id=router_session_id_for(session),
             )
             cached_messages, cached_tools = with_prompt_caching(
                 messages, tools, request_llm_params

--- a/agent/core/effort_probe.py
+++ b/agent/core/effort_probe.py
@@ -29,6 +29,7 @@ from typing import Any
 from litellm import acompletion
 
 from agent.core.llm_params import UnsupportedEffortError, _resolve_llm_params
+from agent.core.prompt_caching import with_prompt_cache_params
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +189,10 @@ async def probe_effort(
                 hf_token,
                 reasoning_effort=effort,
                 strict=True,
+            )
+            params = with_prompt_cache_params(
+                params,
+                session_id=getattr(session, "session_id", None),
             )
         except UnsupportedEffortError:
             # Provider can't even accept this effort name (e.g. "max" on

--- a/agent/core/effort_probe.py
+++ b/agent/core/effort_probe.py
@@ -29,7 +29,7 @@ from typing import Any
 from litellm import acompletion
 
 from agent.core.llm_params import UnsupportedEffortError, _resolve_llm_params
-from agent.core.prompt_caching import with_prompt_cache_params
+from agent.core.prompt_caching import router_session_id_for, with_prompt_cache_params
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +192,7 @@ async def probe_effort(
             )
             params = with_prompt_cache_params(
                 params,
-                session_id=getattr(session, "session_id", None),
+                session_id=router_session_id_for(session),
             )
         except UnsupportedEffortError:
             # Provider can't even accept this effort name (e.g. "max" on

--- a/agent/core/prompt_caching.py
+++ b/agent/core/prompt_caching.py
@@ -19,9 +19,13 @@ _CACHEABLE_ROLES = {"system", "user"}
 _OPENROUTER_SESSION_ID_MAX_LENGTH = 256
 
 
-def _is_fal_router_request(llm_params: dict[str, Any]) -> bool:
+def _is_hf_router_request(llm_params: dict[str, Any]) -> bool:
     api_base = str(llm_params.get("api_base") or "").rstrip("/")
-    return api_base == HF_ROUTER_BASE_URL and ":fal" in _router_model(llm_params)
+    return api_base == HF_ROUTER_BASE_URL
+
+
+def _is_fal_router_request(llm_params: dict[str, Any]) -> bool:
+    return _is_hf_router_request(llm_params) and ":fal" in _router_model(llm_params)
 
 
 def _router_model(llm_params: dict[str, Any]) -> str:
@@ -60,11 +64,8 @@ def with_prompt_cache_params(
     session_id: str | None = None,
 ) -> dict[str, Any]:
     """Return LiteLLM params with provider-native prompt-cache body hints."""
-    if not _is_fal_router_request(llm_params):
-        return llm_params
-
     updates: dict[str, Any] = {}
-    if session_id:
+    if session_id and _is_hf_router_request(llm_params):
         stable_session_id = session_id[:_OPENROUTER_SESSION_ID_MAX_LENGTH]
         updates["session_id"] = stable_session_id
         if _is_openai_gpt55(llm_params):

--- a/agent/core/prompt_caching.py
+++ b/agent/core/prompt_caching.py
@@ -16,7 +16,8 @@ from agent.core.model_ids import HF_ROUTER_BASE_URL
 
 _CACHE_CONTROL = {"type": "ephemeral"}
 _CACHEABLE_ROLES = {"system", "user"}
-_OPENROUTER_SESSION_ID_MAX_LENGTH = 256
+_HF_ROUTER_SESSION_ID_MAX_LENGTH = 256
+HF_ROUTER_SESSION_ID_HEADER = "X-HF-Session-id"
 
 
 def router_session_id_for(session: Any) -> str | None:
@@ -69,6 +70,19 @@ def _merge_extra_body(
     return cached_params
 
 
+def _merge_extra_headers(
+    llm_params: dict[str, Any], updates: dict[str, str]
+) -> dict[str, Any]:
+    if not updates:
+        return llm_params
+
+    cached_params = dict(llm_params)
+    extra_headers = dict(cached_params.get("extra_headers") or {})
+    extra_headers.update(updates)
+    cached_params["extra_headers"] = extra_headers
+    return cached_params
+
+
 def with_prompt_cache_params(
     llm_params: dict[str, Any],
     *,
@@ -76,9 +90,10 @@ def with_prompt_cache_params(
 ) -> dict[str, Any]:
     """Return LiteLLM params with provider-native prompt-cache body hints."""
     updates: dict[str, Any] = {}
+    headers: dict[str, str] = {}
     if session_id and _is_hf_router_request(llm_params):
-        stable_session_id = session_id[:_OPENROUTER_SESSION_ID_MAX_LENGTH]
-        updates["session_id"] = stable_session_id
+        stable_session_id = session_id[:_HF_ROUTER_SESSION_ID_MAX_LENGTH]
+        headers[HF_ROUTER_SESSION_ID_HEADER] = stable_session_id
         if _is_openai_gpt55(llm_params):
             updates["prompt_cache_key"] = stable_session_id
 
@@ -88,7 +103,7 @@ def with_prompt_cache_params(
     if _is_openai_gpt55(llm_params):
         updates["prompt_cache_retention"] = "24h"
 
-    return _merge_extra_body(llm_params, updates)
+    return _merge_extra_headers(_merge_extra_body(llm_params, updates), headers)
 
 
 def _message_role(message: Any) -> str | None:

--- a/agent/core/prompt_caching.py
+++ b/agent/core/prompt_caching.py
@@ -19,6 +19,17 @@ _CACHEABLE_ROLES = {"system", "user"}
 _OPENROUTER_SESSION_ID_MAX_LENGTH = 256
 
 
+def router_session_id_for(session: Any) -> str | None:
+    """Return the usage-window-scoped Router session ID for a runtime session."""
+    billing_session_id = getattr(session, "inference_billing_session_id", None)
+    if isinstance(billing_session_id, str) and billing_session_id:
+        return billing_session_id
+    session_id = getattr(session, "session_id", None)
+    if isinstance(session_id, str) and session_id:
+        return session_id
+    return None
+
+
 def _is_hf_router_request(llm_params: dict[str, Any]) -> bool:
     api_base = str(llm_params.get("api_base") or "").rstrip("/")
     return api_base == HF_ROUTER_BASE_URL

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -140,6 +140,7 @@ class Session:
         )
         self.event_queue = event_queue
         self.session_id = session_id or str(uuid.uuid4())
+        self.inference_billing_session_id: str | None = None
         self.config = config
         self.is_running = True
         self.current_plan: list[dict[str, str]] = []
@@ -454,6 +455,7 @@ class Session:
         self.context_manager.running_context_usage = 0
 
         self.session_id = str(uuid.uuid4())
+        self.inference_billing_session_id = None
         self.session_start_time = datetime.now().astimezone().isoformat()
         self.turn_count = 0
         self.last_auto_save_turn = 0

--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -173,6 +173,7 @@ class MongoSessionStore(NoopSessionStore):
         surface: str = "frontend",
         created_at: datetime | None = None,
         usage_window_started_at: datetime | None = None,
+        inference_billing_session_id: str | None = None,
         runtime_state: str = "idle",
         status: str = "active",
         message_count: int = 0,
@@ -205,6 +206,7 @@ class MongoSessionStore(NoopSessionStore):
                     "usage_window_started_at": (
                         usage_window_started_at or created_at or now
                     ),
+                    "inference_billing_session_id": inference_billing_session_id,
                     "status": status,
                     "runtime_state": runtime_state,
                     "updated_at": now,
@@ -236,6 +238,7 @@ class MongoSessionStore(NoopSessionStore):
         pending_approval: list[dict[str, Any]] | None = None,
         created_at: datetime | None = None,
         usage_window_started_at: datetime | None = None,
+        inference_billing_session_id: str | None = None,
         notification_destinations: list[str] | None = None,
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
@@ -261,6 +264,7 @@ class MongoSessionStore(NoopSessionStore):
             pending_approval=pending_approval,
             notification_destinations=notification_destinations,
             usage_window_started_at=usage_window_started_at,
+            inference_billing_session_id=inference_billing_session_id,
             auto_approval_enabled=auto_approval_enabled,
             auto_approval_cost_cap_usd=auto_approval_cost_cap_usd,
             auto_approval_estimated_spend_usd=auto_approval_estimated_spend_usd,

--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -173,7 +173,6 @@ class MongoSessionStore(NoopSessionStore):
         surface: str = "frontend",
         created_at: datetime | None = None,
         usage_window_started_at: datetime | None = None,
-        usage_window_baseline: dict[str, Any] | None = None,
         runtime_state: str = "idle",
         status: str = "active",
         message_count: int = 0,
@@ -206,7 +205,6 @@ class MongoSessionStore(NoopSessionStore):
                     "usage_window_started_at": (
                         usage_window_started_at or created_at or now
                     ),
-                    "usage_window_baseline": usage_window_baseline,
                     "status": status,
                     "runtime_state": runtime_state,
                     "updated_at": now,
@@ -238,7 +236,6 @@ class MongoSessionStore(NoopSessionStore):
         pending_approval: list[dict[str, Any]] | None = None,
         created_at: datetime | None = None,
         usage_window_started_at: datetime | None = None,
-        usage_window_baseline: dict[str, Any] | None = None,
         notification_destinations: list[str] | None = None,
         auto_approval_enabled: bool = False,
         auto_approval_cost_cap_usd: float | None = None,
@@ -264,7 +261,6 @@ class MongoSessionStore(NoopSessionStore):
             pending_approval=pending_approval,
             notification_destinations=notification_destinations,
             usage_window_started_at=usage_window_started_at,
-            usage_window_baseline=usage_window_baseline,
             auto_approval_enabled=auto_approval_enabled,
             auto_approval_cost_cap_usd=auto_approval_cost_cap_usd,
             auto_approval_estimated_spend_usd=auto_approval_estimated_spend_usd,

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -18,7 +18,11 @@ from agent.core import telemetry
 from agent.core.doom_loop import check_for_doom_loop
 from agent.core.llm_params import _resolve_llm_params
 from agent.core.model_ids import strip_huggingface_model_prefix
-from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_caching
+from agent.core.prompt_caching import (
+    router_session_id_for,
+    with_prompt_cache_params,
+    with_prompt_caching,
+)
 from agent.core.session import Event
 
 logger = logging.getLogger(__name__)
@@ -260,7 +264,8 @@ async def research_handler(
         reasoning_effort=_capped,
     )
     llm_params = with_prompt_cache_params(
-        llm_params, session_id=getattr(session, "session_id", None)
+        llm_params,
+        session_id=router_session_id_for(session),
     )
 
     # Get read-only tool specs from the session's tool router

--- a/backend/models.py
+++ b/backend/models.py
@@ -170,7 +170,7 @@ class HfInferenceProvidersCredits(BaseModel):
 class HfAccountUsage(BaseModel):
     """Authoritative HF account billing usage from the signed-in token."""
 
-    source: Literal["hf_billing_usage_v2"]
+    source: Literal["hf_billing"]
     available: bool = False
     error: str | None = None
     current_session: HfAccountUsageBucket | None = None

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -64,7 +64,7 @@ from agent.core.model_ids import (
     MINIMAX_M27_MODEL_ID,
     strip_huggingface_model_prefix,
 )
-from agent.core.prompt_caching import with_prompt_cache_params
+from agent.core.prompt_caching import router_session_id_for, with_prompt_cache_params
 from usage import build_usage_response
 
 logger = logging.getLogger(__name__)
@@ -347,6 +347,7 @@ async def generate_title(
     so the 60-token output budget isn't consumed before the title is written.
     """
     try:
+        agent_session = await _check_session_access(request.session_id, user)
         llm_params = _resolve_llm_params(
             "openai/gpt-oss-120b:cerebras",
             _user_hf_token(user),
@@ -354,7 +355,7 @@ async def generate_title(
         )
         llm_params = with_prompt_cache_params(
             llm_params,
-            session_id=request.session_id,
+            session_id=router_session_id_for(agent_session.session),
         )
         response = await acompletion(
             messages=[
@@ -380,7 +381,6 @@ async def generate_title(
         if len(title) > 50:
             title = title[:50].rstrip() + "…"
         try:
-            await _check_session_access(request.session_id, user)
             await session_manager.update_session_title(request.session_id, title)
         except Exception:
             logger.debug(

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -64,7 +64,8 @@ from agent.core.model_ids import (
     MINIMAX_M27_MODEL_ID,
     strip_huggingface_model_prefix,
 )
-from usage import build_usage_response, capture_hf_account_usage_baseline
+from agent.core.prompt_caching import with_prompt_cache_params
+from usage import build_usage_response
 
 logger = logging.getLogger(__name__)
 
@@ -77,17 +78,10 @@ DEFAULT_FREE_MODEL_ID = KIMI_K26_MODEL_ID
 DATASET_UPLOAD_MULTIPART_SLACK_BYTES = 1024 * 1024
 
 
-async def _reset_usage_window_with_hf_baseline(
-    session_id: str,
-    hf_token: str | None,
-) -> dict[str, Any] | None:
-    baseline = await capture_hf_account_usage_baseline(hf_token)
-    captured_at = baseline.get("captured_at") if baseline else None
-    started_at = captured_at if isinstance(captured_at, datetime) else datetime.utcnow()
+async def _reset_usage_window(session_id: str) -> dict[str, Any] | None:
     return await session_manager.reset_session_usage_window(
         session_id,
-        started_at=started_at,
-        baseline=baseline,
+        started_at=datetime.utcnow(),
     )
 
 
@@ -358,6 +352,10 @@ async def generate_title(
             _user_hf_token(user),
             reasoning_effort="low",
         )
+        llm_params = with_prompt_cache_params(
+            llm_params,
+            session_id=request.session_id,
+        )
         response = await acompletion(
             messages=[
                 {
@@ -448,7 +446,7 @@ async def create_session(
     except SessionCapacityError as e:
         raise HTTPException(status_code=503, detail=str(e))
 
-    await _reset_usage_window_with_hf_baseline(session_id, hf_token)
+    await _reset_usage_window(session_id)
 
     return SessionResponse(
         session_id=session_id,
@@ -492,7 +490,7 @@ async def restore_session_summary(
     except SessionCapacityError as e:
         raise HTTPException(status_code=503, detail=str(e))
 
-    await _reset_usage_window_with_hf_baseline(session_id, hf_token)
+    await _reset_usage_window(session_id)
 
     await _check_session_access(
         session_id,
@@ -537,8 +535,7 @@ async def activate_session(
 ) -> SessionInfo:
     """Mark a session as actively revisited and reset its usage meter window."""
     await _check_session_access(session_id, user, request)
-    hf_token = resolve_hf_request_token(request)
-    info = await _reset_usage_window_with_hf_baseline(session_id, hf_token)
+    info = await _reset_usage_window(session_id)
     if not info:
         raise HTTPException(status_code=404, detail="Session not found")
     return SessionInfo(**info)

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -123,7 +123,6 @@ class AgentSession:
     broadcaster: Any = None
     title: str | None = None
     usage_window_started_at: datetime | None = None
-    usage_window_baseline: dict[str, Any] | None = None
     usage_warning_next_threshold_usd: float = USAGE_WARNING_FIRST_THRESHOLD_USD
     usage_warning_spend_cache: dict[str, Any] = field(default_factory=dict)
 
@@ -440,14 +439,24 @@ class SessionManager:
                 return None
 
         hf_account = response.get("hf_account")
+        session_bucket = response.get("session")
         if isinstance(hf_account, dict):
             current_session = hf_account.get("current_session")
             if isinstance(current_session, dict):
-                spend = coerce_spend(current_session.get("total_usd"))
+                spend = coerce_spend(
+                    current_session.get("inference_providers_usd")
+                    if "inference_providers_usd" in current_session
+                    else current_session.get("total_usd")
+                )
                 if spend is not None:
+                    if isinstance(session_bucket, dict):
+                        for key in (
+                            "hf_jobs_estimated_usd",
+                            "sandbox_estimated_usd",
+                        ):
+                            spend += coerce_spend(session_bucket.get(key)) or 0.0
                     return spend, "hf_billing_current_session"
 
-        session_bucket = response.get("session")
         if isinstance(session_bucket, dict):
             spend = coerce_spend(session_bucket.get("total_usd"))
             if spend is not None:
@@ -799,7 +808,6 @@ class SessionManager:
                 ),
                 created_at=agent_session.created_at,
                 usage_window_started_at=agent_session.usage_window_started_at,
-                usage_window_baseline=agent_session.usage_window_baseline,
                 notification_destinations=list(
                     agent_session.session.notification_destinations
                 ),
@@ -978,9 +986,6 @@ class SessionManager:
         usage_window_started_at = meta.get("usage_window_started_at")
         if not isinstance(usage_window_started_at, datetime):
             usage_window_started_at = created_at
-        usage_window_baseline = meta.get("usage_window_baseline")
-        if not isinstance(usage_window_baseline, dict):
-            usage_window_baseline = None
 
         agent_session = AgentSession(
             session_id=session_id,
@@ -993,7 +998,6 @@ class SessionManager:
             user_plan=user_plan,
             created_at=created_at,
             usage_window_started_at=usage_window_started_at,
-            usage_window_baseline=usage_window_baseline,
             usage_warning_next_threshold_usd=session.usage_warning_next_threshold_usd,
             is_active=True,
             is_processing=False,
@@ -1742,7 +1746,6 @@ class SessionManager:
         session_id: str,
         *,
         started_at: datetime | None = None,
-        baseline: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Reset the account-billing window used for the visible usage meter."""
         agent_session = self.sessions.get(session_id)
@@ -1751,7 +1754,6 @@ class SessionManager:
 
         window_start = started_at or datetime.utcnow()
         agent_session.usage_window_started_at = window_start
-        agent_session.usage_window_baseline = baseline
         self._touch(agent_session)
 
         store = self._store()
@@ -1759,7 +1761,6 @@ class SessionManager:
             await store.update_session_fields(
                 session_id,
                 usage_window_started_at=window_start,
-                usage_window_baseline=baseline,
                 last_active_at=agent_session.last_active_at,
             )
         return self.get_session_info(session_id)

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -1,7 +1,6 @@
 """Session manager for handling multiple concurrent agent sessions."""
 
 import asyncio
-import hashlib
 import json
 import logging
 import os
@@ -35,7 +34,6 @@ from agent.messaging.gateway import NotificationGateway
 PROJECT_ROOT = Path(__file__).parent.parent
 DEFAULT_CONFIG_PATH = str(PROJECT_ROOT / "configs" / "frontend_agent_config.json")
 USAGE_WARNING_SPEND_CACHE_TTL_SECONDS = 30.0
-INFERENCE_BILLING_SESSION_ID_MAX_LENGTH = 256
 
 
 # These dataclasses match agent/main.py structure
@@ -132,7 +130,9 @@ class AgentSession:
     def __post_init__(self) -> None:
         if self.usage_window_started_at is None:
             self.usage_window_started_at = self.created_at
-        if not self.inference_billing_session_id:
+        if not self.inference_billing_session_id or not _is_uuid(
+            self.inference_billing_session_id
+        ):
             self.inference_billing_session_id = new_inference_billing_session_id(
                 self.session_id,
                 self.usage_window_started_at,
@@ -145,31 +145,20 @@ class AgentSession:
             pass
 
 
-def _billing_window_stamp(started_at: datetime | None) -> str:
-    window_start = started_at or datetime.utcnow()
-    if window_start.tzinfo is None:
-        window_start = window_start.replace(tzinfo=UTC)
-    else:
-        window_start = window_start.astimezone(UTC)
-    return window_start.strftime("%Y%m%dT%H%M%S%fZ")
-
-
 def new_inference_billing_session_id(
-    session_id: str,
-    started_at: datetime | None = None,
+    session_id: str,  # noqa: ARG001 - kept for a stable call signature.
+    started_at: datetime | None = None,  # noqa: ARG001 - kept for a stable call signature.
 ) -> str:
-    """Return a Router session ID scoped to one visible usage window."""
-    stamp = _billing_window_stamp(started_at)
-    nonce = uuid.uuid4().hex[:12]
-    suffix = f":usage:{stamp}:{nonce}"
-    candidate = f"{session_id}{suffix}"
-    if len(candidate) <= INFERENCE_BILLING_SESSION_ID_MAX_LENGTH:
-        return candidate
+    """Return a Router billing session ID scoped to one visible usage window."""
+    return str(uuid.uuid4())
 
-    digest = hashlib.sha256(session_id.encode()).hexdigest()[:16]
-    suffix = f":{digest}{suffix}"
-    prefix_length = max(0, INFERENCE_BILLING_SESSION_ID_MAX_LENGTH - len(suffix))
-    return f"{session_id[:prefix_length]}{suffix}"
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return False
+    return True
 
 
 class SessionCapacityError(Exception):
@@ -1044,7 +1033,9 @@ class SessionManager:
         if not isinstance(usage_window_started_at, datetime):
             usage_window_started_at = created_at
         inference_billing_session_id = meta.get("inference_billing_session_id")
-        if not isinstance(inference_billing_session_id, str):
+        if not isinstance(inference_billing_session_id, str) or not _is_uuid(
+            inference_billing_session_id
+        ):
             inference_billing_session_id = new_inference_billing_session_id(
                 session_id,
                 usage_window_started_at,

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -1,6 +1,7 @@
 """Session manager for handling multiple concurrent agent sessions."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -34,6 +35,7 @@ from agent.messaging.gateway import NotificationGateway
 PROJECT_ROOT = Path(__file__).parent.parent
 DEFAULT_CONFIG_PATH = str(PROJECT_ROOT / "configs" / "frontend_agent_config.json")
 USAGE_WARNING_SPEND_CACHE_TTL_SECONDS = 30.0
+INFERENCE_BILLING_SESSION_ID_MAX_LENGTH = 256
 
 
 # These dataclasses match agent/main.py structure
@@ -123,12 +125,51 @@ class AgentSession:
     broadcaster: Any = None
     title: str | None = None
     usage_window_started_at: datetime | None = None
+    inference_billing_session_id: str | None = None
     usage_warning_next_threshold_usd: float = USAGE_WARNING_FIRST_THRESHOLD_USD
     usage_warning_spend_cache: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.usage_window_started_at is None:
             self.usage_window_started_at = self.created_at
+        if not self.inference_billing_session_id:
+            self.inference_billing_session_id = new_inference_billing_session_id(
+                self.session_id,
+                self.usage_window_started_at,
+            )
+        try:
+            self.session.inference_billing_session_id = (
+                self.inference_billing_session_id
+            )
+        except AttributeError:
+            pass
+
+
+def _billing_window_stamp(started_at: datetime | None) -> str:
+    window_start = started_at or datetime.utcnow()
+    if window_start.tzinfo is None:
+        window_start = window_start.replace(tzinfo=UTC)
+    else:
+        window_start = window_start.astimezone(UTC)
+    return window_start.strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def new_inference_billing_session_id(
+    session_id: str,
+    started_at: datetime | None = None,
+) -> str:
+    """Return a Router session ID scoped to one visible usage window."""
+    stamp = _billing_window_stamp(started_at)
+    nonce = uuid.uuid4().hex[:12]
+    suffix = f":usage:{stamp}:{nonce}"
+    candidate = f"{session_id}{suffix}"
+    if len(candidate) <= INFERENCE_BILLING_SESSION_ID_MAX_LENGTH:
+        return candidate
+
+    digest = hashlib.sha256(session_id.encode()).hexdigest()[:16]
+    suffix = f":{digest}{suffix}"
+    prefix_length = max(0, INFERENCE_BILLING_SESSION_ID_MAX_LENGTH - len(suffix))
+    return f"{session_id[:prefix_length]}{suffix}"
 
 
 class SessionCapacityError(Exception):
@@ -427,6 +468,19 @@ class SessionManager:
             )
 
         agent_session.session.usage_threshold_checker = _checker
+
+    @staticmethod
+    def _set_inference_billing_session_id(
+        agent_session: AgentSession,
+        inference_billing_session_id: str,
+    ) -> None:
+        agent_session.inference_billing_session_id = inference_billing_session_id
+        try:
+            agent_session.session.inference_billing_session_id = (
+                inference_billing_session_id
+            )
+        except AttributeError:
+            pass
 
     @staticmethod
     def _usage_spend_from_response(response: dict[str, Any]) -> tuple[float, str]:
@@ -808,6 +862,9 @@ class SessionManager:
                 ),
                 created_at=agent_session.created_at,
                 usage_window_started_at=agent_session.usage_window_started_at,
+                inference_billing_session_id=(
+                    agent_session.inference_billing_session_id
+                ),
                 notification_destinations=list(
                     agent_session.session.notification_destinations
                 ),
@@ -986,6 +1043,12 @@ class SessionManager:
         usage_window_started_at = meta.get("usage_window_started_at")
         if not isinstance(usage_window_started_at, datetime):
             usage_window_started_at = created_at
+        inference_billing_session_id = meta.get("inference_billing_session_id")
+        if not isinstance(inference_billing_session_id, str):
+            inference_billing_session_id = new_inference_billing_session_id(
+                session_id,
+                usage_window_started_at,
+            )
 
         agent_session = AgentSession(
             session_id=session_id,
@@ -998,6 +1061,7 @@ class SessionManager:
             user_plan=user_plan,
             created_at=created_at,
             usage_window_started_at=usage_window_started_at,
+            inference_billing_session_id=inference_billing_session_id,
             usage_warning_next_threshold_usd=session.usage_warning_next_threshold_usd,
             is_active=True,
             is_processing=False,
@@ -1754,6 +1818,9 @@ class SessionManager:
 
         window_start = started_at or datetime.utcnow()
         agent_session.usage_window_started_at = window_start
+        billing_session_id = new_inference_billing_session_id(session_id, window_start)
+        self._set_inference_billing_session_id(agent_session, billing_session_id)
+        agent_session.usage_warning_spend_cache = {}
         self._touch(agent_session)
 
         store = self._store()
@@ -1761,6 +1828,7 @@ class SessionManager:
             await store.update_session_fields(
                 session_id,
                 usage_window_started_at=window_start,
+                inference_billing_session_id=billing_session_id,
                 last_active_at=agent_session.last_active_at,
             )
         return self.get_session_info(session_id)

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -20,6 +20,9 @@ USAGE_EVENT_TYPES = (
 logger = logging.getLogger(__name__)
 
 HF_BILLING_USAGE_V2_URL = "https://huggingface.co/api/settings/billing/usage-v2"
+HF_BILLING_USAGE_BY_INFERENCE_SESSION_URL = (
+    "https://huggingface.co/api/settings/billing/usage-by-inference-session"
+)
 HF_BILLING_URL = "https://huggingface.co/settings/billing"
 HF_INFERENCE_PROVIDERS_PRICING_URL = (
     "https://huggingface.co/docs/inference-providers/en/pricing"
@@ -63,6 +66,10 @@ def _nano_usd_to_usd(value: Any) -> float:
 
 def _micro_usd_to_usd(value: Any) -> float:
     return _coerce_float(value) / 1_000_000
+
+
+def _cents_to_usd(value: Any) -> float:
+    return _coerce_float(value) / 100
 
 
 def _coerce_timezone(timezone_name: str | None) -> ZoneInfo | None:
@@ -356,88 +363,41 @@ def _account_bucket_from_billing_usage(
     return bucket
 
 
-def _baseline_from_account_bucket(
-    bucket: dict[str, Any],
+def _session_bucket_from_inference_session_usage(
+    payload: dict[str, Any] | None,
     *,
-    captured_at: datetime,
-    month_start: datetime,
-) -> dict[str, Any]:
-    return {
-        "captured_at": _utc(captured_at),
-        "month_start": _utc(month_start),
-        "total_usd": bucket.get("total_usd", 0.0),
-        "inference_providers_usd": bucket.get("inference_providers_usd", 0.0),
-        "hf_jobs_usd": bucket.get("hf_jobs_usd", 0.0),
-        "inference_provider_requests": bucket.get("inference_provider_requests", 0),
-        "hf_jobs_minutes": bucket.get("hf_jobs_minutes", 0.0),
-    }
-
-
-def _baseline_datetime(value: Any) -> datetime | None:
-    if isinstance(value, datetime):
-        return _utc(value)
-    parsed = _parse_timestamp(value)
-    return _utc(parsed) if parsed is not None else None
-
-
-def _baseline_delta_bucket(
-    bucket: dict[str, Any],
-    baseline: dict[str, Any],
-    *,
+    session_id: str,
     window_start: datetime,
     window_end: datetime,
     timezone: str,
 ) -> dict[str, Any]:
-    delta = _empty_hf_account_bucket(
+    bucket = _empty_hf_account_bucket(
         window_start=window_start,
         window_end=window_end,
         timezone=timezone,
     )
-    for key in ("inference_providers_usd", "hf_jobs_usd", "hf_jobs_minutes"):
-        delta[key] = round(
-            max(0.0, _coerce_float(bucket.get(key)) - _coerce_float(baseline.get(key))),
-            6 if key != "hf_jobs_minutes" else 3,
-        )
-    delta["inference_provider_requests"] = max(
-        0,
-        _coerce_int(bucket.get("inference_provider_requests"))
-        - _coerce_int(baseline.get("inference_provider_requests")),
-    )
-    delta["total_usd"] = round(
-        delta["inference_providers_usd"] + delta["hf_jobs_usd"],
-        6,
-    )
-    return delta
+    periods = payload.get("periods") if isinstance(payload, dict) else []
+    if not isinstance(periods, list):
+        return bucket
 
+    cost_cents = 0.0
+    request_count = 0
+    for period in periods:
+        if not isinstance(period, dict):
+            continue
+        sessions = period.get("sessions")
+        if not isinstance(sessions, list):
+            continue
+        for session in sessions:
+            if not isinstance(session, dict) or session.get("id") != session_id:
+                continue
+            cost_cents += _coerce_float(session.get("costCents"))
+            request_count += _coerce_int(session.get("requestCount"))
 
-async def capture_hf_account_usage_baseline(
-    hf_token: str | None,
-    *,
-    now: datetime | None = None,
-) -> dict[str, Any] | None:
-    if not hf_token:
-        return None
-    windows = resolve_usage_windows("UTC", now=now)
-    now_utc = windows["now_utc"]
-    month_start = windows["month_start_utc"]
-    payload = await _fetch_hf_billing_usage_v2(
-        hf_token,
-        start=month_start,
-        end=now_utc,
-    )
-    if payload is None:
-        return None
-    bucket = _account_bucket_from_billing_usage(
-        payload,
-        window_start=month_start,
-        window_end=now_utc,
-        timezone="UTC",
-    )
-    return _baseline_from_account_bucket(
-        bucket,
-        captured_at=now_utc,
-        month_start=month_start,
-    )
+    bucket["inference_providers_usd"] = round(_cents_to_usd(cost_cents), 6)
+    bucket["inference_provider_requests"] = request_count
+    bucket["total_usd"] = bucket["inference_providers_usd"]
+    return bucket
 
 
 def _inference_credits_from_billing_usage(
@@ -494,6 +454,35 @@ async def _fetch_hf_billing_usage_v2(
         return None
 
 
+async def _fetch_hf_inference_session_usage(
+    hf_token: str,
+    *,
+    start: datetime,
+    end: datetime,
+) -> dict[str, Any] | None:
+    start_ts = _iso(start)
+    end_ts = _iso(max(_utc(end), _utc(start) + timedelta(seconds=1)))
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(
+                HF_BILLING_USAGE_BY_INFERENCE_SESSION_URL,
+                params={"startDate": start_ts, "endDate": end_ts},
+                headers={"Authorization": f"Bearer {hf_token}"},
+            )
+            if response.status_code != 200:
+                logger.debug(
+                    "HF inference session usage failed: status=%s body=%s",
+                    response.status_code,
+                    response.text[:200],
+                )
+                return None
+            payload = response.json()
+            return payload if isinstance(payload, dict) else None
+    except (httpx.HTTPError, ValueError) as e:
+        logger.debug("HF inference session usage failed: %s", e)
+        return None
+
+
 def _session_usage_window_started_at(
     manager: Any, session_id: str | None
 ) -> datetime | None:
@@ -507,17 +496,6 @@ def _session_usage_window_started_at(
     if isinstance(created_at, datetime):
         return _utc(created_at)
     return None
-
-
-def _session_usage_window_baseline(
-    manager: Any,
-    session_id: str | None,
-) -> dict[str, Any] | None:
-    if not session_id:
-        return None
-    agent_session = getattr(manager, "sessions", {}).get(session_id)
-    baseline = getattr(agent_session, "usage_window_baseline", None)
-    return baseline if isinstance(baseline, dict) else None
 
 
 async def _load_persisted_session_usage_window_started_at(
@@ -542,23 +520,6 @@ async def _load_persisted_session_usage_window_started_at(
     return _utc(parsed) if parsed is not None else None
 
 
-async def _load_persisted_session_usage_window_baseline(
-    manager: Any,
-    session_id: str | None,
-) -> dict[str, Any] | None:
-    if not session_id:
-        return None
-    store = manager._store()
-    if not getattr(store, "enabled", False) or not hasattr(store, "load_session"):
-        return None
-    loaded = await store.load_session(session_id)
-    metadata = loaded.get("metadata") if isinstance(loaded, dict) else None
-    if not isinstance(metadata, dict):
-        return None
-    baseline = metadata.get("usage_window_baseline")
-    return baseline if isinstance(baseline, dict) else None
-
-
 async def _build_hf_account_usage(
     manager: Any,
     *,
@@ -569,7 +530,7 @@ async def _build_hf_account_usage(
     month_start: datetime,
 ) -> dict[str, Any]:
     account_usage: dict[str, Any] = {
-        "source": "hf_billing_usage_v2",
+        "source": "hf_billing",
         "available": False,
         "current_session": None,
         "month": None,
@@ -584,15 +545,6 @@ async def _build_hf_account_usage(
         session_start = await _load_persisted_session_usage_window_started_at(
             manager, session_id
         )
-    session_baseline = _session_usage_window_baseline(manager, session_id)
-    if session_baseline is None:
-        session_baseline = await _load_persisted_session_usage_window_baseline(
-            manager,
-            session_id,
-        )
-    baseline_month_start = None
-    if session_baseline is not None:
-        baseline_month_start = _baseline_datetime(session_baseline.get("month_start"))
 
     window_tasks: dict[str, tuple[datetime, asyncio.Task[dict[str, Any] | None]]] = {
         "month": (
@@ -602,29 +554,17 @@ async def _build_hf_account_usage(
             ),
         ),
     }
-    if session_start is not None:
-        if baseline_month_start is not None:
-            window_tasks["current_session_baseline"] = (
-                baseline_month_start,
-                asyncio.create_task(
-                    _fetch_hf_billing_usage_v2(
-                        hf_token,
-                        start=baseline_month_start,
-                        end=now_utc,
-                    )
-                ),
-            )
-        else:
-            window_tasks["current_session"] = (
-                session_start,
-                asyncio.create_task(
-                    _fetch_hf_billing_usage_v2(
-                        hf_token,
-                        start=session_start,
-                        end=now_utc,
-                    )
-                ),
-            )
+    if session_id is not None and session_start is not None:
+        window_tasks["current_session"] = (
+            session_start,
+            asyncio.create_task(
+                _fetch_hf_inference_session_usage(
+                    hf_token,
+                    start=session_start,
+                    end=now_utc,
+                )
+            ),
+        )
 
     payloads: dict[str, dict[str, Any] | None] = {}
     for name, (_, task) in window_tasks.items():
@@ -637,37 +577,26 @@ async def _build_hf_account_usage(
         return account_usage
 
     for name, (start, _) in window_tasks.items():
-        if name == "current_session_baseline":
-            continue
         payload = payloads.get(name)
         if payload is None:
+            if name == "current_session":
+                account_usage["error"] = "session_billing_usage_unavailable"
             continue
-        account_usage[name] = _account_bucket_from_billing_usage(
-            payload,
-            window_start=start,
-            window_end=now_utc,
-            timezone=timezone,
-        )
-
-    if (
-        session_start is not None
-        and session_baseline is not None
-        and baseline_month_start is not None
-        and payloads.get("current_session_baseline") is not None
-    ):
-        baseline_bucket = _account_bucket_from_billing_usage(
-            payloads.get("current_session_baseline"),
-            window_start=baseline_month_start,
-            window_end=now_utc,
-            timezone=timezone,
-        )
-        account_usage["current_session"] = _baseline_delta_bucket(
-            baseline_bucket,
-            session_baseline,
-            window_start=session_start,
-            window_end=now_utc,
-            timezone=timezone,
-        )
+        if name == "current_session" and session_id is not None:
+            account_usage[name] = _session_bucket_from_inference_session_usage(
+                payload,
+                session_id=session_id,
+                window_start=start,
+                window_end=now_utc,
+                timezone=timezone,
+            )
+        else:
+            account_usage[name] = _account_bucket_from_billing_usage(
+                payload,
+                window_start=start,
+                window_end=now_utc,
+                timezone=timezone,
+            )
 
     account_usage["inference_providers_credits"] = (
         _inference_credits_from_billing_usage(payloads.get("month"))

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -498,26 +498,46 @@ def _session_usage_window_started_at(
     return None
 
 
-async def _load_persisted_session_usage_window_started_at(
-    manager: Any,
-    session_id: str | None,
-) -> datetime | None:
+def _session_inference_billing_session_id(
+    manager: Any, session_id: str | None
+) -> str | None:
     if not session_id:
         return None
+    agent_session = getattr(manager, "sessions", {}).get(session_id)
+    billing_session_id = getattr(agent_session, "inference_billing_session_id", None)
+    if isinstance(billing_session_id, str) and billing_session_id:
+        return billing_session_id
+    runtime_session = getattr(agent_session, "session", None)
+    billing_session_id = getattr(runtime_session, "inference_billing_session_id", None)
+    if isinstance(billing_session_id, str) and billing_session_id:
+        return billing_session_id
+    return None
+
+
+async def _load_persisted_session_usage_window_metadata(
+    manager: Any,
+    session_id: str | None,
+) -> tuple[datetime | None, str | None]:
+    if not session_id:
+        return None, None
     store = manager._store()
     if not getattr(store, "enabled", False) or not hasattr(store, "load_session"):
-        return None
+        return None, None
     loaded = await store.load_session(session_id)
     metadata = loaded.get("metadata") if isinstance(loaded, dict) else None
     started_at = None
+    billing_session_id = None
     if isinstance(metadata, dict):
         started_at = metadata.get("usage_window_started_at") or metadata.get(
             "created_at"
         )
+        raw_billing_session_id = metadata.get("inference_billing_session_id")
+        if isinstance(raw_billing_session_id, str) and raw_billing_session_id:
+            billing_session_id = raw_billing_session_id
     if isinstance(started_at, datetime):
-        return _utc(started_at)
+        return _utc(started_at), billing_session_id
     parsed = _parse_timestamp(started_at)
-    return _utc(parsed) if parsed is not None else None
+    return (_utc(parsed) if parsed is not None else None), billing_session_id
 
 
 async def _build_hf_account_usage(
@@ -541,10 +561,16 @@ async def _build_hf_account_usage(
         return account_usage
 
     session_start = _session_usage_window_started_at(manager, session_id)
-    if session_start is None:
-        session_start = await _load_persisted_session_usage_window_started_at(
-            manager, session_id
-        )
+    billing_session_id = _session_inference_billing_session_id(manager, session_id)
+    if session_start is None or billing_session_id is None:
+        (
+            persisted_start,
+            persisted_billing_session_id,
+        ) = await _load_persisted_session_usage_window_metadata(manager, session_id)
+        if session_start is None:
+            session_start = persisted_start
+        if billing_session_id is None:
+            billing_session_id = persisted_billing_session_id
 
     window_tasks: dict[str, tuple[datetime, asyncio.Task[dict[str, Any] | None]]] = {
         "month": (
@@ -554,7 +580,7 @@ async def _build_hf_account_usage(
             ),
         ),
     }
-    if session_id is not None and session_start is not None:
+    if billing_session_id is not None and session_start is not None:
         window_tasks["current_session"] = (
             session_start,
             asyncio.create_task(
@@ -582,10 +608,10 @@ async def _build_hf_account_usage(
             if name == "current_session":
                 account_usage["error"] = "session_billing_usage_unavailable"
             continue
-        if name == "current_session" and session_id is not None:
+        if name == "current_session" and billing_session_id is not None:
             account_usage[name] = _session_bucket_from_inference_session_usage(
                 payload,
-                session_id=session_id,
+                session_id=billing_session_id,
                 window_start=start,
                 window_end=now_utc,
                 timezone=timezone,

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -605,8 +605,6 @@ async def _build_hf_account_usage(
     for name, (start, _) in window_tasks.items():
         payload = payloads.get(name)
         if payload is None:
-            if name == "current_session":
-                account_usage["error"] = "session_billing_usage_unavailable"
             continue
         if name == "current_session" and billing_session_id is not None:
             account_usage[name] = _session_bucket_from_inference_session_usage(

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -183,11 +183,14 @@ export default function UsageMeter() {
     void fetchUsage(activeSessionId);
   }, [activeSessionId, fetchUsage]);
 
-  const accountSessionTotal = usage?.hf_account?.current_session?.total_usd;
+  const accountSessionInference =
+    usage?.hf_account?.current_session?.inference_providers_usd;
   const sessionTotal =
-    accountSessionTotal == null
+    accountSessionInference == null
       ? usage?.session?.total_usd
-      : accountSessionTotal + (usage?.session?.sandbox_estimated_usd ?? 0);
+      : accountSessionInference +
+        (usage?.session?.hf_jobs_estimated_usd ?? 0) +
+        (usage?.session?.sandbox_estimated_usd ?? 0);
   const links = useMemo(() => usage?.links ?? {}, [usage?.links]);
   const billingMessage = billingUnavailableMessage(usage?.hf_account?.error);
   const open = Boolean(anchorEl);

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -41,6 +41,16 @@ function textFromUIMessage(message: UIMessage): string {
     .join('');
 }
 
+function messagesSignature(messages: UIMessage[]): string {
+  return JSON.stringify(
+    messages.map((message) => ({
+      id: message.id,
+      role: message.role,
+      parts: message.parts,
+    })),
+  );
+}
+
 function pendingApprovalItemsFromInfo(info: unknown): PendingApprovalItem[] | undefined {
   const pending = (info as { pending_approval?: unknown } | null)?.pending_approval;
   if (!Array.isArray(pending)) return undefined;
@@ -890,13 +900,14 @@ export function useAgentChat({ sessionId, isActive, isProcessing = false, onRead
   }, [sessionId, setProcessingState]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // -- Persist messages ---------------------------------------------------
-  const prevLenRef = useRef(initialMessages.length);
+  const prevMessagesSignatureRef = useRef(messagesSignature(initialMessages));
   useEffect(() => {
     if (chat.messages.length === 0) return;
-    if (chat.messages.length !== prevLenRef.current) {
-      prevLenRef.current = chat.messages.length;
+    const signature = messagesSignature(chat.messages);
+    if (signature !== prevMessagesSignatureRef.current) {
+      prevMessagesSignatureRef.current = signature;
       saveMessages(sessionId, chat.messages);
-    } 
+    }
   }, [sessionId, chat.messages]);
 
   // -- Undo last turn (REST call + client-side message removal) -----------

--- a/frontend/src/lib/convert-llm-messages.ts
+++ b/frontend/src/lib/convert-llm-messages.ts
@@ -59,10 +59,19 @@ export function llmMessagesToUIMessages(
   const uiMessages: UIMessage[] = [];
 
   // Helper to get existing message ID at a given position if roles match
-  const getExistingId = (index: number, role: 'user' | 'assistant'): string | null => {
+  const getExistingId = (
+    index: number,
+    role: 'user' | 'assistant',
+    expectedText?: string,
+  ): string | null => {
     if (!existingUIMessages || index >= existingUIMessages.length) return null;
     const existing = existingUIMessages[index];
-    return existing.role === role ? existing.id : null;
+    if (existing.role !== role) return null;
+    if (expectedText === undefined) return existing.id;
+
+    const existingText = joinText(existing.parts);
+    if (role === 'user') return existingText === expectedText ? existing.id : null;
+    return existingText.startsWith(expectedText) ? existing.id : null;
   };
   const getExistingPendingToolMessageId = (toolCallId: string): string | null => {
     for (const existing of existingUIMessages || []) {
@@ -89,11 +98,12 @@ export function llmMessagesToUIMessages(
         continue;
       }
       // Try to reuse existing ID if the message at this position matches
-      const existingId = getExistingId(uiMessages.length, 'user');
+      const content = msg.content || '';
+      const existingId = getExistingId(uiMessages.length, 'user', content);
       uiMessages.push({
         id: existingId || nextId(),
         role: 'user',
-        parts: [{ type: 'text', text: msg.content || '' }],
+        parts: [{ type: 'text', text: content }],
       });
       continue;
     }
@@ -153,7 +163,12 @@ export function llmMessagesToUIMessages(
         prev.parts.push(...parts);
       } else {
         // Try to reuse existing ID if the message at this position matches
-        const existingId = getExistingId(uiMessages.length, 'assistant');
+        const expectedText = joinText(parts);
+        const existingId = getExistingId(
+          uiMessages.length,
+          'assistant',
+          expectedText,
+        );
         const newId = existingId || nextId();
         uiMessages.push({
           id: newId,

--- a/frontend/src/store/usageStore.ts
+++ b/frontend/src/store/usageStore.ts
@@ -42,7 +42,7 @@ export interface HfInferenceProvidersCredits {
 }
 
 export interface HfAccountUsage {
-  source: 'hf_billing_usage_v2';
+  source: 'hf_billing';
   available: boolean;
   error?: string | null;
   current_session: HfAccountUsageBucket | null;

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -12,6 +12,7 @@ if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
 from routes import agent  # noqa: E402
+from dependencies import INTERNAL_HF_TOKEN_KEY  # noqa: E402
 
 
 def test_available_models_exclude_sonnet_and_have_no_pro_gate():
@@ -99,6 +100,63 @@ async def test_llm_health_skips_router_probe_without_token(monkeypatch):
 
     assert response.status == "skipped"
     assert response.model == agent.DEFAULT_FREE_MODEL_ID
+
+
+@pytest.mark.asyncio
+async def test_generate_title_sends_session_id_to_hf_router(monkeypatch):
+    completions = []
+    titles = []
+
+    def fake_resolve_llm_params(
+        model_name,
+        session_hf_token=None,
+        reasoning_effort=None,
+        strict=False,
+    ):
+        return {
+            "model": f"openai/{model_name}",
+            "api_base": "https://router.huggingface.co/v1",
+            "api_key": session_hf_token,
+            "extra_body": {"reasoning_effort": reasoning_effort},
+        }
+
+    async def fake_acompletion(**kwargs):
+        completions.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="Clean title"),
+                )
+            ]
+        )
+
+    async def fake_check_session_access(session_id, user):
+        assert session_id == "session-1"
+        assert user["user_id"] == "u1"
+
+    async def fake_update_session_title(session_id, title):
+        titles.append((session_id, title))
+
+    monkeypatch.setattr(agent, "_resolve_llm_params", fake_resolve_llm_params)
+    monkeypatch.setattr(agent, "acompletion", fake_acompletion)
+    monkeypatch.setattr(agent, "_check_session_access", fake_check_session_access)
+    monkeypatch.setattr(
+        agent.session_manager,
+        "update_session_title",
+        fake_update_session_title,
+    )
+
+    response = await agent.generate_title(
+        agent.SubmitRequest(session_id="session-1", text="Make something useful"),
+        {"user_id": "u1", INTERNAL_HF_TOKEN_KEY: "hf_fake"},
+    )
+
+    assert response == {"title": "Clean title"}
+    assert completions[0]["extra_body"] == {
+        "reasoning_effort": "low",
+        "session_id": "session-1",
+    }
+    assert titles == [("session-1", "Clean title")]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -133,6 +133,12 @@ async def test_generate_title_sends_session_id_to_hf_router(monkeypatch):
     async def fake_check_session_access(session_id, user):
         assert session_id == "session-1"
         assert user["user_id"] == "u1"
+        return SimpleNamespace(
+            session=SimpleNamespace(
+                session_id="session-1",
+                inference_billing_session_id="session-1:usage:window-1",
+            )
+        )
 
     async def fake_update_session_title(session_id, title):
         titles.append((session_id, title))
@@ -154,7 +160,7 @@ async def test_generate_title_sends_session_id_to_hf_router(monkeypatch):
     assert response == {"title": "Clean title"}
     assert completions[0]["extra_body"] == {
         "reasoning_effort": "low",
-        "session_id": "session-1",
+        "session_id": "session-1:usage:window-1",
     }
     assert titles == [("session-1", "Clean title")]
 

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -11,8 +11,11 @@ _BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
 if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
+from agent.core.prompt_caching import HF_ROUTER_SESSION_ID_HEADER  # noqa: E402
 from routes import agent  # noqa: E402
 from dependencies import INTERNAL_HF_TOKEN_KEY  # noqa: E402
+
+BILLING_SESSION_ID = "00000000-0000-4000-8000-000000000001"
 
 
 def test_available_models_exclude_sonnet_and_have_no_pro_gate():
@@ -136,7 +139,7 @@ async def test_generate_title_sends_session_id_to_hf_router(monkeypatch):
         return SimpleNamespace(
             session=SimpleNamespace(
                 session_id="session-1",
-                inference_billing_session_id="session-1:usage:window-1",
+                inference_billing_session_id=BILLING_SESSION_ID,
             )
         )
 
@@ -158,9 +161,9 @@ async def test_generate_title_sends_session_id_to_hf_router(monkeypatch):
     )
 
     assert response == {"title": "Clean title"}
-    assert completions[0]["extra_body"] == {
-        "reasoning_effort": "low",
-        "session_id": "session-1:usage:window-1",
+    assert completions[0]["extra_body"] == {"reasoning_effort": "low"}
+    assert completions[0]["extra_headers"] == {
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID
     }
     assert titles == [("session-1", "Clean title")]
 

--- a/tests/unit/test_effort_probe.py
+++ b/tests/unit/test_effort_probe.py
@@ -22,11 +22,14 @@ async def test_probe_effort_sends_session_id_to_hf_router(monkeypatch):
         "moonshotai/Kimi-K2.6:novita",
         "high",
         "hf_fake",
-        session=SimpleNamespace(session_id="session-1"),
+        session=SimpleNamespace(
+            session_id="session-1",
+            inference_billing_session_id="session-1:usage:window-1",
+        ),
     )
 
     assert outcome.effective_effort == "high"
     assert completions[0]["extra_body"] == {
         "reasoning_effort": "high",
-        "session_id": "session-1",
+        "session_id": "session-1:usage:window-1",
     }

--- a/tests/unit/test_effort_probe.py
+++ b/tests/unit/test_effort_probe.py
@@ -3,6 +3,9 @@ from types import SimpleNamespace
 import pytest
 
 from agent.core import effort_probe
+from agent.core.prompt_caching import HF_ROUTER_SESSION_ID_HEADER
+
+BILLING_SESSION_ID = "00000000-0000-4000-8000-000000000001"
 
 
 @pytest.mark.asyncio
@@ -24,12 +27,12 @@ async def test_probe_effort_sends_session_id_to_hf_router(monkeypatch):
         "hf_fake",
         session=SimpleNamespace(
             session_id="session-1",
-            inference_billing_session_id="session-1:usage:window-1",
+            inference_billing_session_id=BILLING_SESSION_ID,
         ),
     )
 
     assert outcome.effective_effort == "high"
-    assert completions[0]["extra_body"] == {
-        "reasoning_effort": "high",
-        "session_id": "session-1:usage:window-1",
+    assert completions[0]["extra_body"] == {"reasoning_effort": "high"}
+    assert completions[0]["extra_headers"] == {
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID
     }

--- a/tests/unit/test_effort_probe.py
+++ b/tests/unit/test_effort_probe.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.core import effort_probe
+
+
+@pytest.mark.asyncio
+async def test_probe_effort_sends_session_id_to_hf_router(monkeypatch):
+    completions = []
+
+    async def fake_acompletion(**kwargs):
+        completions.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(finish_reason="stop")],
+            usage=None,
+        )
+
+    monkeypatch.setattr(effort_probe, "acompletion", fake_acompletion)
+
+    outcome = await effort_probe.probe_effort(
+        "moonshotai/Kimi-K2.6:novita",
+        "high",
+        "hf_fake",
+        session=SimpleNamespace(session_id="session-1"),
+    )
+
+    assert outcome.effective_effort == "high"
+    assert completions[0]["extra_body"] == {
+        "reasoning_effort": "high",
+        "session_id": "session-1",
+    }

--- a/tests/unit/test_prompt_caching.py
+++ b/tests/unit/test_prompt_caching.py
@@ -3,10 +3,13 @@ from types import SimpleNamespace
 
 from agent.core.model_ids import HF_ROUTER_BASE_URL
 from agent.core.prompt_caching import (
+    HF_ROUTER_SESSION_ID_HEADER,
     router_session_id_for,
     with_prompt_cache_params,
     with_prompt_caching,
 )
+
+BILLING_SESSION_ID = "00000000-0000-4000-8000-000000000001"
 
 
 def _anthropic_fal_params() -> dict:
@@ -195,37 +198,61 @@ def test_prompt_caching_is_noop_for_non_router_fal_model():
     assert cached_messages is messages
 
 
-def test_prompt_cache_params_add_session_id_for_fal_router_model():
+def test_prompt_cache_params_add_session_id_header_for_fal_router_model():
     llm_params = _anthropic_fal_params()
 
-    cached_params = with_prompt_cache_params(llm_params, session_id="session-1")
+    cached_params = with_prompt_cache_params(llm_params, session_id=BILLING_SESSION_ID)
 
     assert cached_params is not llm_params
-    assert cached_params["extra_body"] == {
-        "session_id": "session-1",
-        "cache_control": {"type": "ephemeral"},
+    assert cached_params["extra_headers"] == {
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID
     }
+    assert cached_params["extra_body"] == {"cache_control": {"type": "ephemeral"}}
+    assert "extra_headers" not in llm_params
     assert "extra_body" not in llm_params
 
 
-def test_prompt_cache_params_adds_session_id_for_novita_router_model():
+def test_prompt_cache_params_adds_session_id_header_for_novita_router_model():
     llm_params = _kimi_novita_params()
 
-    cached_params = with_prompt_cache_params(llm_params, session_id="session-1")
+    cached_params = with_prompt_cache_params(llm_params, session_id=BILLING_SESSION_ID)
 
     assert cached_params is not llm_params
-    assert cached_params["extra_body"] == {"session_id": "session-1"}
+    assert cached_params["extra_headers"] == {
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID
+    }
+    assert "extra_body" not in cached_params
+    assert "extra_headers" not in llm_params
     assert "extra_body" not in llm_params
 
 
-def test_prompt_cache_params_adds_session_id_for_cerebras_router_model():
+def test_prompt_cache_params_adds_session_id_header_for_cerebras_router_model():
     llm_params = _gpt_oss_cerebras_params()
 
-    cached_params = with_prompt_cache_params(llm_params, session_id="session-1")
+    cached_params = with_prompt_cache_params(llm_params, session_id=BILLING_SESSION_ID)
 
     assert cached_params is not llm_params
-    assert cached_params["extra_body"] == {"session_id": "session-1"}
+    assert cached_params["extra_headers"] == {
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID
+    }
+    assert "extra_body" not in cached_params
+    assert "extra_headers" not in llm_params
     assert "extra_body" not in llm_params
+
+
+def test_prompt_cache_params_merges_existing_headers():
+    llm_params = {
+        **_kimi_novita_params(),
+        "extra_headers": {"X-Existing": "1"},
+    }
+
+    cached_params = with_prompt_cache_params(llm_params, session_id=BILLING_SESSION_ID)
+
+    assert cached_params["extra_headers"] == {
+        "X-Existing": "1",
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID,
+    }
+    assert llm_params["extra_headers"] == {"X-Existing": "1"}
 
 
 def test_router_session_id_prefers_billing_window_id():
@@ -233,10 +260,10 @@ def test_router_session_id_prefers_billing_window_id():
         router_session_id_for(
             SimpleNamespace(
                 session_id="session-1",
-                inference_billing_session_id="session-1:usage:window-1",
+                inference_billing_session_id=BILLING_SESSION_ID,
             )
         )
-        == "session-1:usage:window-1"
+        == BILLING_SESSION_ID
     )
     assert router_session_id_for(SimpleNamespace(session_id="session-1")) == "session-1"
 
@@ -253,12 +280,14 @@ def test_prompt_cache_params_merges_gpt55_cache_hints():
         "extra_body": {"reasoning_effort": "high"},
     }
 
-    cached_params = with_prompt_cache_params(llm_params, session_id="session-1")
+    cached_params = with_prompt_cache_params(llm_params, session_id=BILLING_SESSION_ID)
 
+    assert cached_params["extra_headers"] == {
+        HF_ROUTER_SESSION_ID_HEADER: BILLING_SESSION_ID
+    }
     assert cached_params["extra_body"] == {
         "reasoning_effort": "high",
-        "session_id": "session-1",
-        "prompt_cache_key": "session-1",
+        "prompt_cache_key": BILLING_SESSION_ID,
         "prompt_cache_retention": "24h",
     }
     assert llm_params["extra_body"] == {"reasoning_effort": "high"}

--- a/tests/unit/test_prompt_caching.py
+++ b/tests/unit/test_prompt_caching.py
@@ -1,7 +1,12 @@
 from litellm import Message
+from types import SimpleNamespace
 
 from agent.core.model_ids import HF_ROUTER_BASE_URL
-from agent.core.prompt_caching import with_prompt_cache_params, with_prompt_caching
+from agent.core.prompt_caching import (
+    router_session_id_for,
+    with_prompt_cache_params,
+    with_prompt_caching,
+)
 
 
 def _anthropic_fal_params() -> dict:
@@ -221,6 +226,19 @@ def test_prompt_cache_params_adds_session_id_for_cerebras_router_model():
     assert cached_params is not llm_params
     assert cached_params["extra_body"] == {"session_id": "session-1"}
     assert "extra_body" not in llm_params
+
+
+def test_router_session_id_prefers_billing_window_id():
+    assert (
+        router_session_id_for(
+            SimpleNamespace(
+                session_id="session-1",
+                inference_billing_session_id="session-1:usage:window-1",
+            )
+        )
+        == "session-1:usage:window-1"
+    )
+    assert router_session_id_for(SimpleNamespace(session_id="session-1")) == "session-1"
 
 
 def test_prompt_cache_params_adds_anthropic_cache_control_without_session_id():

--- a/tests/unit/test_prompt_caching.py
+++ b/tests/unit/test_prompt_caching.py
@@ -18,6 +18,20 @@ def _gpt55_fal_params() -> dict:
     }
 
 
+def _kimi_novita_params() -> dict:
+    return {
+        "model": "openai/moonshotai/Kimi-K2.6:novita",
+        "api_base": HF_ROUTER_BASE_URL,
+    }
+
+
+def _gpt_oss_cerebras_params() -> dict:
+    return {
+        "model": "openai/openai/gpt-oss-120b:cerebras",
+        "api_base": HF_ROUTER_BASE_URL,
+    }
+
+
 def test_prompt_caching_marks_system_prefix_and_tools_for_fal_router_model():
     messages = [
         Message(role="system", content="stable system prompt"),
@@ -186,6 +200,26 @@ def test_prompt_cache_params_add_session_id_for_fal_router_model():
         "session_id": "session-1",
         "cache_control": {"type": "ephemeral"},
     }
+    assert "extra_body" not in llm_params
+
+
+def test_prompt_cache_params_adds_session_id_for_novita_router_model():
+    llm_params = _kimi_novita_params()
+
+    cached_params = with_prompt_cache_params(llm_params, session_id="session-1")
+
+    assert cached_params is not llm_params
+    assert cached_params["extra_body"] == {"session_id": "session-1"}
+    assert "extra_body" not in llm_params
+
+
+def test_prompt_cache_params_adds_session_id_for_cerebras_router_model():
+    llm_params = _gpt_oss_cerebras_params()
+
+    cached_params = with_prompt_cache_params(llm_params, session_id="session-1")
+
+    assert cached_params is not llm_params
+    assert cached_params["extra_body"] == {"session_id": "session-1"}
     assert "extra_body" not in llm_params
 
 

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -19,7 +19,12 @@ if str(_BACKEND_DIR) not in sys.path:
 from agent.core.model_ids import KIMI_K26_MODEL_ID  # noqa: E402
 from agent.core.session_persistence import NoopSessionStore  # noqa: E402
 from agent.core.usage_thresholds import USAGE_THRESHOLD_TOOL_NAME  # noqa: E402
-from session_manager import AgentSession, SessionManager  # noqa: E402
+from session_manager import (  # noqa: E402
+    INFERENCE_BILLING_SESSION_ID_MAX_LENGTH,
+    AgentSession,
+    SessionManager,
+    new_inference_billing_session_id,
+)
 
 
 class FakeRuntimeSession:
@@ -144,6 +149,16 @@ def _runtime_agent_session(
         hf_token=hf_token,
         user_plan=user_plan,
     )
+
+
+def test_inference_billing_session_id_is_router_safe_for_long_agent_session_ids():
+    billing_session_id = new_inference_billing_session_id(
+        "s" * 300,
+        datetime(2026, 6, 5, 12, 30, tzinfo=UTC),
+    )
+
+    assert len(billing_session_id) <= INFERENCE_BILLING_SESSION_ID_MAX_LENGTH
+    assert ":usage:20260605T123000000000Z:" in billing_session_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -153,6 +153,8 @@ async def test_reset_session_usage_window_updates_runtime_and_store():
     agent_session = _runtime_agent_session("s1")
     manager.sessions["s1"] = agent_session
     started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
+    original_billing_session_id = agent_session.inference_billing_session_id
+    agent_session.usage_warning_spend_cache = {"spend_usd": 12.0}
 
     info = await manager.reset_session_usage_window(
         "s1",
@@ -160,15 +162,23 @@ async def test_reset_session_usage_window_updates_runtime_and_store():
     )
 
     assert agent_session.usage_window_started_at == started_at
+    assert agent_session.inference_billing_session_id is not None
+    assert agent_session.inference_billing_session_id != original_billing_session_id
+    assert agent_session.inference_billing_session_id.startswith("s1:usage:")
+    assert (
+        agent_session.session.inference_billing_session_id
+        == agent_session.inference_billing_session_id
+    )
+    assert agent_session.usage_warning_spend_cache == {}
     assert info is not None
     assert info["usage_window_started_at"] == started_at.isoformat()
-    assert store.updated_fields[-1] == (
-        "s1",
-        {
-            "usage_window_started_at": started_at,
-            "last_active_at": agent_session.last_active_at,
-        },
-    )
+    session_id, fields = store.updated_fields[-1]
+    assert session_id == "s1"
+    assert fields == {
+        "usage_window_started_at": started_at,
+        "inference_billing_session_id": agent_session.inference_billing_session_id,
+        "last_active_at": agent_session.last_active_at,
+    }
 
 
 def test_usage_threshold_pending_approval_serializes_and_restores():

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -153,23 +153,19 @@ async def test_reset_session_usage_window_updates_runtime_and_store():
     agent_session = _runtime_agent_session("s1")
     manager.sessions["s1"] = agent_session
     started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
-    baseline = {"captured_at": started_at, "total_usd": 1.25}
 
     info = await manager.reset_session_usage_window(
         "s1",
         started_at=started_at,
-        baseline=baseline,
     )
 
     assert agent_session.usage_window_started_at == started_at
-    assert agent_session.usage_window_baseline == baseline
     assert info is not None
     assert info["usage_window_started_at"] == started_at.isoformat()
     assert store.updated_fields[-1] == (
         "s1",
         {
             "usage_window_started_at": started_at,
-            "usage_window_baseline": baseline,
             "last_active_at": agent_session.last_active_at,
         },
     )
@@ -225,6 +221,26 @@ def test_usage_spend_prefers_hf_current_session_over_telemetry():
     )
 
     assert spend == 7.5
+    assert source == "hf_billing_current_session"
+
+
+def test_usage_spend_combines_hf_inference_with_telemetry_estimates():
+    spend, source = SessionManager._usage_spend_from_response(
+        {
+            "hf_account": {
+                "current_session": {
+                    "inference_providers_usd": 7.5,
+                },
+            },
+            "session": {
+                "total_usd": 99.0,
+                "hf_jobs_estimated_usd": 1.25,
+                "sandbox_estimated_usd": 0.5,
+            },
+        }
+    )
+
+    assert spend == 9.25
     assert source == "hf_billing_current_session"
 
 

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,7 +21,6 @@ from agent.core.model_ids import KIMI_K26_MODEL_ID  # noqa: E402
 from agent.core.session_persistence import NoopSessionStore  # noqa: E402
 from agent.core.usage_thresholds import USAGE_THRESHOLD_TOOL_NAME  # noqa: E402
 from session_manager import (  # noqa: E402
-    INFERENCE_BILLING_SESSION_ID_MAX_LENGTH,
     AgentSession,
     SessionManager,
     new_inference_billing_session_id,
@@ -151,14 +151,31 @@ def _runtime_agent_session(
     )
 
 
-def test_inference_billing_session_id_is_router_safe_for_long_agent_session_ids():
+def test_inference_billing_session_id_is_uuid_for_long_agent_session_ids():
     billing_session_id = new_inference_billing_session_id(
         "s" * 300,
         datetime(2026, 6, 5, 12, 30, tzinfo=UTC),
     )
 
-    assert len(billing_session_id) <= INFERENCE_BILLING_SESSION_ID_MAX_LENGTH
-    assert ":usage:20260605T123000000000Z:" in billing_session_id
+    assert str(uuid.UUID(billing_session_id)) == billing_session_id
+
+
+def test_agent_session_replaces_non_uuid_inference_billing_session_id():
+    runtime_session = FakeRuntimeSession()
+    agent_session = AgentSession(
+        session_id="s1",
+        session=runtime_session,  # type: ignore[arg-type]
+        tool_router=object(),  # type: ignore[arg-type]
+        submission_queue=asyncio.Queue(),
+        inference_billing_session_id="not-a-uuid",
+    )
+
+    assert str(uuid.UUID(agent_session.inference_billing_session_id)) == (
+        agent_session.inference_billing_session_id
+    )
+    assert runtime_session.inference_billing_session_id == (
+        agent_session.inference_billing_session_id
+    )
 
 
 @pytest.mark.asyncio
@@ -179,7 +196,9 @@ async def test_reset_session_usage_window_updates_runtime_and_store():
     assert agent_session.usage_window_started_at == started_at
     assert agent_session.inference_billing_session_id is not None
     assert agent_session.inference_billing_session_id != original_billing_session_id
-    assert agent_session.inference_billing_session_id.startswith("s1:usage:")
+    assert str(uuid.UUID(agent_session.inference_billing_session_id)) == (
+        agent_session.inference_billing_session_id
+    )
     assert (
         agent_session.session.inference_billing_session_id
         == agent_session.inference_billing_session_id

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -310,6 +310,7 @@ def _agent_session(session_id, user_id, events):
     return SimpleNamespace(
         session_id=session_id,
         user_id=user_id,
+        inference_billing_session_id=f"{session_id}:usage:window-1",
         session=SimpleNamespace(logged_events=events),
     )
 
@@ -451,6 +452,7 @@ async def test_hf_account_usage_uses_session_endpoint_for_current_session(
                 user_id="owner",
                 created_at=session_created_at,
                 usage_window_started_at=usage_window_started_at,
+                inference_billing_session_id="s1:usage:window-1",
                 session=SimpleNamespace(logged_events=[]),
             )
         }
@@ -480,7 +482,12 @@ async def test_hf_account_usage_uses_session_endpoint_for_current_session(
                 {
                     "period": "2026-06-01T00:00:00.000Z",
                     "sessions": [
-                        {"id": "s1", "requestCount": 3, "costCents": 125},
+                        {
+                            "id": "s1:usage:window-1",
+                            "requestCount": 3,
+                            "costCents": 125,
+                        },
+                        {"id": "s1", "requestCount": 11, "costCents": 500},
                         {"id": "other", "requestCount": 9, "costCents": 999},
                     ],
                 }
@@ -534,6 +541,7 @@ async def test_hf_account_usage_reports_session_endpoint_unavailable(monkeypatch
                 user_id="owner",
                 created_at=datetime(2026, 6, 5, 12, 0, tzinfo=UTC),
                 usage_window_started_at=usage_window_started_at,
+                inference_billing_session_id="s1:usage:window-1",
                 session=SimpleNamespace(logged_events=[]),
             )
         }
@@ -574,7 +582,12 @@ async def test_hf_account_usage_reports_session_endpoint_unavailable(monkeypatch
 @pytest.mark.asyncio
 async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
-    store = _MetadataStore({"created_at": session_created_at})
+    store = _MetadataStore(
+        {
+            "created_at": session_created_at,
+            "inference_billing_session_id": "s1:usage:window-1",
+        }
+    )
     manager = _Manager({}, store=store)
     usage_v2_calls = []
     session_usage_calls = []
@@ -632,6 +645,7 @@ async def test_usage_response_loads_only_session_events(monkeypatch):
                 session_id="s1",
                 user_id="owner",
                 created_at=session_created_at,
+                inference_billing_session_id="s1:usage:window-1",
                 session=SimpleNamespace(logged_events=[]),
             )
         },

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -532,7 +532,9 @@ async def test_hf_account_usage_uses_session_endpoint_for_current_session(
 
 
 @pytest.mark.asyncio
-async def test_hf_account_usage_reports_session_endpoint_unavailable(monkeypatch):
+async def test_hf_account_usage_keeps_account_available_when_session_endpoint_fails(
+    monkeypatch,
+):
     usage_window_started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
     manager = _Manager(
         {
@@ -576,7 +578,7 @@ async def test_hf_account_usage_reports_session_endpoint_unavailable(monkeypatch
     assert usage["hf_account"]["available"] is True
     assert usage["hf_account"]["current_session"] is None
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 2.0
-    assert usage["hf_account"]["error"] == "session_billing_usage_unavailable"
+    assert "error" not in usage["hf_account"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -19,6 +19,8 @@ from usage import (  # noqa: E402
 )
 from agent.core import session_persistence  # noqa: E402
 
+BILLING_SESSION_ID = "00000000-0000-4000-8000-000000000001"
+
 
 def _event(event_type, data=None, created_at="2026-06-01T12:00:00+00:00"):
     return {
@@ -310,7 +312,7 @@ def _agent_session(session_id, user_id, events):
     return SimpleNamespace(
         session_id=session_id,
         user_id=user_id,
-        inference_billing_session_id=f"{session_id}:usage:window-1",
+        inference_billing_session_id=BILLING_SESSION_ID,
         session=SimpleNamespace(logged_events=events),
     )
 
@@ -452,7 +454,7 @@ async def test_hf_account_usage_uses_session_endpoint_for_current_session(
                 user_id="owner",
                 created_at=session_created_at,
                 usage_window_started_at=usage_window_started_at,
-                inference_billing_session_id="s1:usage:window-1",
+                inference_billing_session_id=BILLING_SESSION_ID,
                 session=SimpleNamespace(logged_events=[]),
             )
         }
@@ -483,7 +485,7 @@ async def test_hf_account_usage_uses_session_endpoint_for_current_session(
                     "period": "2026-06-01T00:00:00.000Z",
                     "sessions": [
                         {
-                            "id": "s1:usage:window-1",
+                            "id": BILLING_SESSION_ID,
                             "requestCount": 3,
                             "costCents": 125,
                         },
@@ -543,7 +545,7 @@ async def test_hf_account_usage_keeps_account_available_when_session_endpoint_fa
                 user_id="owner",
                 created_at=datetime(2026, 6, 5, 12, 0, tzinfo=UTC),
                 usage_window_started_at=usage_window_started_at,
-                inference_billing_session_id="s1:usage:window-1",
+                inference_billing_session_id=BILLING_SESSION_ID,
                 session=SimpleNamespace(logged_events=[]),
             )
         }
@@ -587,7 +589,7 @@ async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
     store = _MetadataStore(
         {
             "created_at": session_created_at,
-            "inference_billing_session_id": "s1:usage:window-1",
+            "inference_billing_session_id": BILLING_SESSION_ID,
         }
     )
     manager = _Manager({}, store=store)
@@ -647,7 +649,7 @@ async def test_usage_response_loads_only_session_events(monkeypatch):
                 session_id="s1",
                 user_id="owner",
                 created_at=session_created_at,
-                inference_billing_session_id="s1:usage:window-1",
+                inference_billing_session_id=BILLING_SESSION_ID,
                 session=SimpleNamespace(logged_events=[]),
             )
         },

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -12,6 +12,7 @@ if str(_BACKEND_DIR) not in sys.path:
 from usage import (  # noqa: E402
     USAGE_EVENT_TYPES,
     _account_bucket_from_billing_usage,
+    _session_bucket_from_inference_session_usage,
     aggregate_usage_events,
     build_usage_response,
     resolve_usage_windows,
@@ -204,6 +205,60 @@ def test_account_bucket_from_hf_billing_usage_v2():
     assert usage["hf_jobs_minutes"] == 3.5
 
 
+def test_session_bucket_from_inference_session_usage_sums_periods():
+    usage = _session_bucket_from_inference_session_usage(
+        {
+            "currency": "USD",
+            "periods": [
+                {
+                    "period": "2026-06-01T00:00:00.000Z",
+                    "sessions": [
+                        {"id": "s1", "requestCount": 2, "costCents": 123.4},
+                        {"id": "s2", "requestCount": 20, "costCents": 999},
+                    ],
+                },
+                {
+                    "period": "2026-07-01T00:00:00.000Z",
+                    "sessions": [
+                        {"id": "s1", "requestCount": 3, "costCents": 76.6},
+                    ],
+                },
+            ],
+        },
+        session_id="s1",
+        window_start=datetime(2026, 6, 5, 12, 0, tzinfo=UTC),
+        window_end=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+        timezone="UTC",
+    )
+
+    assert usage["inference_providers_usd"] == 2.0
+    assert usage["inference_provider_requests"] == 5
+    assert usage["hf_jobs_usd"] == 0.0
+    assert usage["total_usd"] == 2.0
+
+
+def test_session_bucket_from_inference_session_usage_handles_no_matching_session():
+    usage = _session_bucket_from_inference_session_usage(
+        {
+            "currency": "USD",
+            "periods": [
+                {
+                    "period": "2026-06-01T00:00:00.000Z",
+                    "sessions": [{"id": "other", "requestCount": 1, "costCents": 50}],
+                },
+            ],
+        },
+        session_id="s1",
+        window_start=datetime(2026, 6, 5, 12, 0, tzinfo=UTC),
+        window_end=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+        timezone="UTC",
+    )
+
+    assert usage["inference_providers_usd"] == 0.0
+    assert usage["inference_provider_requests"] == 0
+    assert usage["total_usd"] == 0.0
+
+
 def test_usage_windows_respect_browser_timezone():
     windows = resolve_usage_windows(
         "America/Los_Angeles",
@@ -384,7 +439,9 @@ async def test_hf_account_usage_reports_billing_unavailable_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch):
+async def test_hf_account_usage_uses_session_endpoint_for_current_session(
+    monkeypatch,
+):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
     usage_window_started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
     manager = _Manager(
@@ -398,18 +455,15 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
             )
         }
     )
-    calls = []
+    usage_v2_calls = []
+    session_usage_calls = []
 
-    async def fake_fetch(_token, *, start, end):
-        calls.append((start, end))
-        if start == usage_window_started_at:
-            used_nano = 500_000_000
-        else:
-            used_nano = 2_000_000_000
+    async def fake_usage_v2(_token, *, start, end):
+        usage_v2_calls.append((start, end))
         return {
             "usage": {
                 "inferenceProviders": {
-                    "usedNanoUsd": used_nano,
+                    "usedNanoUsd": 2_000_000_000,
                     "includedNanoUsd": 2_000_000_000,
                     "limitNanoUsd": 5_000_000_000,
                     "numRequests": 4,
@@ -418,7 +472,23 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
             }
         }
 
-    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+    async def fake_session_usage(_token, *, start, end):
+        session_usage_calls.append((start, end))
+        return {
+            "currency": "USD",
+            "periods": [
+                {
+                    "period": "2026-06-01T00:00:00.000Z",
+                    "sessions": [
+                        {"id": "s1", "requestCount": 3, "costCents": 125},
+                        {"id": "other", "requestCount": 9, "costCents": 999},
+                    ],
+                }
+            ],
+        }
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_usage_v2)
+    monkeypatch.setattr("usage._fetch_hf_inference_session_usage", fake_session_usage)
 
     usage = await build_usage_response(
         manager,
@@ -430,7 +500,8 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
     )
 
     assert usage["hf_account"]["available"] is True
-    assert usage["hf_account"]["current_session"]["inference_providers_usd"] == 0.5
+    assert usage["hf_account"]["current_session"]["inference_providers_usd"] == 1.25
+    assert usage["hf_account"]["current_session"]["inference_provider_requests"] == 3
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 2.0
     assert usage["hf_account"]["inference_providers_credits"] == {
         "included_usd": 2.0,
@@ -442,16 +513,20 @@ async def test_hf_account_usage_uses_usage_window_for_current_delta(monkeypatch)
         "period_start": None,
         "period_end": None,
     }
-    assert {start for start, _ in calls} == {
-        datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
-        usage_window_started_at,
-    }
+    assert usage_v2_calls == [
+        (
+            datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+            datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+        )
+    ]
+    assert session_usage_calls == [
+        (usage_window_started_at, datetime(2026, 6, 5, 13, 0, tzinfo=UTC))
+    ]
 
 
 @pytest.mark.asyncio
-async def test_hf_account_usage_uses_baseline_for_current_delta(monkeypatch):
+async def test_hf_account_usage_reports_session_endpoint_unavailable(monkeypatch):
     usage_window_started_at = datetime(2026, 6, 5, 12, 30, tzinfo=UTC)
-    month_start = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
     manager = _Manager(
         {
             "s1": SimpleNamespace(
@@ -459,44 +534,27 @@ async def test_hf_account_usage_uses_baseline_for_current_delta(monkeypatch):
                 user_id="owner",
                 created_at=datetime(2026, 6, 5, 12, 0, tzinfo=UTC),
                 usage_window_started_at=usage_window_started_at,
-                usage_window_baseline={
-                    "captured_at": usage_window_started_at,
-                    "month_start": month_start,
-                    "total_usd": 2.5,
-                    "inference_providers_usd": 2.0,
-                    "hf_jobs_usd": 0.5,
-                    "inference_provider_requests": 10,
-                    "hf_jobs_minutes": 4.0,
-                },
                 session=SimpleNamespace(logged_events=[]),
             )
         }
     )
-    calls = []
 
-    async def fake_fetch(_token, *, start, end):
-        calls.append((start, end))
-        if start == month_start:
-            return {
-                "usage": {
-                    "inferenceProviders": {
-                        "usedNanoUsd": 2_000_000_000,
-                        "numRequests": 10,
-                    },
-                    "jobs": {"usedMicroUsd": 500_000, "totalMinutes": 4.0},
-                }
-            }
+    async def fake_usage_v2(_token, *, start, end):
         return {
             "usage": {
                 "inferenceProviders": {
-                    "usedNanoUsd": 5_000_000_000,
-                    "numRequests": 99,
+                    "usedNanoUsd": 2_000_000_000,
+                    "numRequests": 10,
                 },
-                "jobs": {"usedMicroUsd": 0, "totalMinutes": 0},
+                "jobs": {"usedMicroUsd": 500_000, "totalMinutes": 4.0},
             }
         }
 
-    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+    async def fake_session_usage(_token, *, start, end):
+        return None
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_usage_v2)
+    monkeypatch.setattr("usage._fetch_hf_inference_session_usage", fake_session_usage)
 
     usage = await build_usage_response(
         manager,
@@ -507,9 +565,10 @@ async def test_hf_account_usage_uses_baseline_for_current_delta(monkeypatch):
         now=datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
     )
 
-    assert usage["hf_account"]["current_session"]["total_usd"] == 0.0
-    assert usage["hf_account"]["current_session"]["inference_provider_requests"] == 0
-    assert usage_window_started_at not in {start for start, _ in calls}
+    assert usage["hf_account"]["available"] is True
+    assert usage["hf_account"]["current_session"] is None
+    assert usage["hf_account"]["month"]["inference_providers_usd"] == 2.0
+    assert usage["hf_account"]["error"] == "session_billing_usage_unavailable"
 
 
 @pytest.mark.asyncio
@@ -517,10 +576,11 @@ async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
     session_created_at = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
     store = _MetadataStore({"created_at": session_created_at})
     manager = _Manager({}, store=store)
-    calls = []
+    usage_v2_calls = []
+    session_usage_calls = []
 
-    async def fake_fetch(_token, *, start, end):
-        calls.append((start, end))
+    async def fake_usage_v2(_token, *, start, end):
+        usage_v2_calls.append((start, end))
         return {
             "usage": {
                 "inferenceProviders": {
@@ -532,7 +592,12 @@ async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
             }
         }
 
-    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+    async def fake_session_usage(_token, *, start, end):
+        session_usage_calls.append((start, end))
+        return {"currency": "USD", "periods": []}
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_usage_v2)
+    monkeypatch.setattr("usage._fetch_hf_inference_session_usage", fake_session_usage)
 
     usage = await build_usage_response(
         manager,
@@ -546,10 +611,15 @@ async def test_hf_account_usage_falls_back_to_persisted_created_at(monkeypatch):
     assert usage["hf_account"]["current_session"]["window_start"] == (
         "2026-06-05T12:00:00Z"
     )
-    assert {start for start, _ in calls} == {
-        datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
-        session_created_at,
-    }
+    assert usage_v2_calls == [
+        (
+            datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+            datetime(2026, 6, 5, 13, 0, tzinfo=UTC),
+        )
+    ]
+    assert session_usage_calls == [
+        (session_created_at, datetime(2026, 6, 5, 13, 0, tzinfo=UTC))
+    ]
 
 
 @pytest.mark.asyncio
@@ -567,10 +637,11 @@ async def test_usage_response_loads_only_session_events(monkeypatch):
         },
         store=store,
     )
-    billing_starts = []
+    usage_v2_starts = []
+    session_usage_starts = []
 
-    async def fake_fetch(_token, *, start, end):
-        billing_starts.append(start)
+    async def fake_usage_v2(_token, *, start, end):
+        usage_v2_starts.append(start)
         return {
             "usage": {
                 "inferenceProviders": {
@@ -582,7 +653,12 @@ async def test_usage_response_loads_only_session_events(monkeypatch):
             }
         }
 
-    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_fetch)
+    async def fake_session_usage(_token, *, start, end):
+        session_usage_starts.append(start)
+        return {"currency": "USD", "periods": []}
+
+    monkeypatch.setattr("usage._fetch_hf_billing_usage_v2", fake_usage_v2)
+    monkeypatch.setattr("usage._fetch_hf_inference_session_usage", fake_session_usage)
 
     usage = await build_usage_response(
         manager,
@@ -594,9 +670,8 @@ async def test_usage_response_loads_only_session_events(monkeypatch):
     )
 
     assert store.calls == [("owner", {"session_id": "s1", "start": None, "end": None})]
-    assert set(billing_starts) == {
-        datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
-        session_created_at,
-    }
-    assert datetime(2026, 6, 5, 0, 0, tzinfo=UTC) not in billing_starts
+    assert usage_v2_starts == [datetime(2026, 6, 1, 0, 0, tzinfo=UTC)]
+    assert session_usage_starts == [session_created_at]
+    assert datetime(2026, 6, 5, 0, 0, tzinfo=UTC) not in usage_v2_starts
+    assert datetime(2026, 6, 5, 0, 0, tzinfo=UTC) not in session_usage_starts
     assert usage["hf_account"]["month"]["inference_providers_usd"] == 0.0


### PR DESCRIPTION
Replace current-session inference billing estimates with the Hugging Face session usage endpoint and ensure HF Router requests carry session IDs across providers.

Co-authored-by: OpenAI Codex <codex@openai.com>
