### PR TITLE
[codex] Update hosted web model defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Notes:
 - Vite proxies `/api` and `/auth` to `http://localhost:7860`.
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
-- Non-local LLM calls use `https://router.huggingface.co/v1` with the active Hugging Face user's token. Web sessions default to Kimi K2.6 for free users and Claude Opus 4.8 for Pro users; the CLI default is Claude Opus 4.8. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
+- Non-local LLM calls use `https://router.huggingface.co/v1` with the active Hugging Face user's token. Web sessions default to Kimi K2.7 Code for free users and Claude Opus 4.8 for Pro users; the CLI default is Claude Opus 4.8. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
 - When asked to start the local server, export the GitHub CLI token first with `export GITHUB_TOKEN="$(gh auth token)"`.
 - When debugging a web app issue tied to a session ID, inspect the session data in `smolagents/ml-intern-sessions` for additional context.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Notes:
 - Vite proxies `/api` and `/auth` to `http://localhost:7860`.
 - If `127.0.0.1:7860` is already owned by another local process, binding the backend to `::1` lets the Vite proxy resolve `localhost` cleanly.
 - Prefer `npm ci` over `npm install` for setup, since `npm install` may rewrite `frontend/package-lock.json` metadata depending on npm version.
-- Non-local LLM calls use `https://router.huggingface.co/v1` with the active Hugging Face user's token. Web sessions default to Kimi K2.7 Code for free users and Claude Opus 4.8 for Pro users; the CLI default is Claude Opus 4.8. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
+- Non-local LLM calls use `https://router.huggingface.co/v1` with the active Hugging Face user's token. Web sessions default to GLM 5.2 for free users and Claude Opus 4.8 for Pro users; the CLI default is Claude Opus 4.8. For local development, set `HF_TOKEN` and optionally `ML_INTERN_DEFAULT_MODEL_ID`.
 - When asked to start the local server, export the GitHub CLI token first with `export GITHUB_TOKEN="$(gh auth token)"`.
 - When debugging a web app issue tied to a session ID, inspect the session data in `smolagents/ml-intern-sessions` for additional context.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ml-intern --sandbox-tools "your prompt"                         # use HF Space s
 ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 # Change model
-ml-intern --model moonshotai/Kimi-K2.6 "your prompt"
+ml-intern --model moonshotai/Kimi-K2.7-Code "your prompt"
 ml-intern --model openai/gpt-5.5:fal-ai "your prompt"
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ml-intern --sandbox-tools "your prompt"                         # use HF Space s
 ml-intern --max-iterations 100 "your prompt"
 ml-intern --no-stream "your prompt"
 # Change model
