### PR TITLE
[codex] Instrument dataset usage analytics

### DIFF
--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -21,6 +21,7 @@ from agent.core.usage_thresholds import (
     USAGE_THRESHOLD_TOOL_NAME,
     USAGE_WARNING_FIRST_THRESHOLD_USD,
 )
+from agent.core.usage_metrics import summarize_usage_events, usage_metric_scalar_fields
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +160,7 @@ class Session:
         self.auto_approval_estimated_spend_usd: float = 0.0
         self.usage_warning_next_threshold_usd: float = USAGE_WARNING_FIRST_THRESHOLD_USD
         self.usage_threshold_checker: Any | None = None
+        self.usage_billing_snapshot: dict[str, Any] | None = None
 
         # Session trajectory logging
         self.logged_events: list[dict] = []
@@ -384,6 +386,9 @@ class Session:
             self.auto_approval_estimated_spend_usd + float(amount_usd), 4
         )
 
+    def set_usage_billing_snapshot(self, snapshot: dict[str, Any] | None) -> None:
+        self.usage_billing_snapshot = snapshot
+
     @property
     def auto_approval_remaining_usd(self) -> float | None:
         if self.auto_approval_cost_cap_usd is None:
@@ -462,6 +467,7 @@ class Session:
         self._last_heartbeat_ts = None
         self.pending_approval = None
         self.auto_approval_estimated_spend_usd = 0.0
+        self.usage_billing_snapshot = None
         self.reset_cancel()
 
         # Previous-session metadata is intentionally included for event
@@ -530,6 +536,12 @@ class Session:
             for e in self.logged_events
             if e.get("event_type") == "llm_call"
         )
