### PR TITLE
[codex] Remove unused model provider metadata

### DIFF
--- a/backend/routes/agent.py
+++ b/backend/routes/agent.py
@@ -122,33 +122,27 @@ def _available_models() -> list[dict[str, Any]]:
         {
             "id": DEFAULT_OPUS_MODEL_ID,
             "label": "Claude Opus 4.8",
-            "provider": "huggingface",
             "recommended": True,
         },
         {
             "id": DEFAULT_GPT_MODEL_ID,
             "label": "GPT-5.5",
-            "provider": "huggingface",
         },
         {
             "id": KIMI_K27_CODE_MODEL_ID,
             "label": "Kimi K2.7 Code",
-            "provider": "huggingface",
         },
         {
             "id": MINIMAX_M3_MODEL_ID,
             "label": "MiniMax M3",
-            "provider": "huggingface",
         },
         {
             "id": DEFAULT_FREE_MODEL_ID,
             "label": "GLM 5.2",
-            "provider": "huggingface",
         },
         {
             "id": DEEPSEEK_V4_PRO_MODEL_ID,
             "label": "DeepSeek V4 Pro",
-            "provider": "huggingface",
         },
     ]
     return models

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -124,7 +124,6 @@ const modelOptionId = (modelPath: string) => (
 const modelOptionFromApi = (model: {
   id?: string;
   label?: string;
-  provider?: string;
   recommended?: boolean;
 }): ModelOption | null => {
   if (!model.id) return null;

--- a/tests/unit/test_agent_model_gating.py
+++ b/tests/unit/test_agent_model_gating.py
@@ -27,6 +27,7 @@ def test_available_models_exclude_sonnet_and_have_no_pro_gate():
     assert models["moonshotai/Kimi-K2.7-Code:novita"]["label"] == "Kimi K2.7 Code"
     assert models["MiniMaxAI/MiniMax-M3:novita"]["label"] == "MiniMax M3"
     assert "recommended" not in models[agent.DEFAULT_FREE_MODEL_ID]
+    assert all("provider" not in model for model in models.values())
     assert all("minimum_plan" not in model for model in models.values())
     assert all("tier" not in model for model in models.values())
 


### PR DESCRIPTION
## Summary
- Remove unused `provider: "huggingface"` metadata from the backend hosted model config payload.
- Drop the matching unused optional frontend API type field.
- Add a regression assertion that `AVAILABLE_MODELS` entries do not include `provider`.

## Validation
- `uv run pytest tests/unit/test_agent_model_gating.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `npm run build`