### PR TITLE
[codex] Document GitHub token for local server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Notes:
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
 - Non-local LLM calls use `https://router.huggingface.co/v1` with the active Hugging Face user's token. Web sessions default to Kimi K2.6 for free users and Claude Opus 4.8 for Pro users; the CLI default is Claude Opus 4.8. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
+- When asked to start the local server, export the GitHub CLI token first with `export GITHUB_TOKEN="$(gh auth token)"`.
 - When debugging a web app issue tied to a session ID, inspect the session data in `smolagents/ml-intern-sessions` for additional context.
 
 ## Development Checks


### PR DESCRIPTION
## Summary

Adds a local development note to `AGENTS.md` telling agents to export the GitHub CLI token with `export GITHUB_TOKEN="$(gh auth token)"` before starting the local server.

## Why

The web app's GitHub-backed tools expect `GITHUB_TOKEN` in the environment, and local developers may already have a valid token available through `gh`.

## Impact

Future local-server startup instructions will include the GitHub token export step, reducing setup friction without committing any secret values.

## Validation

- `uv --cache-dir /private/tmp/ml-intern-uv-cache run --frozen --extra dev ruff check .`
- `uv --cache-dir /private/tmp/ml-intern-uv-cache run --frozen --extra dev ruff format --check .`
