### PR TITLE
fix: prevent tool call name merging during streaming

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -999,7 +999,7 @@ async def _call_llm_streaming(
 
                 if delta.tool_calls:
                     for tc_delta in delta.tool_calls:
-                        idx = tc_delta.index
+                        idx = tc_delta.index if tc_delta.index is not None else 0
                         if idx not in tool_calls_acc:
                             tool_calls_acc[idx] = {
                                 "id": "",
@@ -1007,6 +1007,23 @@ async def _call_llm_streaming(
                                 "function": {"name": "", "arguments": ""},
                             }
                         if tc_delta.id:
+                            # New tool call arriving on an index that already
+                            # holds a *different* call — the model is reusing
+                            # the index (violates the OpenAI streaming spec).
+                            # Allocate a fresh slot so names don't merge.
+                            if (
+                                tool_calls_acc[idx]["id"]
+                                and tool_calls_acc[idx]["id"] != tc_delta.id
+                            ):
+                                idx = max(tool_calls_acc.keys()) + 1
+                                tool_calls_acc[idx] = {
+                                    "id": "",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "",
+                                        "arguments": "",
+                                    },
+                                }
                             tool_calls_acc[idx]["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:


### PR DESCRIPTION
## Problem

Some models (e.g. Minimax-M3 via Ollama) reuse the same `index` for multiple tool calls during streaming, violating the [OpenAI streaming spec](https://platform.openai.com/docs/api-reference/chat/streaming). This causes tool call names to concatenate:

```
"bash" + "research" = "bashresearch"
```

The merged name doesn't match any registered tool, so the tool call fails with malformed JSON arguments.

## Root Cause

In `_call_llm_streaming` (agent/core/agent_loop.py), the accumulator uses `tc_delta.index` as the dict key and concatenates names via `+=`. When a model sends two tool calls both with `index=0`, the names merge.

## Fix

When a new `tc_delta.id` arrives at an index that already holds a **different** id, allocate a fresh slot at `max(keys) + 1` instead of appending to the existing entry.

**Changes (1 file, +18/-1):**
- Default `tc_delta.index` to `0` when `None` for robustness
- Detect index reuse via id mismatch and allocate new slot

## Testing

- ✅ `ruff check` and `ruff format --check` pass
- ✅ 377 unit tests pass (all existing tests unaffected)
- ✅ Verified with `test_doom_loop`, `test_malformed_args_recovery`, `test_no_tool_continuation_guard`, `test_compaction_loop_break`, `test_dangling_tool_calls`, `test_cost_estimation`
