### PR TITLE
fix: pass prompt_file_suffix through ContextManager.__init__

### DIFF
--- a/agent/context_manager/manager.py
+++ b/agent/context_manager/manager.py
@@ -186,7 +186,7 @@ class ContextManager:
     ):
         self.system_prompt = self._load_system_prompt(
             tool_specs or [],
-            prompt_file_suffix="system_prompt_v3.yaml",
+            prompt_file_suffix=prompt_file_suffix,
             hf_token=hf_token,
             local_mode=local_mode,
         )

--- a/tests/unit/test_context_manager.py
+++ b/tests/unit/test_context_manager.py
@@ -1,0 +1,15 @@
+"""Unit tests for the context manager."""
+
+from unittest.mock import patch
+
+from agent.context_manager.manager import ContextManager
+
+
+def test_prompt_file_suffix_is_passed_to_loader():
+    """ContextManager should use the prompt_file_suffix parameter instead of hardcoding it."""
+    with patch.object(ContextManager, "_load_system_prompt", return_value="system prompt") as mock_load:
+        ContextManager(prompt_file_suffix="custom_prompt.yaml", tool_specs=[])
+
+    mock_load.assert_called_once()
+    _, kwargs = mock_load.call_args
+    assert kwargs["prompt_file_suffix"] == "custom_prompt.yaml"


### PR DESCRIPTION
Closing this stale PR. Happy to reopen if the maintainers would like to revisit it.