+        usage_metrics = summarize_usage_events(
+            self.logged_events,
+            session_id=self.session_id,
+            hf_billing_snapshot=self.usage_billing_snapshot,
+        )
+        usage_scalar_fields = usage_metric_scalar_fields(usage_metrics)
         return {
             "session_id": self.session_id,
             "user_id": self.user_id,
@@ -538,6 +550,8 @@ class Session:
             "session_end_time": datetime.now().isoformat(),
             "model_name": self.config.model_name,
             "total_cost_usd": total_cost_usd,
+            **usage_scalar_fields,
+            "usage_metrics": usage_metrics,
             "messages": [msg.model_dump() for msg in self.context_manager.items],
             "events": self.logged_events,
             "tools": tools,

--- a/agent/core/session_persistence.py
+++ b/agent/core/session_persistence.py
@@ -22,6 +22,7 @@ SCHEMA_VERSION = 1
 MAX_BSON_BYTES = 15 * 1024 * 1024
 USAGE_EVENT_TYPES = (
     "llm_call",
+    "hf_job_submit",
     "hf_job_complete",
     "sandbox_create",
     "sandbox_destroy",

--- a/agent/core/session_uploader.py
+++ b/agent/core/session_uploader.py
@@ -26,6 +26,12 @@ from typing import Any
 
 from dotenv import load_dotenv
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agent.core.usage_metrics import usage_metric_scalar_fields  # noqa: E402
+
 load_dotenv()
 
 # Token resolution for the org KPI dataset. Fallback chain (least-privilege
@@ -258,12 +264,17 @@ def _scrub_session_for_upload(data: dict) -> dict:
     scrubbed["messages"] = _scrub(data.get("messages") or [])
     scrubbed["events"] = _scrub(data.get("events") or [])
     scrubbed["tools"] = _scrub(data.get("tools") or [])
+    scrubbed["usage_metrics"] = _scrub(data.get("usage_metrics") or {})
     return scrubbed
 
 
 def _write_row_payload(data: dict, tmp_path: str) -> None:
     """Single-row JSONL (existing format) — used by KPI scheduler."""
     scrubbed = _scrub_session_for_upload(data)
+    usage_metrics = scrubbed.get("usage_metrics") or {}
+    if not isinstance(usage_metrics, dict):
+        usage_metrics = {}
+    usage_scalar_fields = usage_metric_scalar_fields(usage_metrics)
     session_row = {
         "session_id": data["session_id"],
         "user_id": data.get("user_id"),
@@ -274,7 +285,10 @@ def _write_row_payload(data: dict, tmp_path: str) -> None:
         "messages": json.dumps(scrubbed["messages"]),
         "events": json.dumps(scrubbed["events"]),
         "tools": json.dumps(scrubbed["tools"]),
+        "usage_metrics": json.dumps(usage_metrics),
     }
+    for key, value in usage_scalar_fields.items():
+        session_row[key] = data.get(key, value)
 
     with open(tmp_path, "w") as tmp:
         json.dump(session_row, tmp)

--- a/agent/core/usage_metrics.py
+++ b/agent/core/usage_metrics.py
@@ -1,0 +1,440 @@
+"""Pure usage/billing summaries for session trajectory analytics."""
+
+from collections import Counter, defaultdict
+from datetime import UTC, datetime, timedelta
+from math import isfinite
+from typing import Any
+
+from agent.core.cost_estimation import SPACE_PRICE_USD_PER_HOUR
+
+USAGE_METRICS_VERSION = 1
+BILLING_SCOPE_ACCOUNT_WINDOW_DELTA = "account_window_delta"
+
+_USAGE_SCALAR_KEYS = (
+    "usage_total_usd",
+    "usage_total_usd_source",
+    "usage_app_total_usd",
+    "usage_hf_billing_total_usd",
+    "usage_llm_calls",
+    "usage_total_tokens",
+    "usage_hf_job_submits",
+    "usage_hf_job_status_snapshots",
+    "usage_sandbox_creates",
+    "usage_sandbox_pairs",
+)
+
+
+def _coerce_float(value: Any) -> float:
+    if isinstance(value, bool) or value is None:
+        return 0.0
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return parsed if isfinite(parsed) else 0.0
+
+
+def _coerce_optional_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isfinite(parsed) else None
+
+
+def _coerce_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _round_usd(value: float) -> float:
+    return round(float(value or 0.0), 6)
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str) and value:
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def event_created_at(event: dict[str, Any]) -> datetime | None:
+    return _parse_timestamp(event.get("created_at") or event.get("timestamp"))
+
+
+def _event_data(event: dict[str, Any]) -> dict[str, Any]:
+    data = event.get("data") or {}
+    return data if isinstance(data, dict) else {}
+
+
+def _has_number(value: Any) -> bool:
+    return _coerce_optional_float(value) is not None
+
+
+def _counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return dict(sorted(counter.items()))
+
+
+def _empty_app_bucket(session_id: str | None) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "total_usd": 0.0,
+        "inference_usd": 0.0,
+        "hf_jobs_estimated_usd": 0.0,
+        "sandbox_estimated_usd": 0.0,
+        "llm_calls": 0,
+        "hf_jobs_count": 0,
+        "sandbox_count": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_tokens": 0,
+        "hf_jobs_billable_seconds_estimate": 0,
+        "sandbox_billable_seconds_estimate": 0,
+    }
+
+
+def _sandbox_id(event: dict[str, Any]) -> str | None:
+    sandbox_id = _event_data(event).get("sandbox_id")
+    return sandbox_id if isinstance(sandbox_id, str) and sandbox_id else None
+
+
+def _sandbox_duration_seconds(
+    create_event: dict[str, Any],
+    destroy_event: dict[str, Any],
+) -> int:
+    create_data = _event_data(create_event)
+    destroy_data = _event_data(destroy_event)
+    lifetime_s = _coerce_int(destroy_data.get("lifetime_s"))
+    if lifetime_s > 0:
+        return lifetime_s
+
+    create_at = event_created_at(create_event)
+    destroy_at = event_created_at(destroy_event)
+    if create_at is None or destroy_at is None:
+        return 0
+    create_latency_s = max(0, _coerce_int(create_data.get("create_latency_s")))
+    interval_start = create_at - timedelta(seconds=create_latency_s)
+    if destroy_at <= interval_start:
+        return 0
+    return int((destroy_at - interval_start).total_seconds())
+
+
+def _aggregate_sandbox_lifecycle(
+    lifecycle_events: list[tuple[int, dict[str, Any]]],
+) -> dict[str, Any]:
+    ordered_events = [
+        event
+        for _, event in sorted(
+            lifecycle_events,
+            key=lambda indexed: (
+                event_created_at(indexed[1]) is None,
+                event_created_at(indexed[1]) or datetime.min.replace(tzinfo=UTC),
+                indexed[0],
+            ),
+        )
+    ]
+    active_creates: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    matched_pairs = 0
+    unpaired_destroys = 0
+    estimated_usd = 0.0
+    billable_seconds = 0
+
+    for event in ordered_events:
+        event_type = event.get("event_type")
+        sandbox_id = _sandbox_id(event)
+        if sandbox_id is None:
+            continue
+        if event_type == "sandbox_create":
+            active_creates[sandbox_id].append(event)
+            continue
+        if event_type != "sandbox_destroy":
+            continue
+
+        creates = active_creates.get(sandbox_id)
+        if not creates:
+            unpaired_destroys += 1
+            continue
+
+        create_event = creates.pop()
+        if not creates:
+            active_creates.pop(sandbox_id, None)
+
+        hardware = str(_event_data(create_event).get("hardware") or "cpu-basic")
+        seconds = _sandbox_duration_seconds(create_event, event)
+        price_usd_per_hour = _coerce_float(SPACE_PRICE_USD_PER_HOUR.get(hardware, 0.0))
+        matched_pairs += 1
+        if price_usd_per_hour > 0:
+            billable_seconds += seconds
+        estimated_usd += price_usd_per_hour * (seconds / 3600)
+
+    return {
+        "matched_pairs": matched_pairs,
+        "unpaired_creates": sum(len(events) for events in active_creates.values()),
+        "unpaired_destroys": unpaired_destroys,
+        "estimated_usd": _round_usd(estimated_usd),
+        "billable_seconds_estimate": billable_seconds,
+    }
+
+
+def normalize_hf_billing_snapshot(snapshot: dict[str, Any] | None) -> dict[str, Any]:
+    hf_billing = snapshot.get("hf_billing") if isinstance(snapshot, dict) else None
+    hf_billing = hf_billing if isinstance(hf_billing, dict) else {}
+    current_session = hf_billing.get("current_session")
+    current_session = current_session if isinstance(current_session, dict) else None
+
+    sanitized_current = None
+    if current_session is not None:
+        sanitized_current = {
+            "window_start": current_session.get("window_start"),
+            "window_end": current_session.get("window_end"),
+            "timezone": current_session.get("timezone"),
+            "total_usd": _round_usd(_coerce_float(current_session.get("total_usd"))),
+            "inference_providers_usd": _round_usd(
+                _coerce_float(current_session.get("inference_providers_usd"))
+            ),
+            "hf_jobs_usd": _round_usd(
+                _coerce_float(current_session.get("hf_jobs_usd"))
+            ),
+            "inference_provider_requests": _coerce_int(
+                current_session.get("inference_provider_requests")
+            ),
+            "hf_jobs_minutes": round(
+                _coerce_float(current_session.get("hf_jobs_minutes")),
+                3,
+            ),
+        }
+
+    available = bool(hf_billing.get("available") and sanitized_current is not None)
+    return {
+        "billing_scope": BILLING_SCOPE_ACCOUNT_WINDOW_DELTA,
+        "hf_billing": {
+            "source": str(hf_billing.get("source") or "hf_billing_usage_v2"),
+            "available": available,
+            "error": None if available else hf_billing.get("error"),
+            "current_session": sanitized_current if available else None,
+        },
+    }
+
+
+def summarize_usage_events(
+    events: list[dict[str, Any]],
+    *,
+    session_id: str | None = None,
+    hf_billing_snapshot: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    app = _empty_app_bucket(session_id)
+    llm_by_kind: Counter[str] = Counter()
+    llm_by_model: Counter[str] = Counter()
+    job_statuses: Counter[str] = Counter()
+    job_submit_flavors: Counter[str] = Counter()
+    job_status_flavors: Counter[str] = Counter()
+    sandbox_hardware: Counter[str] = Counter()
+    lifecycle_events: list[tuple[int, dict[str, Any]]] = []
+
+    event_count = 0
+    events_without_timestamp = 0
+    llm_calls_with_cost_field = 0
+    llm_calls_with_nonzero_cost = 0
+    job_submits = 0
+    job_status_snapshots = 0
+    job_snapshots_with_estimated_cost = 0
+    job_snapshots_with_nonzero_estimated_cost = 0
+    sandbox_creates = 0
+    sandbox_destroys = 0
+    turn_complete_count = 0
+    assistant_stream_end_count = 0
+
+    for index, event in enumerate(events or []):
+        if not isinstance(event, dict):
+            continue
+        event_count += 1
+        if event_created_at(event) is None:
+            events_without_timestamp += 1
+
+        event_type = event.get("event_type")
+        data = _event_data(event)
+        if event_type == "llm_call":
+            app["llm_calls"] += 1
+            if "cost_usd" in data:
+                llm_calls_with_cost_field += 1
+            cost_usd = _coerce_float(data.get("cost_usd"))
+            if cost_usd > 0:
+                llm_calls_with_nonzero_cost += 1
+            app["inference_usd"] += cost_usd
+
+            prompt_tokens = _coerce_int(data.get("prompt_tokens"))
+            completion_tokens = _coerce_int(data.get("completion_tokens"))
+            cache_read_tokens = _coerce_int(data.get("cache_read_tokens"))
+            cache_creation_tokens = _coerce_int(data.get("cache_creation_tokens"))
+            total_tokens = _coerce_int(data.get("total_tokens")) or (
+                prompt_tokens
+                + completion_tokens
+                + cache_read_tokens
+                + cache_creation_tokens
+            )
+            app["prompt_tokens"] += prompt_tokens
+            app["completion_tokens"] += completion_tokens
+            app["cache_read_tokens"] += cache_read_tokens
+            app["cache_creation_tokens"] += cache_creation_tokens
+            app["total_tokens"] += total_tokens
+            llm_by_kind[str(data.get("kind") or "unknown")] += 1
+            llm_by_model[str(data.get("model") or "unknown")] += 1
+        elif event_type == "hf_job_submit":
+            job_submits += 1
+            job_submit_flavors[str(data.get("flavor") or "unknown")] += 1
+        elif event_type == "hf_job_complete":
+            job_status_snapshots += 1
+            app["hf_jobs_count"] += 1
+            estimated_cost = _coerce_float(data.get("estimated_cost_usd"))
+            app["hf_jobs_estimated_usd"] += estimated_cost
+            app["hf_jobs_billable_seconds_estimate"] += _coerce_int(
+                data.get("billable_seconds_estimate") or data.get("wall_time_s")
+            )
+            if _has_number(data.get("estimated_cost_usd")):
+                job_snapshots_with_estimated_cost += 1
+            if estimated_cost > 0:
+                job_snapshots_with_nonzero_estimated_cost += 1
+            job_statuses[str(data.get("final_status") or "unknown")] += 1
+            job_status_flavors[str(data.get("flavor") or "unknown")] += 1
+        elif event_type == "sandbox_create":
+            sandbox_creates += 1
+            sandbox_hardware[str(data.get("hardware") or "cpu-basic")] += 1
+            lifecycle_events.append((index, event))
+        elif event_type == "sandbox_destroy":
+            sandbox_destroys += 1
+            lifecycle_events.append((index, event))
+        elif event_type == "turn_complete":
+            turn_complete_count += 1
+        elif event_type == "assistant_stream_end":
+            assistant_stream_end_count += 1
+
+    sandbox = _aggregate_sandbox_lifecycle(lifecycle_events)
+    app["sandbox_count"] = sandbox["matched_pairs"]
+    app["sandbox_estimated_usd"] = sandbox["estimated_usd"]
+    app["sandbox_billable_seconds_estimate"] = sandbox["billable_seconds_estimate"]
+    app["inference_usd"] = _round_usd(app["inference_usd"])
+    app["hf_jobs_estimated_usd"] = _round_usd(app["hf_jobs_estimated_usd"])
+    app["total_usd"] = _round_usd(
+        app["inference_usd"]
+        + app["hf_jobs_estimated_usd"]
+        + app["sandbox_estimated_usd"]
+    )
+
+    billing = normalize_hf_billing_snapshot(hf_billing_snapshot)
+    current_billing = billing["hf_billing"]["current_session"]
+    hf_billing_total = None
+    if billing["hf_billing"]["available"] and current_billing is not None:
+        hf_billing_total = _round_usd(_coerce_float(current_billing.get("total_usd")))
+        usage_total = _round_usd(hf_billing_total + app["sandbox_estimated_usd"])
+        usage_total_source = "hf_billing_plus_sandbox_estimate"
+    else:
+        usage_total = app["total_usd"]
+        usage_total_source = "app_telemetry_fallback"
+
+    job_flavors = job_submit_flavors or job_status_flavors
+
+    return {
+        "version": USAGE_METRICS_VERSION,
+        "session_id": session_id,
+        "billing_scope": BILLING_SCOPE_ACCOUNT_WINDOW_DELTA,
+        "total_usd": usage_total,
+        "total_usd_source": usage_total_source,
+        "app_total_usd": app["total_usd"],
+        "hf_billing_total_usd": hf_billing_total,
+        "app_telemetry": app,
+        "hf_billing": billing["hf_billing"],
+        "llm": {
+            "calls": app["llm_calls"],
+            "calls_by_kind": _counter_dict(llm_by_kind),
+            "calls_by_model": _counter_dict(llm_by_model),
+            "prompt_tokens": app["prompt_tokens"],
+            "completion_tokens": app["completion_tokens"],
+            "cache_read_tokens": app["cache_read_tokens"],
+            "cache_creation_tokens": app["cache_creation_tokens"],
+            "total_tokens": app["total_tokens"],
+        },
+        "turns": {
+            "turn_complete_count": turn_complete_count,
+            "assistant_stream_end_count": assistant_stream_end_count,
+        },
+        "hf_jobs": {
+            "submits": job_submits,
+            "status_snapshots": job_status_snapshots,
+            "statuses": _counter_dict(job_statuses),
+            "flavors": _counter_dict(job_flavors),
+            "submit_flavors": _counter_dict(job_submit_flavors),
+            "status_snapshot_flavors": _counter_dict(job_status_flavors),
+            "estimated_usd": app["hf_jobs_estimated_usd"],
+            "billable_seconds_estimate": app["hf_jobs_billable_seconds_estimate"],
+            "snapshots_with_estimated_cost": job_snapshots_with_estimated_cost,
+            "snapshots_with_nonzero_estimated_cost": (
+                job_snapshots_with_nonzero_estimated_cost
+            ),
+        },
+        "sandboxes": {
+            "creates": sandbox_creates,
+            "destroys": sandbox_destroys,
+            "matched_pairs": sandbox["matched_pairs"],
+            "unpaired_creates": sandbox["unpaired_creates"],
+            "unpaired_destroys": sandbox["unpaired_destroys"],
+            "hardware": _counter_dict(sandbox_hardware),
+            "estimated_usd": app["sandbox_estimated_usd"],
+            "billable_seconds_estimate": app["sandbox_billable_seconds_estimate"],
+        },
+        "data_quality": {
+            "event_count": event_count,
+            "events_without_timestamp": events_without_timestamp,
+            "llm_calls_with_cost_field": llm_calls_with_cost_field,
+            "llm_calls_with_nonzero_cost": llm_calls_with_nonzero_cost,
+            "job_snapshots_with_estimated_cost": job_snapshots_with_estimated_cost,
+            "job_snapshots_missing_estimated_cost": (
+                job_status_snapshots - job_snapshots_with_estimated_cost
+            ),
+        },
+    }
+
+
+def usage_metric_scalar_fields(metrics: dict[str, Any]) -> dict[str, Any]:
+    app = metrics.get("app_telemetry") if isinstance(metrics, dict) else {}
+    llm = metrics.get("llm") if isinstance(metrics, dict) else {}
+    jobs = metrics.get("hf_jobs") if isinstance(metrics, dict) else {}
+    sandboxes = metrics.get("sandboxes") if isinstance(metrics, dict) else {}
+    values = {
+        "usage_total_usd": metrics.get("total_usd"),
+        "usage_total_usd_source": metrics.get("total_usd_source"),
+        "usage_app_total_usd": metrics.get("app_total_usd"),
+        "usage_hf_billing_total_usd": metrics.get("hf_billing_total_usd"),
+        "usage_llm_calls": app.get("llm_calls") if isinstance(app, dict) else None,
+        "usage_total_tokens": llm.get("total_tokens")
+        if isinstance(llm, dict)
+        else None,
+        "usage_hf_job_submits": (
+            jobs.get("submits") if isinstance(jobs, dict) else None
+        ),
+        "usage_hf_job_status_snapshots": (
+            jobs.get("status_snapshots") if isinstance(jobs, dict) else None
+        ),
+        "usage_sandbox_creates": (
+            sandboxes.get("creates") if isinstance(sandboxes, dict) else None
+        ),
+        "usage_sandbox_pairs": (
+            sandboxes.get("matched_pairs") if isinstance(sandboxes, dict) else None
+        ),
+    }
+    return {key: values.get(key) for key in _USAGE_SCALAR_KEYS}

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -906,6 +906,7 @@ async def record_pro_click(
         target=str(body.get("target") or "pro_pricing"),
     )
     if agent_session.session.config.save_sessions:
+        await session_manager.refresh_session_usage_metrics_snapshot(agent_session)
         agent_session.session.save_and_upload_detached(
             agent_session.session.config.session_dataset_repo
         )
@@ -1150,6 +1151,7 @@ async def submit_feedback(
     # Fire-and-forget save so feedback reaches the dataset even if the user
     # closes the tab right after clicking.
     if agent_session.session.config.save_sessions:
+        await session_manager.refresh_session_usage_metrics_snapshot(agent_session)
         agent_session.session.save_and_upload_detached(
             agent_session.session.config.session_dataset_repo
         )

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -28,6 +28,7 @@ from agent.core.usage_thresholds import (
     normalize_usage_threshold,
     usage_threshold_pending_to_tool,
 )
+from agent.core.usage_metrics import BILLING_SCOPE_ACCOUNT_WINDOW_DELTA
 from agent.messaging.gateway import NotificationGateway
 
 # Get project root (parent of backend directory)
@@ -409,6 +410,86 @@ class SessionManager:
             "estimated_spend_usd": round(estimated, 4),
             "remaining_usd": remaining,
         }
+
+    @staticmethod
+    def _usage_billing_snapshot_from_response(
+        response: dict[str, Any],
+    ) -> dict[str, Any]:
+        hf_account = response.get("hf_account") if isinstance(response, dict) else {}
+        hf_account = hf_account if isinstance(hf_account, dict) else {}
+        current_session = hf_account.get("current_session")
+        current_session = current_session if isinstance(current_session, dict) else None
+        available = bool(hf_account.get("available") and current_session is not None)
+        safe_current_session = None
+        if available and current_session is not None:
+            safe_current_session = {
+                "window_start": current_session.get("window_start"),
+                "window_end": current_session.get("window_end"),
+                "timezone": current_session.get("timezone"),
+                "total_usd": current_session.get("total_usd"),
+                "inference_providers_usd": current_session.get(
+                    "inference_providers_usd"
+                ),
+                "hf_jobs_usd": current_session.get("hf_jobs_usd"),
+                "inference_provider_requests": current_session.get(
+                    "inference_provider_requests"
+                ),
+                "hf_jobs_minutes": current_session.get("hf_jobs_minutes"),
+            }
+        return {
+            "billing_scope": BILLING_SCOPE_ACCOUNT_WINDOW_DELTA,
+            "hf_billing": {
+                "source": "hf_billing_usage_v2",
+                "available": available,
+                "error": (
+                    None
+                    if available
+                    else hf_account.get("error")
+                    or "current_session_billing_unavailable"
+                ),
+                "current_session": safe_current_session,
+            },
+        }
+
+    async def refresh_session_usage_metrics_snapshot(
+        self,
+        agent_session: AgentSession,
+    ) -> dict[str, Any]:
+        """Refresh the safe billing rollup used by dataset usage snapshots."""
+        from usage import build_usage_response
+
+        try:
+            response = await build_usage_response(
+                self,
+                user_id=agent_session.user_id,
+                hf_token=agent_session.hf_token
+                or getattr(agent_session.session, "hf_token", None),
+                session_id=agent_session.session_id,
+                timezone_name="UTC",
+            )
+            snapshot = self._usage_billing_snapshot_from_response(response)
+        except Exception as e:
+            logger.debug(
+                "Usage billing snapshot refresh failed for %s: %s",
+                agent_session.session_id,
+                e,
+            )
+            snapshot = {
+                "billing_scope": BILLING_SCOPE_ACCOUNT_WINDOW_DELTA,
+                "hf_billing": {
+                    "source": "hf_billing_usage_v2",
+                    "available": False,
+                    "error": "snapshot_refresh_failed",
+                    "current_session": None,
+                },
+            }
+
+        setter = getattr(agent_session.session, "set_usage_billing_snapshot", None)
+        if callable(setter):
+            setter(snapshot)
+        else:
+            agent_session.session.usage_billing_snapshot = snapshot
+        return snapshot
 
     def _install_usage_threshold_checker(self, agent_session: AgentSession) -> None:
         threshold = normalize_usage_threshold(
@@ -1470,6 +1551,9 @@ class SessionManager:
                             # than the idle window would otherwise be reaped the
                             # instant it completes.
                             self._touch(agent_session)
+                            await self.refresh_session_usage_metrics_snapshot(
+                                agent_session
+                            )
                             await self.persist_session_snapshot(agent_session)
                         if not should_continue:
                             break
@@ -1498,6 +1582,7 @@ class SessionManager:
             # Idempotent via session_id key; detached subprocess.
             if session.config.save_sessions:
                 try:
+                    await self.refresh_session_usage_metrics_snapshot(agent_session)
                     session.save_and_upload_detached(
                         session.config.session_dataset_repo
                     )

--- a/backend/usage.py
+++ b/backend/usage.py
@@ -9,9 +9,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import httpx
 
 from agent.core.cost_estimation import SPACE_PRICE_USD_PER_HOUR
+from agent.core.usage_metrics import summarize_usage_events
 
 USAGE_EVENT_TYPES = (
     "llm_call",
+    "hf_job_submit",
     "hf_job_complete",
     "sandbox_create",
     "sandbox_destroy",
@@ -181,55 +183,7 @@ def aggregate_usage_events(
     *,
     session_id: str | None = None,
 ) -> dict[str, Any]:
-    bucket = _empty_bucket(session_id=session_id)
-    for event in events:
-        event_type = event.get("event_type")
-        data = event.get("data") or {}
-        if event_type == "llm_call":
-            bucket["llm_calls"] += 1
-            bucket["inference_usd"] += _coerce_float(data.get("cost_usd"))
-            prompt_tokens = _coerce_int(data.get("prompt_tokens"))
-            completion_tokens = _coerce_int(data.get("completion_tokens"))
-            cache_read_tokens = _coerce_int(data.get("cache_read_tokens"))
-            cache_creation_tokens = _coerce_int(data.get("cache_creation_tokens"))
-            total_tokens = _coerce_int(data.get("total_tokens")) or (
-                prompt_tokens
-                + completion_tokens
-                + cache_read_tokens
-                + cache_creation_tokens
-            )
-            bucket["prompt_tokens"] += prompt_tokens
-            bucket["completion_tokens"] += completion_tokens
-            bucket["cache_read_tokens"] += cache_read_tokens
-            bucket["cache_creation_tokens"] += cache_creation_tokens
-            bucket["total_tokens"] += total_tokens
-        elif event_type == "hf_job_complete":
-            bucket["hf_jobs_count"] += 1
-            bucket["hf_jobs_estimated_usd"] += _coerce_float(
-                data.get("estimated_cost_usd")
-            )
-            bucket["hf_jobs_billable_seconds_estimate"] += _coerce_int(
-                data.get("billable_seconds_estimate") or data.get("wall_time_s")
-            )
-        elif event_type == "sandbox_destroy":
-            # Sandbox costs are paired and added after the main pass so the
-            # create event can provide hardware pricing metadata.
-            continue
-
-    _aggregate_sandbox_usage(events, bucket)
-
-    bucket["inference_usd"] = round(bucket["inference_usd"], 6)
-    bucket["hf_jobs_estimated_usd"] = round(bucket["hf_jobs_estimated_usd"], 6)
-    bucket["sandbox_estimated_usd"] = round(bucket["sandbox_estimated_usd"], 6)
-    bucket["total_usd"] = round(
-        (
-            bucket["inference_usd"]
-            + bucket["hf_jobs_estimated_usd"]
-            + bucket["sandbox_estimated_usd"]
-        ),
-        6,
-    )
-    return bucket
+    return summarize_usage_events(events, session_id=session_id)["app_telemetry"]
 
 
 def _event_sort_key(

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -42,6 +42,7 @@ class FakeRuntimeSession:
         self.auto_approval_estimated_spend_usd = 0.0
         self.usage_warning_next_threshold_usd = 5.0
         self.usage_threshold_checker = None
+        self.usage_billing_snapshot = None
         self.logged_events = []
         self.sandbox = None
         self.sandbox_hardware = None
@@ -70,6 +71,9 @@ class FakeRuntimeSession:
     def set_auto_approval_policy(self, *, enabled, cost_cap_usd):
         self.auto_approval_enabled = enabled
         self.auto_approval_cost_cap_usd = cost_cap_usd
+
+    def set_usage_billing_snapshot(self, snapshot):
+        self.usage_billing_snapshot = snapshot
 
 
 class RestoreStore(NoopSessionStore):
@@ -260,6 +264,125 @@ def test_usage_spend_falls_back_when_hf_total_is_unavailable():
 
     assert spend == 3.5
     assert source == "app_telemetry_session"
+
+
+@pytest.mark.asyncio
+async def test_refresh_usage_metrics_snapshot_stores_safe_hf_current_session(
+    monkeypatch,
+):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1")
+
+    async def fake_build_usage_response(
+        _manager,
+        *,
+        user_id,
+        hf_token,
+        session_id,
+        timezone_name,
+    ):
+        assert user_id == "owner"
+        assert hf_token == "owner-token"
+        assert session_id == "s1"
+        assert timezone_name == "UTC"
+        return {
+            "session": {"total_usd": 1.25},
+            "hf_account": {
+                "available": True,
+                "current_session": {
+                    "window_start": "2026-06-05T12:00:00Z",
+                    "window_end": "2026-06-05T13:00:00Z",
+                    "timezone": "UTC",
+                    "total_usd": 2.5,
+                    "inference_providers_usd": 2.0,
+                    "hf_jobs_usd": 0.5,
+                    "inference_provider_requests": 4,
+                    "hf_jobs_minutes": 12.5,
+                    "credit_limit_usd": 100,
+                },
+                "month": {"total_usd": 99},
+                "inference_providers_credits": {"limit_usd": 100},
+                "token": "hf_should_not_be_saved",
+            },
+        }
+
+    monkeypatch.setattr("usage.build_usage_response", fake_build_usage_response)
+
+    snapshot = await manager.refresh_session_usage_metrics_snapshot(agent_session)
+
+    assert agent_session.session.usage_billing_snapshot == snapshot
+    assert snapshot["billing_scope"] == "account_window_delta"
+    hf_billing = snapshot["hf_billing"]
+    assert hf_billing["available"] is True
+    assert hf_billing["error"] is None
+    assert hf_billing["current_session"] == {
+        "window_start": "2026-06-05T12:00:00Z",
+        "window_end": "2026-06-05T13:00:00Z",
+        "timezone": "UTC",
+        "total_usd": 2.5,
+        "inference_providers_usd": 2.0,
+        "hf_jobs_usd": 0.5,
+        "inference_provider_requests": 4,
+        "hf_jobs_minutes": 12.5,
+    }
+    assert "month" not in hf_billing
+    assert "inference_providers_credits" not in hf_billing
+    assert "token" not in hf_billing
+    assert "credit_limit_usd" not in hf_billing["current_session"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_usage_metrics_snapshot_records_missing_token(monkeypatch):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1", hf_token=None)
+
+    async def fake_build_usage_response(
+        _manager,
+        *,
+        user_id,
+        hf_token,
+        session_id,
+        timezone_name,
+    ):
+        assert user_id == "owner"
+        assert hf_token is None
+        assert session_id == "s1"
+        assert timezone_name == "UTC"
+        return {
+            "hf_account": {
+                "available": False,
+                "error": "missing_hf_token",
+                "current_session": None,
+                "month": {"total_usd": 99},
+            }
+        }
+
+    monkeypatch.setattr("usage.build_usage_response", fake_build_usage_response)
+
+    snapshot = await manager.refresh_session_usage_metrics_snapshot(agent_session)
+
+    assert snapshot["hf_billing"]["available"] is False
+    assert snapshot["hf_billing"]["error"] == "missing_hf_token"
+    assert snapshot["hf_billing"]["current_session"] is None
+    assert "month" not in snapshot["hf_billing"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_usage_metrics_snapshot_records_refresh_failure(monkeypatch):
+    manager = _manager_with_store(NoopSessionStore())
+    agent_session = _runtime_agent_session("s1")
+
+    async def fake_build_usage_response(*_args, **_kwargs):
+        raise RuntimeError("billing unavailable")
+
+    monkeypatch.setattr("usage.build_usage_response", fake_build_usage_response)
+
+    snapshot = await manager.refresh_session_usage_metrics_snapshot(agent_session)
+
+    assert snapshot["hf_billing"]["available"] is False
+    assert snapshot["hf_billing"]["error"] == "snapshot_refresh_failed"
+    assert snapshot["hf_billing"]["current_session"] is None
+    assert agent_session.session.usage_billing_snapshot == snapshot
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_uploader.py
+++ b/tests/unit/test_session_uploader.py
@@ -145,6 +145,27 @@ def test_row_payload_scrubs_messages_events_and_tools(tmp_path):
         "messages": [{"role": "user", "content": f"token {HF_SECRET}"}],
         "events": [{"type": "debug", "content": f"key {PROVIDER_SECRET}"}],
         "tools": [{"name": "bash", "env": f"GITHUB_TOKEN={GITHUB_SECRET}"}],
+        "usage_total_usd": 3.1,
+        "usage_total_usd_source": "hf_billing_plus_sandbox_estimate",
+        "usage_app_total_usd": 1.35,
+        "usage_hf_billing_total_usd": 2.5,
+        "usage_llm_calls": 2,
+        "usage_total_tokens": 420,
+        "usage_hf_job_submits": 1,
+        "usage_hf_job_status_snapshots": 1,
+        "usage_sandbox_creates": 1,
+        "usage_sandbox_pairs": 1,
+        "usage_metrics": {
+            "version": 1,
+            "total_usd": 3.1,
+            "total_usd_source": "hf_billing_plus_sandbox_estimate",
+            "app_total_usd": 1.35,
+            "hf_billing_total_usd": 2.5,
+            "app_telemetry": {"llm_calls": 2},
+            "llm": {"total_tokens": 420},
+            "hf_jobs": {"submits": 1, "status_snapshots": 1},
+            "sandboxes": {"creates": 1, "matched_pairs": 1},
+        },
     }
 
     _write_row_payload(data, str(tmp_file))
@@ -156,6 +177,21 @@ def test_row_payload_scrubs_messages_events_and_tools(tmp_path):
     assert "[REDACTED_HF_TOKEN]" in payload
     assert "[REDACTED_PROVIDER_API_KEY]" in payload
     assert "GITHUB_TOKEN=[REDACTED]" in payload
+
+    row = json.loads(payload)
+    assert row["session_id"] == "session-123"
+    assert row["total_cost_usd"] == 0.01
+    assert row["usage_total_usd"] == 3.1
+    assert row["usage_total_usd_source"] == "hf_billing_plus_sandbox_estimate"
+    assert row["usage_app_total_usd"] == 1.35
+    assert row["usage_hf_billing_total_usd"] == 2.5
+    assert row["usage_llm_calls"] == 2
+    assert row["usage_total_tokens"] == 420
+    assert row["usage_hf_job_submits"] == 1
+    assert row["usage_hf_job_status_snapshots"] == 1
+    assert row["usage_sandbox_creates"] == 1
+    assert row["usage_sandbox_pairs"] == 1
+    assert json.loads(row["usage_metrics"])["version"] == 1
 
 
 def test_claude_code_payload_scrubs_messages_before_conversion(tmp_path):
@@ -191,6 +227,11 @@ def test_claude_code_payload_scrubs_messages_before_conversion(tmp_path):
                 "timestamp": "2026-01-01T00:00:03",
             },
         ],
+        "usage_metrics": {
+            "version": 1,
+            "total_usd": 3.1,
+            "total_usd_source": "hf_billing_plus_sandbox_estimate",
+        },
     }
 
     _write_claude_code_payload(data, str(tmp_file))
@@ -202,3 +243,5 @@ def test_claude_code_payload_scrubs_messages_before_conversion(tmp_path):
     assert "[REDACTED_HF_TOKEN]" in payload
     assert "[REDACTED_PROVIDER_API_KEY]" in payload
     assert "GITHUB_TOKEN=[REDACTED]" in payload
+    assert "usage_metrics" not in payload
+    assert "hf_billing_plus_sandbox_estimate" not in payload

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -17,6 +17,7 @@ from usage import (  # noqa: E402
     resolve_usage_windows,
 )
 from agent.core import session_persistence  # noqa: E402
+from agent.core.usage_metrics import summarize_usage_events  # noqa: E402
 
 
 def _event(event_type, data=None, created_at="2026-06-01T12:00:00+00:00"):
@@ -171,11 +172,224 @@ def test_aggregate_usage_events_falls_back_to_sandbox_timestamps():
 
 
 def test_usage_event_type_allowlists_include_sandbox_lifecycle():
-    assert set(USAGE_EVENT_TYPES) >= {"sandbox_create", "sandbox_destroy"}
-    assert set(session_persistence.USAGE_EVENT_TYPES) >= {
+    assert set(USAGE_EVENT_TYPES) >= {
+        "hf_job_submit",
         "sandbox_create",
         "sandbox_destroy",
     }
+    assert set(session_persistence.USAGE_EVENT_TYPES) >= {
+        "hf_job_submit",
+        "sandbox_create",
+        "sandbox_destroy",
+    }
+
+
+def test_summarize_usage_events_aggregates_llm_turns_and_quality():
+    usage = summarize_usage_events(
+        [
+            _event(
+                "llm_call",
+                {
+                    "kind": "main",
+                    "model": "moonshotai/Kimi-K2.6",
+                    "cost_usd": 0.125,
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "cache_read_tokens": 25,
+                    "cache_creation_tokens": 5,
+                    "total_tokens": 180,
+                },
+            ),
+            _event(
+                "llm_call",
+                {
+                    "kind": "research",
+                    "model": "anthropic/claude-opus-4.8",
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                },
+            ),
+            {
+                "event_type": "llm_call",
+                "data": {
+                    "kind": "main",
+                    "model": "moonshotai/Kimi-K2.6",
+                    "cost_usd": 0,
+                },
+            },
+            _event("turn_complete"),
+            _event("assistant_stream_end"),
+        ],
+        session_id="s1",
+    )
+
+    assert usage["version"] == 1
+    assert usage["session_id"] == "s1"
+    assert usage["llm"]["calls"] == 3
+    assert usage["llm"]["calls_by_kind"] == {"main": 2, "research": 1}
+    assert usage["llm"]["calls_by_model"] == {
+        "anthropic/claude-opus-4.8": 1,
+        "moonshotai/Kimi-K2.6": 2,
+    }
+    assert usage["llm"]["prompt_tokens"] == 110
+    assert usage["llm"]["completion_tokens"] == 55
+    assert usage["llm"]["cache_read_tokens"] == 25
+    assert usage["llm"]["cache_creation_tokens"] == 5
+    assert usage["llm"]["total_tokens"] == 195
+    assert usage["turns"] == {
+        "turn_complete_count": 1,
+        "assistant_stream_end_count": 1,
+    }
+    assert usage["data_quality"]["events_without_timestamp"] == 1
+    assert usage["data_quality"]["llm_calls_with_cost_field"] == 2
+    assert usage["data_quality"]["llm_calls_with_nonzero_cost"] == 1
+
+
+def test_summarize_usage_events_aggregates_jobs_and_sandbox_lifecycle():
+    usage = summarize_usage_events(
+        [
+            _event("hf_job_submit", {"flavor": "t4-small"}),
+            _event(
+                "hf_job_complete",
+                {
+                    "flavor": "t4-small",
+                    "final_status": "success",
+                    "estimated_cost_usd": 0.4,
+                    "billable_seconds_estimate": 120,
+                },
+            ),
+            _event(
+                "hf_job_complete",
+                {
+                    "flavor": "cpu-basic",
+                    "final_status": "failed",
+                    "wall_time_s": 30,
+                },
+            ),
+            _event(
+                "sandbox_create",
+                {
+                    "sandbox_id": "alice/sandbox-paid",
+                    "hardware": "t4-small",
+                },
+                created_at="2026-06-01T12:00:00+00:00",
+            ),
+            _event(
+                "sandbox_destroy",
+                {
+                    "sandbox_id": "alice/sandbox-paid",
+                    "lifetime_s": 1800,
+                },
+                created_at="2026-06-01T12:30:00+00:00",
+            ),
+            _event(
+                "sandbox_create",
+                {
+                    "sandbox_id": "alice/sandbox-active",
+                    "hardware": "a100-large",
+                },
+            ),
+            _event("sandbox_destroy", {"sandbox_id": "alice/sandbox-missing"}),
+        ]
+    )
+
+    assert usage["hf_jobs"]["submits"] == 1
+    assert usage["hf_jobs"]["status_snapshots"] == 2
+    assert usage["hf_jobs"]["statuses"] == {"failed": 1, "success": 1}
+    assert usage["hf_jobs"]["flavors"] == {"t4-small": 1}
+    assert usage["hf_jobs"]["submit_flavors"] == {"t4-small": 1}
+    assert usage["hf_jobs"]["status_snapshot_flavors"] == {
+        "cpu-basic": 1,
+        "t4-small": 1,
+    }
+    assert usage["hf_jobs"]["estimated_usd"] == 0.4
+    assert usage["hf_jobs"]["billable_seconds_estimate"] == 150
+    assert usage["hf_jobs"]["snapshots_with_estimated_cost"] == 1
+    assert usage["hf_jobs"]["snapshots_with_nonzero_estimated_cost"] == 1
+    assert usage["sandboxes"]["creates"] == 2
+    assert usage["sandboxes"]["destroys"] == 2
+    assert usage["sandboxes"]["matched_pairs"] == 1
+    assert usage["sandboxes"]["unpaired_creates"] == 1
+    assert usage["sandboxes"]["unpaired_destroys"] == 1
+    assert usage["sandboxes"]["hardware"] == {"a100-large": 1, "t4-small": 1}
+    assert usage["sandboxes"]["estimated_usd"] == 0.3
+    assert usage["sandboxes"]["billable_seconds_estimate"] == 1800
+    assert usage["data_quality"]["job_snapshots_with_estimated_cost"] == 1
+    assert usage["data_quality"]["job_snapshots_missing_estimated_cost"] == 1
+
+
+def test_summarize_usage_events_uses_hf_billing_plus_sandbox_when_available():
+    usage = summarize_usage_events(
+        [
+            _event("llm_call", {"cost_usd": 0.25, "total_tokens": 42}),
+            _event("hf_job_complete", {"estimated_cost_usd": 0.5}),
+            _event(
+                "sandbox_create",
+                {
+                    "sandbox_id": "alice/sandbox-paid",
+                    "hardware": "t4-small",
+                },
+            ),
+            _event(
+                "sandbox_destroy",
+                {
+                    "sandbox_id": "alice/sandbox-paid",
+                    "lifetime_s": 3600,
+                },
+            ),
+        ],
+        hf_billing_snapshot={
+            "hf_billing": {
+                "available": True,
+                "source": "hf_billing_usage_v2",
+                "current_session": {
+                    "window_start": "2026-06-01T12:00:00Z",
+                    "window_end": "2026-06-01T13:00:00Z",
+                    "timezone": "UTC",
+                    "total_usd": 2.5,
+                    "inference_providers_usd": 2.0,
+                    "hf_jobs_usd": 0.5,
+                    "inference_provider_requests": 3,
+                    "hf_jobs_minutes": 12.5,
+                    "monthly_total_usd": 99,
+                },
+                "month": {"total_usd": 99},
+                "inference_providers_credits": {"limit_usd": 100},
+            }
+        },
+    )
+
+    assert usage["app_total_usd"] == 1.35
+    assert usage["hf_billing_total_usd"] == 2.5
+    assert usage["total_usd"] == 3.1
+    assert usage["total_usd_source"] == "hf_billing_plus_sandbox_estimate"
+    assert usage["hf_billing"]["current_session"]["total_usd"] == 2.5
+    assert "month" not in usage["hf_billing"]
+    assert "inference_providers_credits" not in usage["hf_billing"]
+    assert "monthly_total_usd" not in usage["hf_billing"]["current_session"]
+
+
+def test_summarize_usage_events_falls_back_to_app_telemetry_without_hf_billing():
+    usage = summarize_usage_events(
+        [
+            _event("llm_call", {"cost_usd": 0.25, "total_tokens": 42}),
+            _event("hf_job_complete", {"estimated_cost_usd": 0.5}),
+        ],
+        hf_billing_snapshot={
+            "hf_billing": {
+                "available": False,
+                "error": "missing_hf_token",
+                "current_session": None,
+            }
+        },
+    )
+
+    assert usage["total_usd"] == 0.75
+    assert usage["app_total_usd"] == 0.75
+    assert usage["hf_billing_total_usd"] is None
+    assert usage["total_usd_source"] == "app_telemetry_fallback"
+    assert usage["hf_billing"]["available"] is False
+    assert usage["hf_billing"]["error"] == "missing_hf_token"
 
 
 def test_account_bucket_from_hf_billing_usage_v2():


### PR DESCRIPTION
## Summary

Adds durable usage and billing analytics to shared session dataset rows.

- Adds a pure session-event usage summarizer with versioned `usage_metrics`.
- Adds scalar shared-dataset columns for total spend, source, LLM calls/tokens, HF Jobs, and sandbox counts.
- Adds safe HF billing current-session snapshots in `SessionManager`, storing only non-secret account-window deltas.
- Refreshes usage snapshots before turn persistence, final session flush, and feedback/pro-click re-uploads.
- Keeps personal Claude Code trace uploads unchanged.

## Validation

```bash
uv run --frozen --extra dev ruff check .
uv run --frozen --extra dev ruff format --check .
uv run --frozen --extra dev pytest tests/unit/test_usage.py tests/unit/test_session_manager_persistence.py tests/unit/test_session_persistence.py tests/unit/test_session_uploader.py
```

Targeted pytest result: 69 passed.