-ml-intern --model moonshotai/Kimi-K2.7-Code "your prompt"
+ml-intern --model moonshotai/Kimi-K2.7-Code:novita "your prompt"
 ml-intern --model openai/gpt-5.5:fal-ai "your prompt"
 ```
 

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -676,7 +676,7 @@ def _friendly_error_message(
     ):
         return (
             "Model not found. Use '/model' to list suggestions, or paste an "
-            "HF model id like 'MiniMaxAI/MiniMax-M2.7'. Availability is shown "
+            "HF model id like 'MiniMaxAI/MiniMax-M3'. Availability is shown "
             "when you switch."
         )
 

--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -676,7 +676,7 @@ def _friendly_error_message(
     ):
         return (
             "Model not found. Use '/model' to list suggestions, or paste an "
-            "HF model id like 'MiniMaxAI/MiniMax-M3'. Availability is shown "
+            "HF model id like 'MiniMaxAI/MiniMax-M3:novita'. Availability is shown "
             "when you switch."
         )
 

--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -5,17 +5,17 @@ HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 # Keep these as verbatim HF Router ids; version punctuation differs by model.
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
 GPT_55_MODEL_ID = "openai/gpt-5.5:fal-ai"
-KIMI_K26_MODEL_ID = "moonshotai/Kimi-K2.6:novita"
-MINIMAX_M27_MODEL_ID = "MiniMaxAI/MiniMax-M2.7:novita"
-GLM_51_MODEL_ID = "zai-org/GLM-5.1:novita"
+KIMI_K27_CODE_MODEL_ID = "moonshotai/Kimi-K2.7-Code"
+MINIMAX_M3_MODEL_ID = "MiniMaxAI/MiniMax-M3"
+GLM_52_MODEL_ID = "zai-org/GLM-5.2"
 DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:novita"
 
 HOSTED_MODEL_IDS = {
     CLAUDE_OPUS_48_MODEL_ID,
     GPT_55_MODEL_ID,
-    KIMI_K26_MODEL_ID,
-    MINIMAX_M27_MODEL_ID,
-    GLM_51_MODEL_ID,
+    KIMI_K27_CODE_MODEL_ID,
+    MINIMAX_M3_MODEL_ID,
+    GLM_52_MODEL_ID,
     DEEPSEEK_V4_PRO_MODEL_ID,
 }
 

--- a/agent/core/model_ids.py
+++ b/agent/core/model_ids.py
@@ -5,9 +5,9 @@ HF_ROUTER_BASE_URL = "https://router.huggingface.co/v1"
 # Keep these as verbatim HF Router ids; version punctuation differs by model.
 CLAUDE_OPUS_48_MODEL_ID = "anthropic/claude-opus-4.8:fal-ai"
 GPT_55_MODEL_ID = "openai/gpt-5.5:fal-ai"
-KIMI_K27_CODE_MODEL_ID = "moonshotai/Kimi-K2.7-Code"
-MINIMAX_M3_MODEL_ID = "MiniMaxAI/MiniMax-M3"
-GLM_52_MODEL_ID = "zai-org/GLM-5.2"
+KIMI_K27_CODE_MODEL_ID = "moonshotai/Kimi-K2.7-Code:novita"
+MINIMAX_M3_MODEL_ID = "MiniMaxAI/MiniMax-M3:novita"
+GLM_52_MODEL_ID = "zai-org/GLM-5.2:novita"
 DEEPSEEK_V4_PRO_MODEL_ID = "deepseek-ai/DeepSeek-V4-Pro:novita"
 
 HOSTED_MODEL_IDS = {

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -29,24 +29,24 @@ from agent.core.local_models import (
 from agent.core.model_ids import (
     CLAUDE_OPUS_48_MODEL_ID,
     DEEPSEEK_V4_PRO_MODEL_ID,
-    GLM_51_MODEL_ID,
+    GLM_52_MODEL_ID,
     GPT_55_MODEL_ID,
-    KIMI_K26_MODEL_ID,
-    MINIMAX_M27_MODEL_ID,
+    KIMI_K27_CODE_MODEL_ID,
+    MINIMAX_M3_MODEL_ID,
     strip_huggingface_model_prefix,
 )
 
 
 # Suggested models shown by `/model` (not a gate). Users can paste any HF
-# Router model id (e.g. "MiniMaxAI/MiniMax-M2.7"). Append ":fastest",
+# Router model id (e.g. "MiniMaxAI/MiniMax-M3"). Append ":fastest",
 # ":cheapest", ":preferred", or ":<provider>" to override the default routing
 # policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
     {"id": CLAUDE_OPUS_48_MODEL_ID, "label": "Claude Opus 4.8"},
     {"id": GPT_55_MODEL_ID, "label": "GPT-5.5"},
-    {"id": MINIMAX_M27_MODEL_ID, "label": "MiniMax M2.7"},
-    {"id": KIMI_K26_MODEL_ID, "label": "Kimi K2.6"},
-    {"id": GLM_51_MODEL_ID, "label": "GLM 5.1"},
+    {"id": MINIMAX_M3_MODEL_ID, "label": "MiniMax M3"},
+    {"id": KIMI_K27_CODE_MODEL_ID, "label": "Kimi K2.7 Code"},
+    {"id": GLM_52_MODEL_ID, "label": "GLM 5.2"},
     {"id": DEEPSEEK_V4_PRO_MODEL_ID, "label": "DeepSeek V4 Pro"},
 ]
 
@@ -161,7 +161,7 @@ def print_model_listing(config, console) -> None:
         marker = " [dim]<-- current[/dim]" if m["id"] == current else ""
         console.print(f"  {m['id']}  [dim]({m['label']})[/dim]{marker}")
     console.print(
-        "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M2.7').\n"
+        "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M3').\n"
         "Add ':fastest', ':cheapest', ':preferred', or ':<provider>' to override routing.\n"
         "Use 'ollama/<model>', 'vllm/<model>', 'lm_studio/<model>', or "
         "'llamacpp/<model>' for local OpenAI-compatible endpoints.[/dim]"

--- a/agent/core/model_switcher.py
+++ b/agent/core/model_switcher.py
@@ -38,7 +38,7 @@ from agent.core.model_ids import (
 
 
 # Suggested models shown by `/model` (not a gate). Users can paste any HF
-# Router model id (e.g. "MiniMaxAI/MiniMax-M3"). Append ":fastest",
+# Router model id (e.g. "MiniMaxAI/MiniMax-M3:novita"). Append ":fastest",
 # ":cheapest", ":preferred", or ":<provider>" to override the default routing
 # policy (auto = fastest with failover).
 SUGGESTED_MODELS = [
@@ -161,7 +161,7 @@ def print_model_listing(config, console) -> None:
         marker = " [dim]<-- current[/dim]" if m["id"] == current else ""
         console.print(f"  {m['id']}  [dim]({m['label']})[/dim]{marker}")
     console.print(
-        "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M3').\n"
+        "\n[dim]Paste any HF model id (e.g. 'MiniMaxAI/MiniMax-M3:novita').\n"
         "Add ':fastest', ':cheapest', ':preferred', or ':<provider>' to override routing.\n"
         "Use 'ollama/<model>', 'vllm/<model>', 'lm_studio/<model>', or "
         "'llamacpp/<model>' for local OpenAI-compatible endpoints.[/dim]"

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -52,7 +52,7 @@ def _get_max_tokens_safe(model_name: str) -> int:
 
     Primary source: ``litellm.get_model_info(model)['max_input_tokens']``.
     Strips any HF routing suffix / huggingface/ prefix so tagged ids
-    ('moonshotai/Kimi-K2.7-Code:cheapest') look up the bare model. Falls back to a
+    ('moonshotai/Kimi-K2.7-Code:novita') look up the bare model. Falls back to a
     conservative 200k default for models not in the catalog.
     """
     from litellm import get_model_info

--- a/agent/core/session.py
+++ b/agent/core/session.py
@@ -52,7 +52,7 @@ def _get_max_tokens_safe(model_name: str) -> int:
 
     Primary source: ``litellm.get_model_info(model)['max_input_tokens']``.
     Strips any HF routing suffix / huggingface/ prefix so tagged ids
-    ('moonshotai/Kimi-K2.6:cheapest') look up the bare model. Falls back to a
+    ('moonshotai/Kimi-K2.7-Code:cheapest') look up the bare model. Falls back to a
     conservative 200k default for models not in the catalog.
     """
     from litellm import get_model_info

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -58,10 +58,10 @@ from agent.core.llm_params import _resolve_llm_params
 from agent.core.model_ids import (
     CLAUDE_OPUS_48_MODEL_ID,
     DEEPSEEK_V4_PRO_MODEL_ID,
-    GLM_51_MODEL_ID,
+    GLM_52_MODEL_ID,
     GPT_55_MODEL_ID,
-    KIMI_K26_MODEL_ID,
-    MINIMAX_M27_MODEL_ID,
+    KIMI_K27_CODE_MODEL_ID,
+    MINIMAX_M3_MODEL_ID,
     strip_huggingface_model_prefix,
 )
 from agent.core.prompt_caching import with_prompt_cache_params
@@ -74,7 +74,7 @@ _background_route_tasks: set[asyncio.Task] = set()
 
 DEFAULT_OPUS_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 DEFAULT_GPT_MODEL_ID = GPT_55_MODEL_ID
-DEFAULT_FREE_MODEL_ID = KIMI_K26_MODEL_ID
+DEFAULT_FREE_MODEL_ID = KIMI_K27_CODE_MODEL_ID
 DATASET_UPLOAD_MULTIPART_SLACK_BYTES = 1024 * 1024
 
 
@@ -132,17 +132,17 @@ def _available_models() -> list[dict[str, Any]]:
         },
         {
             "id": DEFAULT_FREE_MODEL_ID,
-            "label": "Kimi K2.6",
+            "label": "Kimi K2.7 Code",
             "provider": "huggingface",
         },
         {
-            "id": MINIMAX_M27_MODEL_ID,
-            "label": "MiniMax M2.7",
+            "id": MINIMAX_M3_MODEL_ID,
+            "label": "MiniMax M3",
             "provider": "huggingface",
         },
         {
-            "id": GLM_51_MODEL_ID,
-            "label": "GLM 5.1",
+            "id": GLM_52_MODEL_ID,
+            "label": "GLM 5.2",
             "provider": "huggingface",
         },
         {

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -74,7 +74,7 @@ _background_route_tasks: set[asyncio.Task] = set()
 
 DEFAULT_OPUS_MODEL_ID = CLAUDE_OPUS_48_MODEL_ID
 DEFAULT_GPT_MODEL_ID = GPT_55_MODEL_ID
-DEFAULT_FREE_MODEL_ID = KIMI_K27_CODE_MODEL_ID
+DEFAULT_FREE_MODEL_ID = GLM_52_MODEL_ID
 DATASET_UPLOAD_MULTIPART_SLACK_BYTES = 1024 * 1024
 
 
@@ -131,7 +131,7 @@ def _available_models() -> list[dict[str, Any]]:
             "provider": "huggingface",
         },
         {
-            "id": DEFAULT_FREE_MODEL_ID,
+            "id": KIMI_K27_CODE_MODEL_ID,
             "label": "Kimi K2.7 Code",
             "provider": "huggingface",
         },
@@ -141,7 +141,7 @@ def _available_models() -> list[dict[str, Any]]:
             "provider": "huggingface",
         },
         {
-            "id": GLM_52_MODEL_ID,
+            "id": DEFAULT_FREE_MODEL_ID,
             "label": "GLM 5.2",
             "provider": "huggingface",
         },
@@ -177,7 +177,7 @@ async def _model_override_for_new_session(
 ) -> str | None:
     """Return the model override to use when creating a new session.
 
-    Explicit model requests are honored. Empty web requests default to Kimi for
+    Explicit model requests are honored. Empty web requests default to GLM for
     non-Pro users and Opus for Pro users.
     """
     return requested_model or _default_model_for_user(user)

--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -292,18 +292,22 @@ async def health_check() -> HealthResponse:
 
 
 @router.get("/health/llm", response_model=LLMHealthResponse)
-async def llm_health_check(request: Request) -> LLMHealthResponse:
+async def llm_health_check(
+    request: Request,
+    user: dict = Depends(get_current_user),
+) -> LLMHealthResponse:
     """Check if the LLM provider is reachable and the API key is valid.
 
-    Makes a minimal 1-token completion call when a token is available. For
-    token-less HF Router requests, returns ``status="skipped"`` instead of
-    making an unauthenticated probe. Catches common errors:
+    Makes a minimal 1-token completion call against the authenticated user's
+    plan-aware default model when a token is available. For token-less HF Router
+    requests, returns ``status="skipped"`` instead of making an unauthenticated
+    probe. Catches common errors:
     - 401 → invalid API key
     - 402/insufficient_quota → out of credits
     - 429 → rate limited
     - timeout / network → provider unreachable
     """
-    model = session_manager.config.model_name
+    model = _default_model_for_user(user)
     hf_token = resolve_hf_request_token(request)
     if _model_requires_hf_router_token(model) and not hf_token:
         return LLMHealthResponse(status="skipped", model=model)

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 from agent.config import load_config
 from agent.core.agent_loop import process_submission
 from agent.core.model_ids import (
-    KIMI_K27_CODE_MODEL_ID,
+    GLM_52_MODEL_ID,
     is_known_router_model_id,
     strip_huggingface_model_prefix,
 )
@@ -269,7 +269,7 @@ class SessionManager:
         if normalized and is_known_router_model_id(normalized):
             return normalized
 
-        fallback_model = KIMI_K27_CODE_MODEL_ID
+        fallback_model = GLM_52_MODEL_ID
         logger.warning(
             "Saved session model %r failed validation; using %r",
             model,

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 from agent.config import load_config
 from agent.core.agent_loop import process_submission
 from agent.core.model_ids import (
-    KIMI_K26_MODEL_ID,
+    KIMI_K27_CODE_MODEL_ID,
     is_known_router_model_id,
     strip_huggingface_model_prefix,
 )
@@ -269,7 +269,7 @@ class SessionManager:
         if normalized and is_known_router_model_id(normalized):
             return normalized
 
-        fallback_model = KIMI_K26_MODEL_ID
+        fallback_model = KIMI_K27_CODE_MODEL_ID
         logger.warning(
             "Saved session model %r failed validation; using %r",
             model,

--- a/configs/frontend_agent_config.json
+++ b/configs/frontend_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-moonshotai/Kimi-K2.7-Code}",
+  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-moonshotai/Kimi-K2.7-Code:novita}",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "share_traces": true,

--- a/configs/frontend_agent_config.json
+++ b/configs/frontend_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-moonshotai/Kimi-K2.7-Code:novita}",
+  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-zai-org/GLM-5.2:novita}",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "share_traces": true,

--- a/configs/frontend_agent_config.json
+++ b/configs/frontend_agent_config.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-moonshotai/Kimi-K2.6}",
+  "model_name": "${ML_INTERN_DEFAULT_MODEL_ID:-moonshotai/Kimi-K2.7-Code}",
   "save_sessions": true,
   "session_dataset_repo": "smolagents/ml-intern-sessions",
   "share_traces": true,

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -87,7 +87,7 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   },
 ];
 
-const DEFAULT_FREE_MODEL_OPTION_ID = 'kimi-k2.7-code';
+const DEFAULT_FREE_MODEL_OPTION_ID = 'glm-5.2';
 
 const normalizeModelPath = (path: string | undefined) => (
   (path ?? '')

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -26,10 +26,10 @@ import { useSessionStore } from '@/store/sessionStore';
 import {
   CLAUDE_OPUS_48_MODEL_PATH,
   DEEPSEEK_V4_PRO_MODEL_PATH,
-  GLM_51_MODEL_PATH,
+  GLM_52_MODEL_PATH,
   GPT_55_MODEL_PATH,
-  KIMI_K26_MODEL_PATH,
-  MINIMAX_M27_MODEL_PATH,
+  KIMI_K27_CODE_MODEL_PATH,
+  MINIMAX_M3_MODEL_PATH,
   isClaudePath,
 } from '@/utils/model';
 
@@ -62,22 +62,22 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
     avatarUrl: getHfAvatarUrl(GPT_55_MODEL_PATH),
   },
   {
-    id: 'kimi-k2.6',
-    name: 'Kimi K2.6',
-    modelPath: KIMI_K26_MODEL_PATH,
-    avatarUrl: getHfAvatarUrl(KIMI_K26_MODEL_PATH),
+    id: 'kimi-k2.7-code',
+    name: 'Kimi K2.7 Code',
+    modelPath: KIMI_K27_CODE_MODEL_PATH,
+    avatarUrl: getHfAvatarUrl(KIMI_K27_CODE_MODEL_PATH),
   },
   {
-    id: 'minimax-m2.7',
-    name: 'MiniMax M2.7',
-    modelPath: MINIMAX_M27_MODEL_PATH,
-    avatarUrl: getHfAvatarUrl('MiniMaxAI/MiniMax-M2.7'),
+    id: 'minimax-m3',
+    name: 'MiniMax M3',
+    modelPath: MINIMAX_M3_MODEL_PATH,
+    avatarUrl: getHfAvatarUrl(MINIMAX_M3_MODEL_PATH),
   },
   {
-    id: 'glm-5.1',
-    name: 'GLM 5.1',
-    modelPath: GLM_51_MODEL_PATH,
-    avatarUrl: getHfAvatarUrl('zai-org/GLM-5.1'),
+    id: 'glm-5.2',
+    name: 'GLM 5.2',
+    modelPath: GLM_52_MODEL_PATH,
+    avatarUrl: getHfAvatarUrl(GLM_52_MODEL_PATH),
   },
   {
     id: 'deepseek-v4-pro',
@@ -87,7 +87,7 @@ const DEFAULT_MODEL_OPTIONS: ModelOption[] = [
   },
 ];
 
-const DEFAULT_FREE_MODEL_OPTION_ID = 'kimi-k2.6';
+const DEFAULT_FREE_MODEL_OPTION_ID = 'kimi-k2.7-code';
 
 const normalizeModelPath = (path: string | undefined) => (
   (path ?? '')

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -8,9 +8,9 @@
 
 export const CLAUDE_OPUS_48_MODEL_PATH = 'anthropic/claude-opus-4.8:fal-ai';
 export const GPT_55_MODEL_PATH = 'openai/gpt-5.5:fal-ai';
-export const KIMI_K26_MODEL_PATH = 'moonshotai/Kimi-K2.6:novita';
-export const MINIMAX_M27_MODEL_PATH = 'MiniMaxAI/MiniMax-M2.7:novita';
-export const GLM_51_MODEL_PATH = 'zai-org/GLM-5.1:novita';
+export const KIMI_K27_CODE_MODEL_PATH = 'moonshotai/Kimi-K2.7-Code';
+export const MINIMAX_M3_MODEL_PATH = 'MiniMaxAI/MiniMax-M3';
+export const GLM_52_MODEL_PATH = 'zai-org/GLM-5.2';
 export const DEEPSEEK_V4_PRO_MODEL_PATH = 'deepseek-ai/DeepSeek-V4-Pro:novita';
 
 export function isClaudePath(modelPath: string | undefined): boolean {

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -8,9 +8,9 @@
 
 export const CLAUDE_OPUS_48_MODEL_PATH = 'anthropic/claude-opus-4.8:fal-ai';
 export const GPT_55_MODEL_PATH = 'openai/gpt-5.5:fal-ai';
-export const KIMI_K27_CODE_MODEL_PATH = 'moonshotai/Kimi-K2.7-Code';
-export const MINIMAX_M3_MODEL_PATH = 'MiniMaxAI/MiniMax-M3';
-export const GLM_52_MODEL_PATH = 'zai-org/GLM-5.2';
+export const KIMI_K27_CODE_MODEL_PATH = 'moonshotai/Kimi-K2.7-Code:novita';
+export const MINIMAX_M3_MODEL_PATH = 'MiniMaxAI/MiniMax-M3:novita';
+export const GLM_52_MODEL_PATH = 'zai-org/GLM-5.2:novita';
 export const DEEPSEEK_V4_PRO_MODEL_PATH = 'deepseek-ai/DeepSeek-V4-Pro:novita';
 
 export function isClaudePath(modelPath: string | undefined): boolean {

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -24,8 +24,8 @@ def test_available_models_exclude_sonnet_and_have_no_pro_gate():
     assert models[agent.DEFAULT_OPUS_MODEL_ID]["label"] == "Claude Opus 4.8"
     assert models[agent.DEFAULT_OPUS_MODEL_ID]["recommended"] is True
     assert models[agent.DEFAULT_FREE_MODEL_ID]["label"] == "Kimi K2.7 Code"
-    assert models["MiniMaxAI/MiniMax-M3"]["label"] == "MiniMax M3"
-    assert models["zai-org/GLM-5.2"]["label"] == "GLM 5.2"
+    assert models["MiniMaxAI/MiniMax-M3:novita"]["label"] == "MiniMax M3"
+    assert models["zai-org/GLM-5.2:novita"]["label"] == "GLM 5.2"
     assert "recommended" not in models[agent.DEFAULT_FREE_MODEL_ID]
     assert all("minimum_plan" not in model for model in models.values())
     assert all("tier" not in model for model in models.values())

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -23,9 +23,9 @@ def test_available_models_exclude_sonnet_and_have_no_pro_gate():
 
     assert models[agent.DEFAULT_OPUS_MODEL_ID]["label"] == "Claude Opus 4.8"
     assert models[agent.DEFAULT_OPUS_MODEL_ID]["recommended"] is True
-    assert models[agent.DEFAULT_FREE_MODEL_ID]["label"] == "Kimi K2.7 Code"
+    assert models[agent.DEFAULT_FREE_MODEL_ID]["label"] == "GLM 5.2"
+    assert models["moonshotai/Kimi-K2.7-Code:novita"]["label"] == "Kimi K2.7 Code"
     assert models["MiniMaxAI/MiniMax-M3:novita"]["label"] == "MiniMax M3"
-    assert models["zai-org/GLM-5.2:novita"]["label"] == "GLM 5.2"
     assert "recommended" not in models[agent.DEFAULT_FREE_MODEL_ID]
     assert all("minimum_plan" not in model for model in models.values())
     assert all("tier" not in model for model in models.values())

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -40,7 +40,7 @@ def test_default_model_for_user_is_plan_aware():
 
 
 @pytest.mark.asyncio
-async def test_llm_health_uses_request_hf_token(monkeypatch):
+async def test_llm_health_uses_plan_default_and_request_hf_token(monkeypatch):
     class Request:
         headers = {"Authorization": "Bearer user-token"}
         cookies = {}
@@ -72,10 +72,10 @@ async def test_llm_health_uses_request_hf_token(monkeypatch):
     monkeypatch.setattr(agent, "_resolve_llm_params", fake_resolve_llm_params)
     monkeypatch.setattr(agent, "acompletion", fake_acompletion)
 
-    response = await agent.llm_health_check(Request())
+    response = await agent.llm_health_check(Request(), {"user_id": "u1", "plan": "pro"})
 
     assert response.status == "ok"
-    assert resolved == [(agent.DEFAULT_FREE_MODEL_ID, "user-token", "high", False)]
+    assert resolved == [(agent.DEFAULT_OPUS_MODEL_ID, "user-token", "high", False)]
     assert completions[0]["api_key"] == "user-token"
 
 
@@ -97,12 +97,14 @@ async def test_llm_health_skips_router_probe_without_token(monkeypatch):
     monkeypatch.setattr(
         agent.session_manager,
         "config",
-        SimpleNamespace(model_name=agent.DEFAULT_FREE_MODEL_ID),
+        SimpleNamespace(model_name=agent.DEFAULT_OPUS_MODEL_ID),
     )
     monkeypatch.setattr(agent, "_resolve_llm_params", fail_resolve_llm_params)
     monkeypatch.setattr(agent, "acompletion", fail_acompletion)
 
-    response = await agent.llm_health_check(Request())
+    response = await agent.llm_health_check(
+        Request(), {"user_id": "u1", "plan": "free"}
+    )
 
     assert response.status == "skipped"
     assert response.model == agent.DEFAULT_FREE_MODEL_ID

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -23,6 +23,9 @@ def test_available_models_exclude_sonnet_and_have_no_pro_gate():
 
     assert models[agent.DEFAULT_OPUS_MODEL_ID]["label"] == "Claude Opus 4.8"
     assert models[agent.DEFAULT_OPUS_MODEL_ID]["recommended"] is True
+    assert models[agent.DEFAULT_FREE_MODEL_ID]["label"] == "Kimi K2.7 Code"
+    assert models["MiniMaxAI/MiniMax-M3"]["label"] == "MiniMax M3"
+    assert models["zai-org/GLM-5.2"]["label"] == "GLM 5.2"
     assert "recommended" not in models[agent.DEFAULT_FREE_MODEL_ID]
     assert all("minimum_plan" not in model for model in models.values())
     assert all("tier" not in model for model in models.values())

--- a/tests/unit/test_auto_approval_policy.py
+++ b/tests/unit/test_auto_approval_policy.py
@@ -12,7 +12,7 @@ from agent.core.cost_estimation import CostEstimate
 
 def _config(**overrides):
     data = {
-        "model_name": "moonshotai/Kimi-K2.6",
+        "model_name": "moonshotai/Kimi-K2.7-Code",
         "confirm_cpu_jobs": True,
         "auto_file_upload": False,
         "yolo_mode": False,

--- a/tests/unit/test_build_kpis.py
+++ b/tests/unit/test_build_kpis.py
@@ -369,9 +369,9 @@ def test_aggregate_sessions_by_model_split():
     s_claude = _session([], user_id="a")
     s_claude["model_name"] = "anthropic/claude-opus-4.8:fal-ai"
     s_kimi = _session([], user_id="b")
-    s_kimi["model_name"] = "moonshotai/Kimi-K2.6"
+    s_kimi["model_name"] = "moonshotai/Kimi-K2.7-Code"
     s_kimi2 = _session([], user_id="c")
-    s_kimi2["model_name"] = "moonshotai/Kimi-K2.6"
+    s_kimi2["model_name"] = "moonshotai/Kimi-K2.7-Code"
     row = mod._aggregate(
         [
             mod._session_metrics(s_claude),
@@ -381,7 +381,7 @@ def test_aggregate_sessions_by_model_split():
     )
     assert _json.loads(row["sessions_by_model_json"]) == {
         "anthropic/claude-opus-4.8:fal-ai": 1,
-        "moonshotai/Kimi-K2.6": 2,
+        "moonshotai/Kimi-K2.7-Code": 2,
     }
 
 

--- a/tests/unit/test_cli_local_models.py
+++ b/tests/unit/test_cli_local_models.py
@@ -48,7 +48,7 @@ def test_cli_default_model_is_opus():
 def test_model_switcher_accepts_router_model_ids():
     assert model_switcher.is_valid_model_id("openai/gpt-5.5:fal-ai")
     assert model_switcher.is_valid_model_id("openai/gpt-oss-120b")
-    assert model_switcher.is_valid_model_id("moonshotai/Kimi-K2.6")
+    assert model_switcher.is_valid_model_id("moonshotai/Kimi-K2.7-Code")
 
 
 def test_local_models_skip_hf_router_catalog_output():

--- a/tests/unit/test_cli_rendering.py
+++ b/tests/unit/test_cli_rendering.py
@@ -216,7 +216,7 @@ async def test_interactive_main_applies_model_override_before_banner(monkeypatch
         main_mod,
         "load_config",
         lambda _path, **_kwargs: SimpleNamespace(
-            model_name="moonshotai/Kimi-K2.6",
+            model_name="moonshotai/Kimi-K2.7-Code",
             mcpServers={},
             tool_runtime="local",
         ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,7 +17,7 @@ def test_load_config_does_not_apply_slack_user_defaults_by_default(
     _write_json(
         config_path,
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": False,
                 "destinations": {},
@@ -35,7 +35,7 @@ def test_load_config_does_not_apply_slack_user_defaults_by_default(
 
 def test_load_config_applies_slack_user_defaults_from_env(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
-    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.6"})
+    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.7-Code"})
     monkeypatch.delenv("ML_INTERN_CLI_CONFIG", raising=False)
     monkeypatch.setattr(
         config_module,
@@ -63,7 +63,7 @@ def test_load_config_applies_slack_user_defaults_from_env(tmp_path, monkeypatch)
 def test_load_config_merges_user_config_before_env_substitution(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     user_config_path = tmp_path / "user-config.json"
-    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.6"})
+    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.7-Code"})
     _write_json(
         user_config_path,
         {
@@ -103,7 +103,7 @@ def test_slack_user_defaults_can_be_disabled(tmp_path, monkeypatch):
     _write_json(
         config_path,
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": False,
                 "destinations": {},
@@ -128,7 +128,7 @@ def test_slack_user_defaults_can_be_disabled(tmp_path, monkeypatch):
 
 def test_tool_runtime_defaults_to_local(tmp_path):
     config_path = tmp_path / "config.json"
-    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.6"})
+    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.7-Code"})
 
     config = config_module.load_config(str(config_path))
 
@@ -138,7 +138,7 @@ def test_tool_runtime_defaults_to_local(tmp_path):
 def test_user_config_can_set_sandbox_tool_runtime(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     user_config_path = tmp_path / "user-config.json"
-    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.6"})
+    _write_json(config_path, {"model_name": "moonshotai/Kimi-K2.7-Code"})
     _write_json(user_config_path, {"tool_runtime": "sandbox"})
     monkeypatch.setenv("ML_INTERN_CLI_CONFIG", str(user_config_path))
 
@@ -151,7 +151,7 @@ def test_invalid_tool_runtime_is_rejected(tmp_path):
     config_path = tmp_path / "config.json"
     _write_json(
         config_path,
-        {"model_name": "moonshotai/Kimi-K2.6", "tool_runtime": "hybrid"},
+        {"model_name": "moonshotai/Kimi-K2.7-Code", "tool_runtime": "hybrid"},
     )
 
     with pytest.raises(ValidationError):

--- a/tests/unit/test_effort_probe.py
+++ b/tests/unit/test_effort_probe.py
@@ -22,7 +22,7 @@ async def test_probe_effort_sends_session_id_to_hf_router(monkeypatch):
     monkeypatch.setattr(effort_probe, "acompletion", fake_acompletion)
 
     outcome = await effort_probe.probe_effort(
-        "moonshotai/Kimi-K2.6:novita",
+        "moonshotai/Kimi-K2.7-Code:novita",
         "high",
         "hf_fake",
         session=SimpleNamespace(

--- a/tests/unit/test_llm_error_classification.py
+++ b/tests/unit/test_llm_error_classification.py
@@ -28,7 +28,7 @@ from agent.core.agent_loop import (
 
 
 def test_kimi_prompt_too_long_is_context_overflow():
-    # Verbatim error text from session 62ccfdcb (2026-04-25, Kimi K2.6).
+    # Verbatim error text from session 62ccfdcb (2026-04-25, Kimi-family model).
     err = Exception(
         "litellm.BadRequestError: OpenAIException - The prompt is too long: "
         "365407, model maximum context length: 262143"

--- a/tests/unit/test_llm_params.py
+++ b/tests/unit/test_llm_params.py
@@ -64,7 +64,7 @@ def test_router_params_fall_back_to_hf_cache_when_session_token_missing(monkeypa
 
 
 def test_router_params_never_set_bill_to_headers():
-    params = _resolve_llm_params("moonshotai/Kimi-K2.6", "session-token")
+    params = _resolve_llm_params("moonshotai/Kimi-K2.7-Code", "session-token")
 
     assert params["api_key"] == "session-token"
     assert "extra_headers" not in params
@@ -203,7 +203,7 @@ def test_hf_router_params_allow_missing_token_without_headers(monkeypatch):
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.setattr(huggingface_hub, "get_token", lambda: None)
 
-    params = _resolve_llm_params("moonshotai/Kimi-K2.6")
+    params = _resolve_llm_params("moonshotai/Kimi-K2.7-Code")
 
     assert params["api_key"] is None
     assert "extra_headers" not in params

--- a/tests/unit/test_messaging.py
+++ b/tests/unit/test_messaging.py
@@ -53,7 +53,7 @@ def _config_with_messaging(**destination_overrides) -> Config:
     }
     return Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "destinations": {
@@ -79,7 +79,7 @@ def test_messaging_config_validates_destination_names():
     with pytest.raises(ValidationError):
         Config.model_validate(
             {
-                "model_name": "moonshotai/Kimi-K2.6",
+                "model_name": "moonshotai/Kimi-K2.7-Code",
                 "messaging": {
                     "enabled": True,
                     "destinations": {
@@ -101,7 +101,7 @@ def test_messaging_config_validates_destination_names():
 def test_messaging_config_default_auto_destinations_only_returns_auto_enabled():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "destinations": {
@@ -128,7 +128,7 @@ def test_messaging_config_default_auto_destinations_only_returns_auto_enabled():
 def test_messaging_config_default_auto_destinations_empty_when_disabled():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": False,
                 "destinations": {
@@ -272,14 +272,14 @@ async def test_notify_tool_sends_to_allowlisted_destinations():
     assert len(gateway.sent) == 1
     sent = gateway.sent[0]
     assert sent.metadata["session_id"] == "sess-42"
-    assert sent.metadata["model"] == "moonshotai/Kimi-K2.6"
+    assert sent.metadata["model"] == "moonshotai/Kimi-K2.7-Code"
 
 
 @pytest.mark.asyncio
 async def test_session_auto_notifications_only_send_opted_in_auto_destinations():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "destinations": {
@@ -325,7 +325,7 @@ async def test_session_auto_notifications_only_send_opted_in_auto_destinations()
 async def test_turn_complete_auto_notification_includes_final_response_summary():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "destinations": {
@@ -366,7 +366,7 @@ async def test_turn_complete_auto_notification_includes_final_response_summary()
 async def test_turn_complete_auto_notification_supports_longer_summary():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "destinations": {
@@ -406,7 +406,7 @@ async def test_turn_complete_auto_notification_supports_longer_summary():
 async def test_turn_complete_auto_notification_can_be_deferred():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "destinations": {
@@ -452,7 +452,7 @@ async def test_turn_complete_auto_notification_can_be_deferred():
 async def test_turn_complete_can_be_disabled_by_custom_auto_event_config():
     config = Config.model_validate(
         {
-            "model_name": "moonshotai/Kimi-K2.6",
+            "model_name": "moonshotai/Kimi-K2.7-Code",
             "messaging": {
                 "enabled": True,
                 "auto_event_types": ["error"],

--- a/tests/unit/test_personal_trace_repo.py
+++ b/tests/unit/test_personal_trace_repo.py
@@ -11,7 +11,7 @@ class DummyToolRouter:
 
 def _session(*, user_id: str | None, hf_username: str | None) -> Session:
     config = SimpleNamespace(
-        model_name="moonshotai/Kimi-K2.6",
+        model_name="moonshotai/Kimi-K2.7-Code",
         save_sessions=True,
         share_traces=True,
         personal_trace_repo_template="{hf_user}/ml-intern-sessions",

--- a/tests/unit/test_prompt_caching.py
+++ b/tests/unit/test_prompt_caching.py
@@ -28,7 +28,7 @@ def _gpt55_fal_params() -> dict:
 
 def _kimi_novita_params() -> dict:
     return {
-        "model": "openai/moonshotai/Kimi-K2.6:novita",
+        "model": "openai/moonshotai/Kimi-K2.7-Code:novita",
         "api_base": HF_ROUTER_BASE_URL,
     }
 
@@ -158,7 +158,7 @@ def test_prompt_caching_is_noop_for_non_fal_router_model():
         {"role": "user", "content": "current question"},
     ]
     llm_params = {
-        "model": "openai/moonshotai/Kimi-K2.6",
+        "model": "openai/moonshotai/Kimi-K2.7-Code",
         "api_base": HF_ROUTER_BASE_URL,
     }
 

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -17,7 +17,7 @@ _BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
 if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
-from agent.core.model_ids import KIMI_K27_CODE_MODEL_ID  # noqa: E402
+from agent.core.model_ids import GLM_52_MODEL_ID  # noqa: E402
 from agent.core.session_persistence import NoopSessionStore  # noqa: E402
 from agent.core.usage_thresholds import USAGE_THRESHOLD_TOOL_NAME  # noqa: E402
 from agent.core.yolo_budget import YOLO_BUDGET_TOOL_NAME  # noqa: E402
@@ -826,10 +826,10 @@ async def test_yolo_budget_checker_uses_local_ledger_when_billing_lags(monkeypat
     assert pending["billing_source"] == "hf_billing_current_session"
 
 
-def test_unknown_saved_model_defaults_to_kimi():
+def test_unknown_saved_model_defaults_to_glm():
     model = SessionManager._model_from_saved_metadata("unsupported/model")
 
-    assert model == KIMI_K27_CODE_MODEL_ID
+    assert model == GLM_52_MODEL_ID
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_manager_persistence.py
+++ b/tests/unit/test_session_manager_persistence.py
@@ -17,7 +17,7 @@ _BACKEND_DIR = Path(__file__).resolve().parent.parent.parent / "backend"
 if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
 
-from agent.core.model_ids import KIMI_K26_MODEL_ID  # noqa: E402
+from agent.core.model_ids import KIMI_K27_CODE_MODEL_ID  # noqa: E402
 from agent.core.session_persistence import NoopSessionStore  # noqa: E402
 from agent.core.usage_thresholds import USAGE_THRESHOLD_TOOL_NAME  # noqa: E402
 from agent.core.yolo_budget import YOLO_BUDGET_TOOL_NAME  # noqa: E402
@@ -829,7 +829,7 @@ async def test_yolo_budget_checker_uses_local_ledger_when_billing_lags(monkeypat
 def test_unknown_saved_model_defaults_to_kimi():
     model = SessionManager._model_from_saved_metadata("unsupported/model")
 
-    assert model == KIMI_K26_MODEL_ID
+    assert model == KIMI_K27_CODE_MODEL_ID
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_resume.py
+++ b/tests/unit/test_session_resume.py
@@ -60,7 +60,7 @@ class _FakeContext:
 class _FakeSession:
     def __init__(self, *, user_id: str | None = "user-a") -> None:
         self.context_manager = _FakeContext()
-        self.config = SimpleNamespace(model_name="moonshotai/Kimi-K2.6")
+        self.config = SimpleNamespace(model_name="moonshotai/Kimi-K2.7-Code")
         self.session_id = "current-session"
         self.session_start_time = "2026-01-02T00:00:00"
         self.user_id = user_id

--- a/tests/unit/test_sft_tagger.py
+++ b/tests/unit/test_sft_tagger.py
@@ -21,7 +21,7 @@ def _traj(events=None, messages=None, model="anthropic/claude-opus-4.8:fal-ai"):
 
 def test_model_family():
     assert "model:opus" in tag_session(_traj(model="anthropic/claude-opus-4.8:fal-ai"))
-    assert "model:kimi" in tag_session(_traj(model="moonshotai/Kimi-K2.6"))
+    assert "model:kimi" in tag_session(_traj(model="moonshotai/Kimi-K2.7-Code"))
     assert "model:other" in tag_session(_traj(model="unknown-model-xyz"))
 
 


### PR DESCRIPTION
## Summary

Updates the hosted model defaults and web model picker entries requested for the web app:

- Replaces Kimi K2.6 with `moonshotai/Kimi-K2.7-Code:novita`
- Replaces MiniMax M2.7 with `MiniMaxAI/MiniMax-M3:novita`
- Replaces GLM 5.1 with `zai-org/GLM-5.2:novita`

The change keeps backend model validation, frontend fallback model options, config defaults, docs, and targeted tests in sync. The hosted open-model IDs are pinned to the `novita` provider, and free web sessions now default to GLM 5.2 while Pro web sessions continue to default to Claude Opus 4.8.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/unit/test_agent_model_gating.py tests/unit/test_session_manager_persistence.py::test_unknown_saved_model_defaults_to_glm`
- `npm run build`
